### PR TITLE
Fix TF model tests errors when running in parallel.

### DIFF
--- a/tests/unitary/with_extras/model/test_model_framework_tensorflow_model.py
+++ b/tests/unitary/with_extras/model/test_model_framework_tensorflow_model.py
@@ -49,10 +49,12 @@ class MyTFModel:
                     "Timeout when waiting for MNIST data to finished downloading in another process. "
                     "Please check internet connection."
                 )
+        os.makedirs(os.path.dirname(lock_file), exist_ok=True)
         Path(lock_file).touch()
         (x_train, y_train), (x_test, y_test) = mnist.load_data()
     finally:
-        os.unlink(lock_file)
+        if os.path.exists(lock_file):
+            os.unlink(lock_file)
 
     x_train, x_test = x_train / 255.0, x_test / 255.0
 

--- a/tests/unitary/with_extras/model/test_model_framework_tensorflow_model.py
+++ b/tests/unitary/with_extras/model/test_model_framework_tensorflow_model.py
@@ -9,8 +9,10 @@
 import base64
 import os
 import shutil
+import time
 import uuid
 from io import BytesIO
+from pathlib import Path
 
 import numpy as np
 import onnxruntime as rt
@@ -35,9 +37,23 @@ def setup_module():
 
 
 class MyTFModel:
-
     mnist = tf.keras.datasets.mnist
-    (x_train, y_train), (x_test, y_test) = mnist.load_data()
+    lock_file = os.path.expanduser("~/.keras/datasets/mnist.npz.downloading")
+    try:
+        time_start = time.time()
+        while os.path.exists(lock_file):
+            time.sleep(10)
+            elapsed = time.time() - time_start
+            if elapsed > 60 * 15:
+                raise TimeoutError(
+                    "Timeout when waiting for MNIST data to finished downloading in another process. "
+                    "Please check internet connection."
+                )
+        Path(lock_file).touch()
+        (x_train, y_train), (x_test, y_test) = mnist.load_data()
+    finally:
+        os.unlink(lock_file)
+
     x_train, x_test = x_train / 255.0, x_test / 255.0
 
     x_train, y_train = x_train[:1000], y_train[:1000]


### PR DESCRIPTION
Using a local file as lock to make sure the load_data() of MNIST dataset finishes before any other process access it.

When collecting the tests with multiple workers, each worker will try to collect all the tests in parallel (even though a worker will only run some of the tests). Each worker will run the code in the `setup_class` during the test collection. This might cause errors when running `mnist.load_data()` because it will cache the data at a fixed location (`~/.keras/datasets/mnist.npz`) and the data will be reused if exist. However, when multiple processes are running `mnist.load_data()`, for example, the first process will create the cache file and start the downloading, and the second process may see the file already exists so it will try to load the file while it is still being downloaded by the first process. This will cause the "Incomplete or corrupted file" error.

To avoid the issue, we could assign a random file name for the cache file but this will create many cache files when developers are running the test locally.

This PR updates the test to create a `lock_file` when the data is being downloaded, and adding the logic to wait until the `lock_file` is removed.