### PR TITLE
fix example in ads docs

### DIFF
--- a/docs/source/user_guide/apachespark/dataflow-spark-magic.rst
+++ b/docs/source/user_guide/apachespark/dataflow-spark-magic.rst
@@ -239,7 +239,7 @@ To connect to the existing session use the `%use_session` magic command.
 
 .. code-block:: python
 
-  %use_session -s "<application_id>"
+  %use_session -s <application_id>
 
 
 Basic Spark Usage Examples

--- a/docs/source/user_guide/model_registration/quick_start.rst
+++ b/docs/source/user_guide/model_registration/quick_start.rst
@@ -139,8 +139,8 @@ Create a model, prepare it, verify that it works, save it to the model catalog, 
     artifact_dir=tempfile.mkdtemp()
     torch_model = PyTorchModel(torch_estimator, artifact_dir=artifact_dir)
 
-    # Autogenerate score.py, pickled model, runtime.yaml, input_schema.json and output_schema.json
-    # Set `save_entire_model` to `True` to save the model as Torchscript program.
+    # Autogenerate score.py, serialized model, runtime.yaml
+    # Set `use_torch_script` to `True` to save the model as Torchscript program.
     torch_model.prepare(inference_conda_env="pytorch110_p38_cpu_v1", use_torch_script=True)
 
     # Verify generated artifacts


### PR DESCRIPTION
# Description
This PR aims to fix the example in ads docs.
* `%use_session` in dataflow-spark-magic
* `Quick start` example of using PyTorch Framework.