### PR TITLE
TC 23367/release notes 2.7.3

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,11 +6,11 @@ Release Notes
 -----
 Release date: January 18, 2023 
 
-* Added support for the `MVS (Model Version Set) <./ads.model_version_set.index>`__ feature.
-* Added --job-info option to ads opctl run CLI to save job run information to a YAML file.
-* Added `AuthContext <./ads.common.html#ads.common.auth.OCIAuthContext>`__ class with support for api key configuration, resource principal, and instance principal authentication, as well as predefined signers, callable signers, or api keys configurations from specified locations.
-* Fixed a bug in to_sql(). The string length for the column created in Oracle Database table was counting characters, not bytes.
-* Fixed a bug where any exception that occurred in a notebook cell would print “ADS Exception” even if ADS code was not responsible for the error.
+* Added support for the :doc:`model version set <./user_guide/model_version_set/index.html>` feature.
+* Added ``--job-info`` option to ``ads opctl run`` CLI to save job run information to a YAML file.
+* Added the `AuthContext <./ads.common.html#ads.common.auth.OCIAuthContext>`__ class. It supports API key configuration, resource principal, and instance principal authentication. In addition, predefined signers, callable signers, or API keys configurations from specified locations.
+* Fixed a bug in ``to_sql()``. The string length for the column created in Oracle Database table was counting characters, not bytes.
+* Fixed a bug where any exception that occurred in a notebook cell printed "ADS Exception" even if the ADS code was not responsible for the error.
 
 2.7.2
 -----

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,7 +6,7 @@ Release Notes
 -----
 Release date: January 18, 2023 
 
-* Added support for the :doc:`model version set <./user_guide/model_version_set/index.html>` feature.
+* Added support for the :doc:`model version set <./user_guide/model_version_set/index>` feature.
 * Added ``--job-info`` option to ``ads opctl run`` CLI to save job run information to a YAML file.
 * Added the `AuthContext <./ads.common.html#ads.common.auth.OCIAuthContext>`__ class. It supports API key configuration, resource principal, and instance principal authentication. In addition, predefined signers, callable signers, or API keys configurations from specified locations.
 * Fixed a bug in ``to_sql()``. The string length for the column created in Oracle Database table was counting characters, not bytes.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,7 +8,7 @@ Release date: January 18, 2023
 
 * Added support for the `MVS (Model Version Set) <./ads.model_version_set.index>`__ feature.
 * Added --job-info option to ads opctl run CLI to save job run information to a YAML file.
-* Added `AuthContext <./ads.common.auth.OCIAuthContext>`__ class with support for api key configuration, resource principal, and instance principal authentication, as well as predefined signers, callable signers, or api keys configurations from specified locations.
+* Added `AuthContext <./ads.common.html#ads.common.auth.OCIAuthContext>`__ class with support for api key configuration, resource principal, and instance principal authentication, as well as predefined signers, callable signers, or api keys configurations from specified locations.
 * Fixed a bug in to_sql(). The string length for the column created in Oracle Database table was counting characters, not bytes.
 * Fixed a bug where any exception that occurred in a notebook cell would print “ADS Exception” even if ADS code was not responsible for the error.
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,15 @@
 Release Notes
 =============
 
+2.7.3
+-----
+Release date: January 18, 2023
+* Added support for the :ref:`MVS<https://accelerated-data-science.readthedocs.io/en/latest/user_guide/model_version_set/index.html>` (Model Version Set) feature.
+* Added --job-info option to ads opctl run CLI to save job run information to a YAML file.
+* Added AuthContext class with support for api key configuration, resource principal, and instance principal authentication, as well as predefined signers, callable signers, or api keys configurations from specified locations.
+* Fixed a bug in to_sql(). The string length for the column created in Oracle Database table was counting characters, not bytes.
+* Fixed a bug where any exception that occurred in a notebook cell would print “ADS Exception” even if ADS code was not responsible for the error.
+
 2.7.2
 -----
 Release date: December 20, 2022

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,10 +4,11 @@ Release Notes
 
 2.7.3
 -----
-Release date: January 18, 2023
-* Added support for the :ref:`MVS<https://accelerated-data-science.readthedocs.io/en/latest/user_guide/model_version_set/index.html>` (Model Version Set) feature.
+Release date: January 18, 2023 
+
+* Added support for the `MVS (Model Version Set) <./ads.model_version_set.index>`__ feature.
 * Added --job-info option to ads opctl run CLI to save job run information to a YAML file.
-* Added AuthContext class with support for api key configuration, resource principal, and instance principal authentication, as well as predefined signers, callable signers, or api keys configurations from specified locations.
+* Added `AuthContext <./ads.common.auth.OCIAuthContext>`__ class with support for api key configuration, resource principal, and instance principal authentication, as well as predefined signers, callable signers, or api keys configurations from specified locations.
 * Fixed a bug in to_sql(). The string length for the column created in Oracle Database table was counting characters, not bytes.
 * Fixed a bug where any exception that occurred in a notebook cell would print “ADS Exception” even if ADS code was not responsible for the error.
 

--- a/docs/source/user_guide/model_version_set/index.rst
+++ b/docs/source/user_guide/model_version_set/index.rst
@@ -1,10 +1,8 @@
 .. _model version set:
 
-########################
-Model Version Set |beta|
-########################
-
-.. |beta| image:: ../../_static/badge_beta.svg
+#################
+Model Version Set
+#################
 
 
 .. toctree::


### PR DESCRIPTION
add a release notes for ads 2.7.3 and remove the beta mark for model version set feature