### PR TITLE
Bug fixes in ads opctl command: container entrypoint and distributed …

### DIFF
--- a/ads/opctl/cmds.py
+++ b/ads/opctl/cmds.py
@@ -141,7 +141,7 @@ def _save_yaml(yaml_content, **kwargs):
     yaml_content : str
         YAML content as string.
     """
-    if kwargs["job_info"]:
+    if kwargs.get("job_info"):
         yaml_path = os.path.abspath(os.path.expanduser(kwargs["job_info"]))
         if os.path.isfile(yaml_path):
             overwrite = input(
@@ -210,7 +210,7 @@ def run(config: Dict, **kwargs) -> Dict:
                 "backend operator for distributed training can either be local or job"
             )
         else:
-            if not kwargs["dry_run"]:
+            if not kwargs["dry_run"] and not kwargs["nobuild"]:
                 verify_and_publish_image(kwargs["nopush"], config)
                 print("running image: " + config["spec"]["cluster"]["spec"]["image"])
             cluster_def = YamlSpecParser.parse_content(config)

--- a/ads/opctl/config/resolver.py
+++ b/ads/opctl/config/resolver.py
@@ -155,7 +155,11 @@ class ConfigResolver(ConfigProcessor):
     def _resolve_entry_script(self) -> None:
         # this should be run after _resolve_source_folder_path
         if not self._is_ads_operator():
-            if os.path.splitext(self.config["execution"]["entrypoint"])[1] == ".ipynb":
+            if (
+                self.config["execution"].get("entrypoint")
+                and os.path.splitext(self.config["execution"]["entrypoint"])[1]
+                == ".ipynb"
+            ):
                 input_path = os.path.join(
                     self.config["execution"]["source_folder"],
                     self.config["execution"]["entrypoint"],


### PR DESCRIPTION
### Following fixes are covered in this PR - 

1. `ads opctl run` for distributed training jobs works only when the image is present locally. This happens because the tool tries to automatically build and publish the image to the registry. There can be situations where user is reusing image that is already in the registry and late binding the code. User will have to use `--nobuild` option to suppress build and publish.
2. Fix for entrypoint check when user tries to run an image using ads opctl. Eg - `ads opctl run --backend local --image iad.ocir.io/ociodscdev/myimage`

![pr-screenshot-disttrain](https://user-images.githubusercontent.com/876989/228096147-ee84debb-061e-4ccf-aeb6-6e76282adc56.png)

