### PR TITLE
hotfix/user guide job example

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
--e .
 autodoc
 nbsphinx
 sphinx

--- a/docs/source/user_guide/jobs/run_script.rst
+++ b/docs/source/user_guide/jobs/run_script.rst
@@ -201,11 +201,14 @@ Suppose you want to run the following python script named ``job_script_env.py``:
 
   import os
   import sys
-  print("Hello " + os.environ["KEY1"] + " and " + os.environ["KEY2"])""")
+  print("Hello " + os.environ["KEY1"] + " and " + os.environ["KEY2"])
 
 This example runs a job with environment variables:
 
 .. code-block:: python3
+  from ads.jobs import Job
+  from ads.jobs import DataScienceJob
+  from ads.jobs import ScriptRuntime
 
   job = Job()
   job.with_infrastructure(
@@ -246,12 +249,12 @@ You could create the preceding example job with the following YAML file:
 
 .. code-block:: yaml
 
-	kind: job
-	spec:
+  kind: job
+  spec:
 	  infrastructure:
-	    kind: infrastructure
+      kind: infrastructure
       type: dataScienceJob
-	    spec:
+      spec:
         logGroupId: <log_group_ocid>
         logId: <log_ocid>
         compartmentId: <compartment_ocid>
@@ -263,11 +266,11 @@ You could create the preceding example job with the following YAML file:
           ocpus: 1
         blockStorageSize: 50
 	  runtime:
-	    kind: runtime
+      kind: runtime
       type: python
-	    spec:
-	      env:
-	      - name: KEY1
+      spec:
+        env:
+        - name: KEY1
 	        value: <first_value>
 	      - name: KEY2
 		      value: <second_value>

--- a/docs/source/user_guide/jobs/run_script.rst
+++ b/docs/source/user_guide/jobs/run_script.rst
@@ -128,6 +128,10 @@ This example runs a job with CLI arguments:
 
 .. code-block:: python3
 
+  from ads.jobs import Job
+  from ads.jobs import DataScienceJob
+  from ads.jobs import ScriptRuntime
+
   job = Job()
   job.with_infrastructure(
     DataScienceJob()
@@ -161,9 +165,9 @@ You could create the preceding example job with the following YAML file:
 
 .. code-block:: yaml
 
-	kind: job
-	spec:
-	  infrastructure:
+  kind: job
+  spec:
+    infrastructure:
       kind: infrastructure
       type: dataScienceJob
       spec:
@@ -177,14 +181,14 @@ You could create the preceding example job with the following YAML file:
           memoryInGBs: 16
           ocpus: 1
         blockStorageSize: 50
-	  runtime:
-	    kind: runtime
+    runtime:
+      kind: runtime
       type: python
-	    spec:
-	      args:
-	      - <first_argument>
-	      - <second_argument>
-	      scriptPathURI: job_script_argument.py
+      spec:
+        args:
+        - <first_argument>
+        - <second_argument>
+      scriptPathURI: job_script_env.py
 
 
 Environment Variables
@@ -206,6 +210,7 @@ Suppose you want to run the following python script named ``job_script_env.py``:
 This example runs a job with environment variables:
 
 .. code-block:: python3
+
   from ads.jobs import Job
   from ads.jobs import DataScienceJob
   from ads.jobs import ScriptRuntime
@@ -251,7 +256,7 @@ You could create the preceding example job with the following YAML file:
 
   kind: job
   spec:
-	  infrastructure:
+    infrastructure:
       kind: infrastructure
       type: dataScienceJob
       spec:
@@ -265,16 +270,16 @@ You could create the preceding example job with the following YAML file:
           memoryInGBs: 16
           ocpus: 1
         blockStorageSize: 50
-	  runtime:
+    runtime:
       kind: runtime
       type: python
       spec:
         env:
         - name: KEY1
-	        value: <first_value>
-	      - name: KEY2
-		      value: <second_value>
-	      scriptPathURI: job_script_env.py
+          value: <first_value>
+        - name: KEY2
+          value: <second_value>
+      scriptPathURI: job_script_env.py
 
 
 


### PR DESCRIPTION
# Description
Jira : ODSC-39187
This PR aims to fix several error in the user guide.

* typo in example code
```
import os
import sys
print("Hello " + os.environ["KEY1"] + " and " + os.environ["KEY2"])""")
```
* incorrect indent in yaml example
```
  kind: job
  spec:
    infrastructure:
      kind: infrastructure
type: dataScienceJob
      spec:
  logGroupId: <log_group_ocid>
  logId: <log_ocid>
  compartmentId: <compartment_ocid>
  projectId: <project_ocid>
  subnetId: <subnet_ocid>
  shapeName: VM.Standard.E3.Flex
  shapeConfigDetails:
    memoryInGBs: 16
    ocpus: 1
  blockStorageSize: 50
    runtime:
      kind: runtime
type: python
      spec:
        env:
        - name: KEY1
          value: <first_value>
        - name: KEY2
                value: <second_value>
        scriptPathURI: job_script_env.py
```

* When user follow the guide (https://github.com/oracle/accelerated-data-science/tree/main/docs) to set up the developing environment, they will see the error.
```
09:47 $ pip install -r requirements.txt
Obtaining file:///Users/<name>/<path>/accelerated-data-science/docs (from -r requirements.txt (line 1))
ERROR: file:///Users/<name>/<path>/accelerated-data-science/docs (from -r requirements.txt (line 1)) does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.
```
Solution: `-e .` in requirements.txt need to be removed. 