### PR TITLE
ODSC-36680: Adds LA flag for the MVS user guide.

### DIFF
--- a/docs/source/user_guide/model_version_set/index.rst
+++ b/docs/source/user_guide/model_version_set/index.rst
@@ -1,10 +1,11 @@
 .. _model version set:
 
-###################
-Model Version Set
-###################
+########################
+Model Version Set |beta|
+########################
 
-.. versionadded:: 2.7.1
+.. |beta| image:: ../../_static/badge_beta.svg
+
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
## Description
https://jira.oci.oraclecorp.com/browse/ODSC-36680
[MVS][User Guide] Add Model Version Set user guide.

* Adds limited availability flag to the MVS documentation.

<img width="780" alt="image" src="https://user-images.githubusercontent.com/5256765/207163310-566c5a4c-a5b0-4fce-95e8-56a08c6c34cc.png">
<img width="151" alt="image" src="https://user-images.githubusercontent.com/5256765/207163353-7e6af385-d274-4c67-9e99-347d5b4a2d38.png">
