### PR TITLE
Add action for publish ADS to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,30 @@
+name: "[DO NOT TRIGGER] Publish to PyPI"
+
+on:
+  # To run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distribution 📦 to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Build distribution 📦
+        run: |
+          make dist
+      - name: Validate
+        run: |
+          pip install dist/*.whl
+          python -c "import ads;"
+      - name: Publish distribution 📦 to Test PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.GH_ADS_TESTPYPI_TOKEN }}
+        run: |
+          twine upload -r testpypi dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -39,4 +39,4 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.GH_ADS_PYPI_TOKEN }}
         run: |
           pip install twine
-          twine upload -r testpypi dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD
+          twine upload dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,8 +1,7 @@
 name: "[DO NOT TRIGGER] Publish to PyPI"
 
-on:
-  # To run this workflow manually from the Actions tab
-  workflow_dispatch
+# To run this workflow manually from the Actions tab
+on: workflow_dispatch
 
 jobs:
   build-n-publish:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,7 +2,7 @@ name: "[DO NOT TRIGGER] Publish to PyPI"
 
 on:
   # To run this workflow manually from the Actions tab
-  workflow_dispatch:
+  workflow_dispatch
 
 jobs:
   build-n-publish:
@@ -23,10 +23,21 @@ jobs:
         run: |
           pip install dist/*.whl
           python -c "import ads;"
-      - name: Publish distribution 📦 to Test PyPI
+## To run publish to test PyPI secret with token needs to be added,
+##    this one GH_ADS_TESTPYPI_TOKEN - removed after initial test.
+## Project name also needed to be updated in setup.py - setup(name="test_oracle_ads", ...),
+##    regular name is occupied by former developer and can't be used for testing
+#      - name: Publish distribution 📦 to Test PyPI
+#        env:
+#          TWINE_USERNAME: __token__
+#          TWINE_PASSWORD: ${{ secrets.GH_ADS_TESTPYPI_TOKEN }}
+#        run: |
+#          pip install twine
+#          twine upload -r testpypi dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD
+      - name: Publish distribution 📦 to PyPI
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.GH_ADS_TESTPYPI_TOKEN }}
+          TWINE_PASSWORD: ${{ secrets.GH_ADS_PYPI_TOKEN }}
         run: |
           pip install twine
-          twine upload -r testpypi dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD
+#          twine upload -r testpypi dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -39,4 +39,4 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.GH_ADS_PYPI_TOKEN }}
         run: |
           pip install twine
-#          twine upload -r testpypi dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD
+          twine upload -r testpypi dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -27,4 +27,5 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.GH_ADS_TESTPYPI_TOKEN }}
         run: |
+          pip install twine
           twine upload -r testpypi dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -17,6 +17,7 @@ jobs:
           python-version: "3.x"
       - name: Build distribution 📦
         run: |
+          pip install wheel
           make dist
       - name: Validate
         run: |

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ with open(
 
 long_description = (this_directory / "README.md").read_text()
 setup(
-    name="oracle_ads",
+    name="test_oracle_ads",
     version=ADS_VERSION,
     description="Oracle Accelerated Data Science SDK",
     author="Oracle Data Science",

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ with open(
 
 long_description = (this_directory / "README.md").read_text()
 setup(
-    name="test_oracle_ads",
+    name="oracle_ads",
     version=ADS_VERSION,
     description="Oracle Accelerated Data Science SDK",
     author="Oracle Data Science",


### PR DESCRIPTION
## Description

We need action which will publish ADS to PyPI. 

Jira: https://jira.oci.oraclecorp.com/browse/ODSC-37152

## What was done

1. I've created account in TestPyPI
2. Created publish-to-pypi.yml with step to publish to TestPyPI
3. Manually triggered Action - [DO NOT TRIGGER] Publish to PyPI
4. Observed logs showing success and artifact uploaded - check the logs: https://github.com/oracle/accelerated-data-science/actions/runs/4622770194/jobs/8175860530
5. Checked TestPyPI has test ads project published: https://test.pypi.org/project/test-oracle-ads/2.8.3/
6. Updated publish-to-pypi.yml - commented out publish to TestPyPI, added publish to real PyPI

