### PR TITLE
Action to auto-trigger docs build in readthedocs

### DIFF
--- a/.github/workflows/publish-to-readthedocs.yml
+++ b/.github/workflows/publish-to-readthedocs.yml
@@ -1,0 +1,22 @@
+name: "Publish Docs"
+
+on:
+  # Auto-trigger this workflow on tag creation
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-n-publish:
+    name: Build and publish Docs 📖 to Readthedocs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Readthedocs build
+        env:
+          RTDS_ADS_PROJECT: https://readthedocs.org/api/v3/projects/accelerated-data-science
+          RTDS_ADS_TOKEN: ${{ secrets.RTDS_ADS_TOKEN }}
+        run: |
+          curl \
+            -X POST \
+            -H "Authorization: Token $RTDS_ADS_TOKEN" $RTDS_ADS_PROJECT/versions/${{ github.ref_name }}/builds/


### PR DESCRIPTION
## Description

Using use the [generic API integration](https://docs.readthedocs.io/en/stable/guides/git-integrations.html#using-the-generic-api-integration) to auto-trigger readthedocs building the docs.

Jira: https://jira.oci.oraclecorp.com/browse/ODSC-37153

- added workflow publish-to-readthedocs.yml