### PR TITLE
Update sphinx config

### DIFF
--- a/docs/source/ads.jobs.rst
+++ b/docs/source/ads.jobs.rst
@@ -6,11 +6,12 @@ ads.jobs package
 
    ads.jobs
 
+
 Subpackages
 -----------
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 3
 
    ads.jobs.builders
    ads.jobs.schema

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@ import sys
 # This causes documentation within the __init__ method to be pulled into the documentation properly
 autoclass_content = "both"
 
-sys.path.insert(0, os.path.abspath("../../advanced-ds"))
+sys.path.insert(0, os.path.abspath("../../ads"))
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
The ADS path in sphinx config `conf.py` is incorrect. This path is needed for Sphinx to build the latest ADS class documentation. Class documentation might be missing or outdated because of this.

For example, the class documentation for the newly added huggingface model is missing: https://accelerated-data-science.readthedocs.io/en/latest/ads.model.framework.html#ads-model-framework-huggingface-model-module

This PR also updates the TOC tree level in the class documentation for Jobs.