### PR TITLE
ODSC-36926/replaced ads.common.model_metadata with ads.model.model_metadata

### DIFF
--- a/docs/source/user_guide/model_catalog/model_catalog.rst
+++ b/docs/source/user_guide/model_catalog/model_catalog.rst
@@ -21,7 +21,7 @@ provenance, reproduced, and deployed.
     from ads.catalog.model import ModelCatalog
     from ads.common.model import ADSModel
     from ads.common.model_export_util import prepare_generic_model
-    from ads.common.model_metadata import (MetadataCustomCategory,
+    from ads.model.model_metadata import (MetadataCustomCategory,
                                            UseCaseType,
                                            Framework)
     from ads.dataset.factory import DatasetFactory

--- a/docs/source/user_guide/model_registration/frameworks/automlmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/automlmodel.rst
@@ -64,7 +64,7 @@ Example
 
   from ads.automl.driver import AutoML
   from ads.automl.provider import OracleAutoMLProvider
-  from ads.common.model_metadata import UseCaseType
+  from ads.model.model_metadata import UseCaseType
   from ads.dataset.dataset_browser import DatasetBrowser
   from ads.model.framework.automl_model import AutoMLModel
 

--- a/docs/source/user_guide/model_registration/frameworks/lightgbmmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/lightgbmmodel.rst
@@ -38,14 +38,14 @@ The Training API in ``LightGBM`` contains training and cross-validation routines
             trainx,
             trainy,
         )
-    
+
 
 Prepare Model Artifact
 ======================
 
 .. code-block:: python3
 
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
     from ads.model.framework.lightgbm_model import LightGBMModel
 
     artifact_dir = tempfile.mkdtemp()
@@ -117,7 +117,7 @@ Run Prediction against Endpoint
     # Generate prediction by invoking the deployed endpoint
     lightgbm_model.predict(testx)['prediction']
 
-.. parsed-literal:: 
+.. parsed-literal::
 
     [1,0,...,1]
 
@@ -250,7 +250,7 @@ Example
 .. code-block:: python3
 
     from ads.model.framework.lightgbm_model import LightGBMModel
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
 
     import lightgbm as lgb
 

--- a/docs/source/user_guide/model_registration/frameworks/pytorchmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/pytorchmodel.rst
@@ -37,7 +37,7 @@ Serializing model in TorchScript program by setting `use_torch_script` to `True`
 
 .. code-block:: python3
 
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
     from ads.model.framework.pytorch_model import PyTorchModel
 
     import tempfile
@@ -59,7 +59,7 @@ Save state_dict
 ---------------
 .. code-block:: python3
 
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
     from ads.model.framework.pytorch_model import PyTorchModel
 
     import tempfile
@@ -417,7 +417,7 @@ Example
 
 .. code-block:: python3
 
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
     from ads.model.framework.pytorch_model import PyTorchModel
 
     import numpy as np

--- a/docs/source/user_guide/model_registration/frameworks/sklearnmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/sklearnmodel.rst
@@ -19,7 +19,7 @@ The following steps take your trained ``scikit-learn`` model and deploy it into 
 
 .. code-block:: python3
 
-    from sklearn.ensemble import RandomForestClassifier 
+    from sklearn.ensemble import RandomForestClassifier
     from sklearn.datasets import make_classification
     from sklearn.model_selection import train_test_split
 
@@ -42,8 +42,8 @@ Prepare Model Artifact
 .. code-block:: python3
 
     from ads.model.framework.sklearn_model import SklearnModel
-    from ads.common.model_metadata import UseCaseType
-    
+    from ads.model.model_metadata import UseCaseType
+
     sklearn_model = SklearnModel(estimator=model, artifact_dir="~/sklearn_artifact_dir")
     sklearn_model.prepare(
         inference_conda_env="generalml_p38_cpu_v1",
@@ -239,7 +239,7 @@ Examples
 .. code-block:: python3
 
     from ads.model.framework.sklearn_model import SklearnModel
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
 
     from sklearn.ensemble import RandomForestClassifier
     from sklearn.datasets import make_classification

--- a/docs/source/user_guide/model_registration/frameworks/sparkpipelinemodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/sparkpipelinemodel.rst
@@ -69,7 +69,7 @@ Prepare Model Artifact
 
     import tempfile
     from ads.model.framework.spark_model import SparkPipelineModel
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
 
     artifact_dir=tempfile.mkdtemp()
     spark_model = SparkPipelineModel(estimator=model, artifact_dir=artifact_dir)
@@ -202,7 +202,7 @@ Adapted from an example provided by Apache in the PySpark API Reference Document
     from pyspark.ml.feature import HashingTF, Tokenizer
     from pyspark.sql import SparkSession
     from ads.model.framework.spark_model import SparkPipelineModel
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
 
     spark = SparkSession \
         .builder \

--- a/docs/source/user_guide/model_registration/frameworks/tensorflowmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/tensorflowmodel.rst
@@ -41,7 +41,7 @@ Prepare Model Artifact
 
 .. code-block:: python3
 
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
     from ads.model.framework.tensorflow_model import TensorFlowModel
     import tempfile
 
@@ -228,7 +228,7 @@ Example
 
 .. code-block:: python3
 
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
     from ads.model.framework.tensorflow_model import TensorFlowModel
 
     import tensorflow as tf

--- a/docs/source/user_guide/model_registration/frameworks/xgboostmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/xgboostmodel.rst
@@ -21,7 +21,7 @@ The ``XGBoostModel`` module in ADS supports serialization for models generated f
 .. code-block:: python3
 
     from ads.model.framework.xgboost_model import XGBoostModel
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
 
     from sklearn.datasets import make_classification
     from sklearn.model_selection import train_test_split
@@ -49,7 +49,7 @@ Prepare Model Artifact
 .. code-block:: python3
 
     from ads.model.framework.xgboost_model import XGBoostModel
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
 
     artifact_dir = tempfile.mkdtemp()
     xgb_model = XGBoostModel(estimator=model, artifact_dir=artifact_dir)
@@ -249,7 +249,7 @@ Example
 .. code-block:: python3
 
     from ads.model.framework.xgboost_model import XGBoostModel
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
 
     from sklearn.datasets import make_classification
     from sklearn.model_selection import train_test_split

--- a/docs/source/user_guide/model_registration/model_artifact.rst
+++ b/docs/source/user_guide/model_registration/model_artifact.rst
@@ -48,7 +48,7 @@ Here is an example for preparing a model artifact for ``TensorFlow`` model.
     from ads.model.framework.tensorflow_model import TensorFlowModel
     import tempfile
     import tensorflow as tf
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
 
     mnist = tf.keras.datasets.mnist
     (x_train, y_train), (x_test, y_test) = mnist.load_data()

--- a/docs/source/user_guide/model_registration/model_deploy.rst
+++ b/docs/source/user_guide/model_registration/model_deploy.rst
@@ -6,7 +6,7 @@ Here is an example of deploying LightGBM model:
 
     import lightgbm as lgb
     import tempfile
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
     from ads.model.framework.lightgbm_model import LightGBMModel
     from sklearn.datasets import load_iris
     from sklearn.model_selection import train_test_split

--- a/docs/source/user_guide/model_registration/model_file_customization.rst
+++ b/docs/source/user_guide/model_registration/model_file_customization.rst
@@ -14,7 +14,7 @@ Step1: Train your estimator and then generate the Model artifact as shown below 
     from ads.model.framework.tensorflow_model import TensorFlowModel
     import tempfile
     import tensorflow as tf
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
 
     mnist = tf.keras.datasets.mnist
     (x_train, y_train), (x_test, y_test) = mnist.load_data()

--- a/docs/source/user_guide/model_registration/model_metadata.rst
+++ b/docs/source/user_guide/model_registration/model_metadata.rst
@@ -9,7 +9,7 @@ Taxonomy Metadata
 
 Taxonomy metadata includes the type of the model, use case type, libraries, framework, and so on. This metadata provides a way of documenting the schema of the model.  The ``UseCaseType``, ``FrameWork``, ``FrameWorkVersion``, ``Algorithm``, and ``Hyperparameters`` are fixed taxonomy metadata. These fields are automatically populated when the ``.prepare()`` method is called. You can also manually update the values of those fields.
 
-*  ``ads.common.model_metadata.UseCaseType``: The machine learning problem associated with the Estimator class.  The ``UseCaseType.values()`` method returns the most current list. This is a list of allowed values.:
+*  ``ads.model.model_metadata.UseCaseType``: The machine learning problem associated with the Estimator class.  The ``UseCaseType.values()`` method returns the most current list. This is a list of allowed values.:
 
    -  ``UseCaseType.ANOMALY_DETECTION``
    -  ``UseCaseType.BINARY_CLASSIFICATION``
@@ -26,7 +26,7 @@ Taxonomy metadata includes the type of the model, use case type, libraries, fram
    -  ``UseCaseType.TIME_SERIES_FORECASTING``
    -  ``UseCaseType.TOPIC_MODELING``
 
-*  ``ads.common.model_metadata.FrameWork``: The FrameWork of the ``estimator`` object.  You can get the list of allowed values using ``Framework.values()``:
+*  ``ads.model.model_metadata.FrameWork``: The FrameWork of the ``estimator`` object.  You can get the list of allowed values using ``Framework.values()``:
 
    -  ``FrameWork.BERT``
    -  ``FrameWork.CUML``
@@ -71,14 +71,14 @@ You can populate the ``use_case_type`` by passing it in the ``.prepare()`` metho
     from sklearn.datasets import load_iris
     from sklearn.linear_model import LogisticRegression
     from sklearn.model_selection import train_test_split
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
 
-    # Load dataset and Prepare train and test split 
+    # Load dataset and Prepare train and test split
     iris = load_iris()
     X, y = iris.data, iris.target
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25)
-    
-    # Train a LogisticRegression model 
+
+    # Train a LogisticRegression model
     sklearn_estimator = LogisticRegression()
     sklearn_estimator.fit(X_train, y_train)
 

--- a/docs/source/user_guide/model_serialization/automlmodel.rst
+++ b/docs/source/user_guide/model_serialization/automlmodel.rst
@@ -148,7 +148,7 @@ Example
 
   from ads.automl.driver import AutoML
   from ads.automl.provider import OracleAutoMLProvider
-  from ads.common.model_metadata import UseCaseType
+  from ads.model.model_metadata import UseCaseType
   from ads.dataset.dataset_browser import DatasetBrowser
   from ads.model.framework.automl_model import AutoMLModel
   from ads.catalog.model import ModelCatalog

--- a/docs/source/user_guide/model_serialization/pytorchmodel.rst
+++ b/docs/source/user_guide/model_serialization/pytorchmodel.rst
@@ -159,7 +159,7 @@ Example
     import tempfile
     import torchvision
     from ads.catalog.model import ModelCatalog
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
     from ads.model.framework.pytorch_model import PyTorchModel
 
     # Load the PyTorch Model

--- a/docs/source/user_guide/model_serialization/quick_start.rst
+++ b/docs/source/user_guide/model_serialization/quick_start.rst
@@ -19,7 +19,7 @@ Create a model, prepare it, verify that it works, save it to the model catalog, 
     from ads.automl.driver import AutoML
     from ads.automl.provider import OracleAutoMLProvider
     from ads.catalog.model import ModelCatalog
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
     from ads.dataset.dataset_browser import DatasetBrowser
     from ads.model.framework.automl_model import AutoMLModel
 

--- a/docs/source/user_guide/model_serialization/sklearnmodel.rst
+++ b/docs/source/user_guide/model_serialization/sklearnmodel.rst
@@ -185,7 +185,7 @@ Examples
     import tempfile
 
     from ads.catalog.model import ModelCatalog
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
     from ads.model.framework.sklearn_model import SklearnModel
     from sklearn.pipeline import Pipeline
     from sklearn.compose import ColumnTransformer

--- a/docs/source/user_guide/model_serialization/tensorflowmodel.rst
+++ b/docs/source/user_guide/model_serialization/tensorflowmodel.rst
@@ -150,7 +150,7 @@ Example
     import tensorflow as tf
 
     from ads.catalog.model import ModelCatalog
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
     from ads.model.framework.tensorflow_model import TensorFlowModel
 
     mnist = tf.keras.datasets.mnist

--- a/docs/source/user_guide/model_serialization/xgboostmodel.rst
+++ b/docs/source/user_guide/model_serialization/xgboostmodel.rst
@@ -219,7 +219,7 @@ Example
     import xgboost as xgb
 
     from ads.catalog.model import ModelCatalog
-    from ads.common.model_metadata import UseCaseType
+    from ads.model.model_metadata import UseCaseType
     from ads.model.framework.xgboost_model import XGBoostModel
     from sklearn.compose import ColumnTransformer
     from sklearn.impute import SimpleImputer


### PR DESCRIPTION
# Desciption
The [code examples](https://accelerated-data-science.readthedocs.io/en/latest/user_guide/model_registration/frameworks/xgboostmodel.html#example) copied from quick start guide gives warning message -

```
WARNING:py.warnings:/tmp/ipykernel_2025/2352313256.py:2: DeprecationWarning: The `ads.common.model_metadata` is deprecated in `oracle-ads 2.6.8` and will be removed in future release. Use the `ads.model.model_metadata` instead.
  from ads.common.model_metadata import UseCaseType
```

We need to update all the examples to remove the deprecated code.