### PR TITLE
Fixed misspelling

### DIFF
--- a/docs/source/user_guide/cli/opctl/configure.rst
+++ b/docs/source/user_guide/cli/opctl/configure.rst
@@ -6,7 +6,7 @@ CLI Configuration
 * You have completed :doc:`ADS CLI installation <../quickstart>` 
 
 
-Setup default values for different options while running ``OCI Data Sciecne Jobs`` or ``OCI DataFlow``. By setting defaults, you can avoid inputing compartment ocid, project ocid, etc.
+Setup default values for different options while running ``OCI Data Science Jobs`` or ``OCI DataFlow``. By setting defaults, you can avoid inputing compartment ocid, project ocid, etc.
 
 To setup configuration run - 
 


### PR DESCRIPTION
"Science" was misspelled in configure.rst