### PR TITLE
ODSC-39737 : allow to use `GenericModel.predict()` locally

### DIFF
--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -2483,6 +2483,7 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         self,
         data: Any = None,
         auto_serialize_data: bool = False,
+        local: bool = False,
         **kwargs,
     ) -> Dict[str, Any]:
         """Returns prediction of input data run against the model deployment endpoint.
@@ -2507,6 +2508,8 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
             Whether to auto serialize input data. Defauls to `False` for GenericModel, and `True` for other frameworks.
             `data` required to be json serializable if `auto_serialize_data=False`.
             If `auto_serialize_data` set to True, data will be serialized before sending to model deployment endpoint.
+        local: bool.
+            Whether to invoke the prediction locally. Default to False.
         kwargs:
             content_type: str, used to indicate the media type of the resource.
             image: PIL.Image Object or uri for the image.
@@ -2527,6 +2530,9 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         ValueError
             If `data` is empty or not JSON serializable.
         """
+        if local:
+            return self.verify(data=data, auto_serialize_data=auto_serialize_data, **kwargs)
+
         if not self.model_deployment:
             raise ValueError("Use `deploy()` method to start model deployment.")
 

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -2528,13 +2528,21 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         NotActiveDeploymentError
             If model deployment process was not started or not finished yet.
         ValueError
-            If `data` is empty or not JSON serializable.
+            If model is not deployed yet or the endpoint information is not available.
         """
         if local:
-            return self.verify(data=data, auto_serialize_data=auto_serialize_data, **kwargs)
+            return self.verify(
+                data=data, auto_serialize_data=auto_serialize_data, **kwargs
+            )
 
-        if not self.model_deployment:
-            raise ValueError("Use `deploy()` method to start model deployment.")
+        if not (self.model_deployment and self.model_deployment.url):
+            raise ValueError(
+                "Error invoking the remote endpoint as the model is not "
+                "deployed yet or the endpoint information is not available. "
+                "Use `deploy()` method to start model deployment. "
+                "If you intend to invoke inference using locally available "
+                "model artifact, set parameter `local=True`"
+            )
 
         current_state = self.model_deployment.state.name.upper()
         if current_state != ModelDeploymentState.ACTIVE.name:

--- a/tests/unitary/with_extras/model/test_generic_model.py
+++ b/tests/unitary/with_extras/model/test_generic_model.py
@@ -168,8 +168,8 @@ OCI_MODEL_PROVENANCE_PAYLOAD = {
     "training_script": None,
 }
 
-INFERENCE_CONDA_ENV = "oci://service-conda-packs@ociodscdev/service_pack/cpu/General_Machine_Learning_for_CPUs/1.0/mlcpuv1"
-TRAINING_CONDA_ENV = "oci://service-conda-packs@ociodscdev/service_pack/cpu/Oracle_Database_for_CPU_Python_3.7/1.0/database_p37_cpu_v1"
+INFERENCE_CONDA_ENV = "oci://bucket@namespace/<path_to_service_pack>"
+TRAINING_CONDA_ENV = "oci://bucket@namespace/<path_to_service_pack>"
 DEFAULT_PYTHON_VERSION = "3.8"
 MODEL_FILE_NAME = "fake_model_name"
 FAKE_MD_URL = "http://<model-deployment-url>"


### PR DESCRIPTION
# Description
Related JIRA:https://jira.oci.oraclecorp.com/browse/ODSC-39737
Currently, the GenericModel supports two methods that can be used to test the model:
* verify()
* predict()

The difference between these two methods is that verify is used for local testing, where predict sends the request to the ML endpoint. Having two different methods confuses users, they don't really understand why we need two different methods for inferring the model. 

# Changed 
* Add a new attribute - `local=True/False` to the predict method to be able to invoke the prediction locally.

# User Experience
```
prediction = GenericModel.predict(local=True)
```
![Screenshot 2023-04-05 at 3 54 17 PM](https://user-images.githubusercontent.com/49049296/230229678-55234049-9a24-48b8-b96b-89ad9cec7a65.png)

# Test
<img width="721" alt="Screenshot 2023-03-29 at 1 08 10 PM" src="https://user-images.githubusercontent.com/49049296/228655443-2937a486-a732-4e52-a99b-879004a9f155.png">

## Int test in TC
TC: https://teamcity.oci.oraclecorp.com/buildConfiguration/Odsc_Ads_AdsCiCd_CiTrigger/38127161?buildTab=buildParameters
![Screenshot 2023-04-05 at 3 51 59 PM](https://user-images.githubusercontent.com/49049296/230229203-39adf687-fcb9-41e5-8627-b231a9a836f8.png)

