### PR TITLE
Modified ADS dataset class

### DIFF
--- a/ads/dataset/classification_dataset.py
+++ b/ads/dataset/classification_dataset.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import pandas as pd
@@ -22,7 +22,7 @@ class ClassificationDataset(ADSDatasetWithTarget):
 
     def __init__(self, df, sampled_df, target, target_type, shape, **kwargs):
         ADSDatasetWithTarget.__init__(
-            self, df, sampled_df, target, target_type, shape, **kwargs
+            self, df=df, sampled_df=sampled_df, target=target, target_type=target_type, shape=shape, **kwargs
         )
 
     def auto_transform(

--- a/ads/dataset/dataset.py
+++ b/ads/dataset/dataset.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*--
 
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 from __future__ import print_function, absolute_import, division
@@ -16,7 +16,7 @@ import uuid
 
 from collections import Counter
 from sklearn.preprocessing import FunctionTransformer
-from typing import Iterable, Union
+from typing import Iterable, Tuple, Union
 
 from ads import set_documentation_mode
 from ads.common import utils
@@ -71,8 +71,8 @@ class ADSDataset(PandasDataset):
     def __init__(
         self,
         df,
-        sampled_df,
-        shape,
+        sampled_df=None,
+        shape=None,
         name="",
         description=None,
         type_discovery=True,
@@ -88,6 +88,17 @@ class ADSDataset(PandasDataset):
         # to keep performance high and linear no matter the size of the distributed dataset we
         # create a pandas df that's used internally because this has a fixed upper size.
         #
+        if not isinstance(shape, Tuple):
+            shape = df.shape
+
+        if not isinstance(sampled_df, pd.DataFrame):
+            sampled_df = generate_sample(
+                df,
+                shape[0],
+                DatasetDefaults.sampling_confidence_level,
+                DatasetDefaults.sampling_confidence_interval,
+                **kwargs,
+            )
         super().__init__(
             sampled_df,
             type_discovery=type_discovery,
@@ -133,6 +144,36 @@ class ADSDataset(PandasDataset):
 
     def __len__(self):
         return self.shape[0]
+
+    @staticmethod
+    def from_dataframe(
+        df,
+        sampled_df=None,
+        shape=None,
+        name="",
+        description=None,
+        type_discovery=True,
+        types={},
+        metadata=None,
+        progress=DummyProgressBar(),
+        transformer_pipeline=None,
+        interactive=False,
+        **kwargs,
+    ) -> "ADSDataset":
+        return ADSDataset(
+            df=df,
+            sampled_df=sampled_df,
+            shape=shape,
+            name=name,
+            description=description,
+            type_discovery=type_discovery,
+            types=types,
+            metadata=metadata,
+            progress=progress,
+            transformer_pipeline=transformer_pipeline,
+            interactive=interactive,
+            **kwargs
+        )
 
     @property
     @deprecated(

--- a/ads/dataset/dataset.py
+++ b/ads/dataset/dataset.py
@@ -88,10 +88,10 @@ class ADSDataset(PandasDataset):
         # to keep performance high and linear no matter the size of the distributed dataset we
         # create a pandas df that's used internally because this has a fixed upper size.
         #
-        if not isinstance(shape, Tuple):
+        if shape is None:
             shape = df.shape
 
-        if not isinstance(sampled_df, pd.DataFrame):
+        if sampled_df is None:
             sampled_df = generate_sample(
                 df,
                 shape[0],

--- a/ads/dataset/dataset_with_target.py
+++ b/ads/dataset/dataset_with_target.py
@@ -77,9 +77,9 @@ class ADSDatasetWithTarget(ADSDataset, metaclass=ABCMeta):
         **kwargs,
     ):
         self.recommendation_transformer = None
-        if not isinstance(shape, Tuple):
+        if shape is None:
             shape = df.shape
-        if not isinstance(sampled_df, pd.DataFrame):
+        if sampled_df is None:
             sampled_df = generate_sample(
                 df,
                 shape[0],
@@ -161,7 +161,7 @@ class ADSDatasetWithTarget(ADSDataset, metaclass=ABCMeta):
             cols.insert(0, cols.pop(cols.index(target)))
             self.sampled_df = self.sampled_df[[*cols]]
 
-        if not isinstance(target_type, TypedFeature):
+        if target_type is None:
             target_type = get_target_type(target, sampled_df, **kwargs)
         self.target = TargetVariable(self, target, target_type)
 
@@ -192,7 +192,7 @@ class ADSDatasetWithTarget(ADSDataset, metaclass=ABCMeta):
         from ads.dataset.forecasting_dataset import ForecastingDataset
         from ads.dataset.regression_dataset import RegressionDataset
 
-        if not isinstance(sampled_df, pd.DataFrame):
+        if sampled_df is None:
             sampled_df = generate_sample(
                 df,
                 (shape or df.shape)[0],
@@ -201,7 +201,7 @@ class ADSDatasetWithTarget(ADSDataset, metaclass=ABCMeta):
                 **init_kwargs,
             )
             
-        if not isinstance(target_type, TypedFeature):
+        if target_type is None:
             target_type = get_target_type(target, sampled_df, **init_kwargs)
 
         if len(df[target].dropna()) == 0:

--- a/ads/dataset/dataset_with_target.py
+++ b/ads/dataset/dataset_with_target.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 from __future__ import absolute_import, print_function
@@ -10,7 +10,7 @@ import abc
 import importlib
 from collections import defaultdict
 from numbers import Number
-from typing import Union
+from typing import Tuple, Union
 
 import pandas as pd
 from ads.common import utils, logger
@@ -23,14 +23,30 @@ from ads.dataset import helper
 from ads.dataset.dataset import ADSDataset
 from ads.dataset.feature_engineering_transformer import FeatureEngineeringTransformer
 from ads.dataset.feature_selection import FeatureImportance
-from ads.dataset.helper import deprecate_default_value, deprecate_variable
+from ads.dataset.helper import (
+    DatasetDefaults,
+    deprecate_default_value, 
+    deprecate_variable, 
+    generate_sample,
+    get_target_type,
+    is_text_data,
+)
 from ads.dataset.label_encoder import DataFrameLabelEncoder
 from ads.dataset.pipeline import TransformerPipeline
 from ads.dataset.progress import DummyProgressBar
 from ads.dataset.recommendation import Recommendation
 from ads.dataset.recommendation_transformer import RecommendationTransformer
 from ads.dataset.target import TargetVariable
-from ads.type_discovery.typed_feature import DateTimeTypedFeature
+from ads.type_discovery.typed_feature import (
+    CategoricalTypedFeature,
+    ContinuousTypedFeature,
+    DocumentTypedFeature,
+    GISTypedFeature,
+    OrdinalTypedFeature,
+    TypedFeature,
+    DateTimeTypedFeature, 
+    TypedFeature
+)
 from sklearn.model_selection import train_test_split
 from pandas.io.formats.printing import pprint_thing
 from sklearn.preprocessing import FunctionTransformer
@@ -45,10 +61,10 @@ class ADSDatasetWithTarget(ADSDataset, metaclass=ABCMeta):
     def __init__(
         self,
         df,
-        sampled_df,
         target,
-        target_type,
-        shape,
+        sampled_df=None,
+        shape=None,
+        target_type=None,
         sample_max_rows=-1,
         type_discovery=True,
         types={},
@@ -61,6 +77,16 @@ class ADSDatasetWithTarget(ADSDataset, metaclass=ABCMeta):
         **kwargs,
     ):
         self.recommendation_transformer = None
+        if not isinstance(shape, Tuple):
+            shape = df.shape
+        if not isinstance(sampled_df, pd.DataFrame):
+            sampled_df = generate_sample(
+                df,
+                shape[0],
+                DatasetDefaults.sampling_confidence_level,
+                DatasetDefaults.sampling_confidence_interval,
+                **kwargs,
+            )
 
         if parent is None:
             cols = sampled_df.columns.tolist()
@@ -135,6 +161,8 @@ class ADSDatasetWithTarget(ADSDataset, metaclass=ABCMeta):
             cols.insert(0, cols.pop(cols.index(target)))
             self.sampled_df = self.sampled_df[[*cols]]
 
+        if not isinstance(target_type, TypedFeature):
+            target_type = get_target_type(target, sampled_df, **kwargs)
         self.target = TargetVariable(self, target, target_type)
 
         # remove target from type discovery conversion
@@ -144,6 +172,141 @@ class ADSDatasetWithTarget(ADSDataset, metaclass=ABCMeta):
                 and self.target.name in step[1].kw_args["dtypes"]
             ):
                 step[1].kw_args["dtypes"].pop(self.target.name)
+
+    @staticmethod
+    def from_dataframe(
+        df: pd.DataFrame,
+        target: str,
+        sampled_df: pd.DataFrame = None,
+        shape: Tuple[int, int] = None,
+        target_type: TypedFeature = None,
+        positive_class=None,
+        **init_kwargs,
+    ):
+        from ads.dataset.classification_dataset import (
+            BinaryClassificationDataset, 
+            BinaryTextClassificationDataset, 
+            MultiClassClassificationDataset, 
+            MultiClassTextClassificationDataset
+        )
+        from ads.dataset.forecasting_dataset import ForecastingDataset
+        from ads.dataset.regression_dataset import RegressionDataset
+
+        if not isinstance(sampled_df, pd.DataFrame):
+            sampled_df = generate_sample(
+                df,
+                (shape or df.shape)[0],
+                DatasetDefaults.sampling_confidence_level,
+                DatasetDefaults.sampling_confidence_interval,
+                **init_kwargs,
+            )
+            
+        if not isinstance(target_type, TypedFeature):
+            target_type = get_target_type(target, sampled_df, **init_kwargs)
+
+        if len(df[target].dropna()) == 0:
+            logger.warning(
+                "It is not recommended to use an empty column as the target variable."
+            )
+            raise ValueError(
+                f"We do not support using empty columns as the chosen target"
+            )
+        if utils.is_same_class(target_type, ContinuousTypedFeature):
+            return RegressionDataset(
+                df=df,
+                sampled_df=sampled_df,
+                target=target,
+                target_type=target_type,
+                shape=shape,
+                **init_kwargs,
+            )
+        elif utils.is_same_class(
+            target_type, DateTimeTypedFeature
+        ) or df.index.dtype.name.startswith("datetime"):
+            return ForecastingDataset(
+                df=df,
+                sampled_df=sampled_df,
+                target=target,
+                target_type=target_type,
+                shape=shape,
+                **init_kwargs,
+            )
+
+        # Adding ordinal typed feature, but ultimately we should rethink how we want to model this type
+        elif utils.is_same_class(target_type, CategoricalTypedFeature) or utils.is_same_class(
+            target_type, OrdinalTypedFeature
+        ):
+            if target_type.meta_data["internal"]["unique"] == 2:
+                if is_text_data(sampled_df, target):
+                    return BinaryTextClassificationDataset(
+                        df=df,
+                        sampled_df=sampled_df,
+                        target=target,
+                        shape=shape,
+                        target_type=target_type,
+                        positive_class=positive_class,
+                        **init_kwargs,
+                    )
+
+                return BinaryClassificationDataset(
+                    df=df,
+                    sampled_df=sampled_df,
+                    target=target,
+                    shape=shape,
+                    target_type=target_type,
+                    positive_class=positive_class,
+                    **init_kwargs,
+                )
+            else:
+                if is_text_data(sampled_df, target):
+                    return MultiClassTextClassificationDataset(
+                        df=df,
+                        sampled_df=sampled_df,
+                        target=target,
+                        target_type=target_type,
+                        shape=shape,
+                        **init_kwargs,
+                    )
+                return MultiClassClassificationDataset(
+                    df=df,
+                    sampled_df=sampled_df,
+                    target=target,
+                    target_type=target_type,
+                    shape=shape,
+                    **init_kwargs,
+                )
+        elif (
+            utils.is_same_class(target, DocumentTypedFeature)
+            or "text" in target_type["type"]
+            or "text" in target
+        ):
+            raise ValueError(
+                f"The column {target} cannot be used as the target column."
+            )
+        elif (
+            utils.is_same_class(target_type, GISTypedFeature)
+            or "coord" in target_type["type"]
+            or "coord" in target
+        ):
+            raise ValueError(
+                f"The column {target} cannot be used as the target column."
+            )
+        # This is to catch constant columns that are boolean. Added as a fix for pd.isnull(), and datasets with a
+        #   binary target, but only data on one instance
+        elif target_type and target_type["low_level_type"] == "bool":
+            return BinaryClassificationDataset(
+                df=df,
+                sampled_df=sampled_df,
+                target=target,
+                shape=shape,
+                target_type=target_type,
+                positive_class=positive_class,
+                **init_kwargs,
+            )
+        raise ValueError(
+            f"Unable to identify problem type. Specify the data type of {target} using 'types'. "
+            f"For example, types = {{{target}: 'category'}}"
+        )
 
     def rename_columns(self, columns):
         """

--- a/ads/dataset/forecasting_dataset.py
+++ b/ads/dataset/forecasting_dataset.py
@@ -14,7 +14,7 @@ class ForecastingDataset(ADSDatasetWithTarget):
         if isinstance(target, DateTimeTypedFeature):
             df = df.set_index(target)
         ADSDatasetWithTarget.__init__(
-            self, df, sampled_df, target, target_type, shape, **kwargs
+            self, df=df, sampled_df=sampled_df, target=target, target_type=target_type, shape=shape, **kwargs
         )
 
     def select_best_features(self, score_func=None, k=12):

--- a/ads/dataset/helper.py
+++ b/ads/dataset/helper.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import ast
@@ -832,3 +832,20 @@ def _log_yscale_not_set():
     logger.info(
         "`yscale` parameter is not set. Valid values are `'linear'`, `'log'`, `'symlog'`."
     )
+
+def infer_target_type(target, target_series, discover_target_type=True):
+    # if type discovery is turned off, infer type from pandas dtype
+    if discover_target_type:
+        target_type = TypeDiscoveryDriver().discover(
+            target, target_series, is_target=True
+        )
+    else:
+        target_type = get_feature_type(target, target_series)
+    return target_type
+
+def get_target_type(target, sampled_df, **init_kwargs):
+    discover_target_type = init_kwargs.get("type_discovery", True)
+    if target in init_kwargs.get("types", {}):
+        sampled_df[target] = sampled_df[target].astype(init_kwargs.get("types")[target])
+        discover_target_type = False
+    return infer_target_type(target, sampled_df[target], discover_target_type)

--- a/ads/dataset/regression_dataset.py
+++ b/ads/dataset/regression_dataset.py
@@ -10,5 +10,5 @@ from ads.dataset.dataset_with_target import ADSDatasetWithTarget
 class RegressionDataset(ADSDatasetWithTarget):
     def __init__(self, df, sampled_df, target, target_type, shape, **kwargs):
         ADSDatasetWithTarget.__init__(
-            self, df, sampled_df, target, target_type, shape, **kwargs
+            self, df=df, sampled_df=sampled_df, target=target, target_type=target_type, shape=shape, **kwargs
         )

--- a/docs/source/user_guide/data_transformation/data_transformation.rst
+++ b/docs/source/user_guide/data_transformation/data_transformation.rst
@@ -3,7 +3,7 @@
 Transform Data 
 ##############
 
-When datasets are loaded with DatasetFactory, they can be transformed and manipulated easily with the built-in functions. Underlying, an ``ADSDataset`` object is a Pandas dataframe. Any operation that can be performed to a `Pandas dataframe <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`_ can also be applied to an ADS Dataset.
+When datasets are loaded, they can be transformed and manipulated easily with the built-in functions. Underlying, an ``ADSDataset`` object is a Pandas dataframe. Any operation that can be performed to a `Pandas dataframe <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`_ can also be applied to an ADS Dataset.
 
 Loading the Dataset
 ********************
@@ -12,9 +12,9 @@ You can load a ``pandas`` dataframe into an ``ADSDataset`` by calling.
 
 .. code-block:: python3
 
-   from ads.dataset.factory import DatasetFactory
+   from ads.dataset.dataset import ADSDataset
 
-   ds = DatasetFactory.from_dataframe(df)
+   ds = ADSDataset.from_dataframe(df)
 
 
 Automated Transformations
@@ -513,11 +513,14 @@ The resulting three data subsets each have separate data (X) and labels (y).
     print(train.X)  # print out all features in train dataset
     print(train.y)  # print out labels in train dataset
 
-You can split the dataset right after the ``DatasetFactory.open()`` statement:
+You can split the dataset right after the ``ADSDatasetWithTarget.from_dataframe()`` statement:
 
 .. code-block:: python3
 
-    ds = DatasetFactory.open("path/data.csv").set_target('target')
+    ds = ADSDatasetWithTarget.from_dataframe(
+        df=pd.read_csv("path/data.csv"),
+        target="target"
+    )
     train, test = ds.train_test_split(test_size=0.25)
 
 Text Data 

--- a/docs/source/user_guide/loading_data/connect.rst
+++ b/docs/source/user_guide/loading_data/connect.rst
@@ -526,34 +526,34 @@ To load a dataframe from a remote web server source, use ``pandas`` directly and
 Convert Pandas DataFrame to ``ADSDataset``
 ==========================================
 
-To convert a Pandas dataframe to ``ADSDataset``, pass the ``pandas.DataFrame`` object directly into the ADS ``DatasetFactory.open`` method:
+To convert a Pandas dataframe to ``ADSDataset``, pass the ``pandas.DataFrame`` object directly into the ADS ``ADSDataset`` constructor or ``ADSDataset.from_dataframe()`` method:
 
 .. code-block:: python3
 
   import pandas as pd
-  from ads.dataset.factory import DatasetFactory
+  from ads.dataset.dataset import ADSDataset
 
   df = pd.read_csv('/path/some_data.csv) # load data with Pandas
 
   # use open...
 
-  ds = DatasetFactory.open(df) # construct **ADS** Dataset from DataFrame
+  ds = ADSDataset(df) # construct **ADS** Dataset from DataFrame
 
   # alternative form...
 
-  ds = DatasetFactory.from_dataframe(df)
+  ds = ADSDataset.from_dataframe(df)
 
   # an example using Pandas to parse data on the clipboard as a CSV and construct an ADS Dataset object
   # this allows easily transfering data from an application like Microsoft Excel, Apple Numbers, etc.
 
-  ds = DatasetFactory.from_dataframe(pd.read_clipboard())
+  ds = ADSDataset.from_dataframe(pd.read_clipboard())
 
   # use Pandas to query a SQL database:
 
   from sqlalchemy import create_engine
   engine = create_engine('dialect://user:pass@host:port/schema', echo=False)
   df = pd.read_sql_query('SELECT * FROM mytable', engine, index_col = 'ID')
-  ds = DatasetFactory.from_dataframe(df)
+  ds = ADSDataset.from_dataframe(df)
 
 
 Using ``PyArrow``

--- a/docs/source/user_guide/loading_data/connect_legacy.rst
+++ b/docs/source/user_guide/loading_data/connect_legacy.rst
@@ -1,5 +1,5 @@
-Connect with ``DatasetFactory`` 
-*******************************
+Connect with ``ADSDataset`` and ``ADSDatasetWithTarget`` 
+********************************************************
 
 
 .. admonition:: Deprecation Note |deprecated|
@@ -25,7 +25,8 @@ Begin by loading the required libraries and modules:
     import pandas as pd
 
     from ads.dataset.dataset_browser import DatasetBrowser
-    from ads.dataset.factory import DatasetFactory
+    from ads.dataset.dataset import ADSDataset
+    from ads.dataset.dataset_with_target import ADSDatasetWithTarget
 
 Object Storage
 ==============
@@ -37,14 +38,15 @@ To open a dataset from Object Storage using the resource principal method, you c
   import ads
   import os
 
-  from ads.dataset.factory import DatasetFactory
-
   ads.set_auth(auth='resource_principal')
   bucket_name = <bucket-name>
   file_name = <file-name>
   namespace = <namespace>
   storage_options = {'config':{}, 'tenancy': os.environ['TENANCY_OCID'], 'region': os.environ['NB_REGION']}
-  ds = DatasetFactory.open(f"oci://{bucket_name}@{namespace}/{file_name}", storage_options=storage_options)
+  ds = ADSDataset(
+    df=pd.read_csv(f"oci://{bucket_name}@{namespace}/{file_name}.csv"),
+    storage_options=storage_options
+  )
 
 
 To open a dataset from Object Storage using the Oracle Cloud Infrastructure configuration file method, include the location of the file using this format ``oci://<bucket_name>@<namespace>/<file_name>`` and modify the optional parameter ``storage_options``. Insert:
@@ -56,19 +58,22 @@ For example:
 
 .. code-block:: python3
 
-  ds = DatasetFactory.open("oci://<bucket_name>@<namespace>/<file_name>", storage_options = {
+  ds = ADSDataset(
+    df=pd.read_csv(f"oci://{bucket_name}@{namespace}/{file_name}.csv"),
+    storage_options={
      "config": "~/.oci/config",
      "profile": "DEFAULT"
-  })
+    }
+  )
 
 Local Storage
 =============
 
-To open a dataset from a local source, use ``DatasetFactory.open`` and specify the path of the data file:
+To open a dataset from a local source, use ``ADSDataset`` and specify the path of the data file:
 
 .. code-block:: python3
 
-  ds = DatasetFactory.open("/path/to/data.data", format='csv', delimiter=" ")
+  ds = ADSDataset(df=pd.read_csv("/path/to/data.csv"))
 
 Oracle Database
 ---------------
@@ -122,9 +127,11 @@ You can also use ``cx_Oracle`` within ADS by creating a connection string:
 .. code-block:: python3
 
   os.environ['TNS_ADMIN'] = creds['tns_admin']
-  from ads.dataset.factory import DatasetFactory
+  from ads.dataset.dataset import ADSDataset
   uri = 'oracle+cx_oracle://' + creds['user'] + ':' + creds['password'] + '@' + creds['sid']
-  ds = DatasetFactory.open(uri, format="sql", table=table, index_col=index_col)
+  ds = ADSDataset(
+    df=pd.read_sql(uri, table=table, index_col=index_col)
+  )
 
 Autonomous Database
 ===================
@@ -148,13 +155,13 @@ After you have stored the ADB username, password, and database name (SID) as var
 
     uri = 'oracle+cx_oracle://' + creds['user'] + ':' + creds['password'] + '@' + creds['sid']
 
-You can use ADS to query a table from your database, and then load that table as an ``ADSDataset`` object through ``DatasetFactory``.
-When you open ``DatasetFactory``, specify the name of the table you want to pull using the ``table`` variable for a given table. For SQL expressions, use the table parameter also. For example, *(`table="SELECT * FROM sh.times WHERE rownum <= 30"`)*.
+You can use ADS to query a table from your database, and then load that table as an ``ADSDatasetWithTarget`` object.
+When you open ``ADSDatasetWithTarget``, specify the name of the table you want to pull using the ``table`` variable for a given table. For SQL expressions, use the table parameter also. For example, *(`table="SELECT * FROM sh.times WHERE rownum <= 30"`)*.
 
 .. code-block:: python3
 
     os.environ['TNS_ADMIN'] = creds['tns_admin']
-    ds = DatasetFactory.open(uri, format="sql", table=table, target='label')
+    ds = ADSDatasetWithTarget(df=pd.read_sql(uri, table=table), target='label')
 
 Query ADB
 ---------
@@ -172,11 +179,11 @@ Query ADB
       engine = create_engine(uri)
       df = pd.read_sql('SELECT * from <TABLENAME>', con=engine)
 
-You can convert the ``pd.DataFrame`` into ``ADSDataset`` using the ``DatasetFactory.from_dataframe()`` function.
+You can convert the ``pd.DataFrame`` into ``ADSDataset`` using the ``ADSDataset.from_dataframe()`` function.
 
 .. code-block:: python3
 
-      ds = DatasetFactory.from_dataframe(df)
+      ds = ADSDataset.from_dataframe(df)
 
 These two examples run a simple query on ADW data. With ``read_sql_query`` you can use SQL expressions not just for tables, but also to limit the number of rows and to apply conditions with filters, such as (``where``).
 
@@ -207,7 +214,7 @@ You can also query data from ADW using cx_Oracle. Use the cx_Oracle 7.0.0 versio
       data = results.fetchall()
       df = pd.DataFrame(np.array(data))
 
-      ds = DatasetFactory.from_dataframe(df)
+      ds = ADSDataset.from_dataframe(df)
 
 .. code-block:: python3
 
@@ -230,7 +237,7 @@ This example adds predictions programmatically using cx_Oracle. It uses ``execut
 
 .. code-block:: python3
 
-    ds = DatasetFactory.open("iris.csv")
+    ds = ADSDataset(pd.read_csv("iris.csv"))
 
     create_table = '''CREATE TABLE IRIS_PREDICTED (,
                             sepal_length number,
@@ -269,12 +276,14 @@ You can open Amazon S3 public or private files in ADS. For private files, you mu
 
 .. code-block:: python3
 
-  ds = DatasetFactory.open("s3://bucket_name/iris.csv", storage_options = {
+  ds = ADSDataset(
+    df=pd.read_csv("s3://bucket_name/iris.csv"),
+    storage_options = {
       'key': 'aws key',
       'secret': 'aws secret,
       'blocksize': 1000000,
       'client_kwargs': {
-              "endpoint_url": "https://s3-us-west-1.amazonaws.com"
+        "endpoint_url": "https://s3-us-west-1.amazonaws.com"
       }
   })
 
@@ -282,11 +291,14 @@ You can open Amazon S3 public or private files in ADS. For private files, you mu
 HTTP(S) Sources
 ===============
 
-To open a dataset from a remote web server source, use ``DatasetFactory.open()`` and specify the URL of the data:
+To open a dataset from a remote web server source, use ``ADSDatasetWithTarget`` and specify the URL of the data:
 
 .. code-block:: python3
 
-   ds = DatasetFactory.open('https://example.com/path/to/data.csv', target='label')
+  ds = ADSDatasetWithTarget(
+    df=pd.read_csv('https://example.com/path/to/data.csv'),
+    target='label'
+  )
 
 
 ``DatasetBrowser``

--- a/docs/source/user_guide/loading_data/connect_legacy.rst
+++ b/docs/source/user_guide/loading_data/connect_legacy.rst
@@ -127,7 +127,6 @@ You can also use ``cx_Oracle`` within ADS by creating a connection string:
 .. code-block:: python3
 
   os.environ['TNS_ADMIN'] = creds['tns_admin']
-  from ads.dataset.dataset import ADSDataset
   with cx_Oracle.connect(creds['user'], creds['password'], creds['sid']) as ora_conn:
     ds = ADSDataset(
       df=pd.read_sql('''
@@ -205,7 +204,6 @@ You can also query data from ADW using cx_Oracle. Use the cx_Oracle 7.0.0 versio
 
 .. code-block:: python3
 
-      import
       import pandas as pd
       import numpy as np
       import os

--- a/docs/source/user_guide/loading_data/supported_format.rst
+++ b/docs/source/user_guide/loading_data/supported_format.rst
@@ -3,11 +3,11 @@ Supported Formats
 
 You can load datasets into ADS, either locally or from network file systems.
 
-You can open datasets with ``DatasetFactory``, ``DatasetBrowser`` or ``pandas``. ``DatasetFactory`` allows datasets to be loaded into ADS.
+You can open datasets with ``DatasetBrowser`` or ``pandas``.
 
 ``DatasetBrowser`` supports opening the datasets from web sites and libraries, such as scikit-learn directly into ADS.
 
-When you open a dataset in ``DatasetFactory``, you can get the summary statistics, correlations, and visualizations of the dataset.
+When you load a dataset in ``ADSDataset`` from ``pandas.DataFrame``, you can get the summary statistics, correlations, and visualizations of the dataset.
 
 ADS Supports:
 

--- a/docs/source/user_guide/model_catalog/model_catalog.rst
+++ b/docs/source/user_guide/model_catalog/model_catalog.rst
@@ -17,6 +17,7 @@ provenance, reproduced, and deployed.
     import os
     import tempfile
     import warnings
+    import pandas as pd
 
     from ads.catalog.model import ModelCatalog
     from ads.common.model import ADSModel
@@ -24,7 +25,7 @@ provenance, reproduced, and deployed.
     from ads.common.model_metadata import (MetadataCustomCategory,
                                            UseCaseType,
                                            Framework)
-    from ads.dataset.factory import DatasetFactory
+    from ads.dataset.dataset_with_target import ADSDatasetWithTarget
     from ads.feature_engineering.schema import Expression, Schema
     from os import path
     from sklearn.ensemble import RandomForestClassifier
@@ -97,7 +98,7 @@ The ``RandomForestClassifier`` object is converted to into an ``ADSModel`` using
     # Load the dataset
     ds_path = path.join("/", "opt", "notebooks", "ads-examples", "oracle_data", "oracle_classification_dataset1_150K.csv")
 
-    ds = DatasetFactory.open(ds_path, target="class")
+    ds = ADSDatasetWithTarget(df=pd.read_csv(ds_path), target="class")
 
     # Data preprocessing
     transformed_ds = ds.auto_transform(fix_imbalance=False)

--- a/docs/source/user_guide/quickstart/quickstart.rst
+++ b/docs/source/user_guide/quickstart/quickstart.rst
@@ -60,8 +60,8 @@ to use (regression, binary, and multi-class classification, or time series forec
 
 There are several ways to turn data into an ``ADSDataset``. The simplest way is to
 use `ADSDataset` or `ADSDatasetWithTarget` constructor, which takes as its first argument
-as a ``Pandas Dataframe`` object. The ``Pandas Dataframe`` supports many formats, such as
-Object Storage or S3 files. The
+as a ``Pandas Dataframe`` object. The ``Pandas Dataframe`` supports loading data from many
+URL schemes, such as Object Storage or S3 files. The
 `class documentation <https://docs.cloud.oracle.com/en-us/iaas/tools/ads-sdk/latest/modules.html>_` describes all classes.
 
 For example:

--- a/docs/source/user_guide/quickstart/quickstart.rst
+++ b/docs/source/user_guide/quickstart/quickstart.rst
@@ -59,9 +59,9 @@ variable during modeling. The type of this target determines what type of modeli
 to use (regression, binary, and multi-class classification, or time series forecasting).
 
 There are several ways to turn data into an ``ADSDataset``. The simplest way is to
-use `DatasetFactory`, which takes as its first argument as a string URI or a
-``Pandas Dataframe`` object. The URI supports many formats, such as Object Storage
-or S3 files. The
+use `ADSDataset` or `ADSDatasetWithTarget` constructor, which takes as its first argument
+as a ``Pandas Dataframe`` object. The ``Pandas Dataframe`` supports many formats, such as
+Object Storage or S3 files. The
 `class documentation <https://docs.cloud.oracle.com/en-us/iaas/tools/ads-sdk/latest/modules.html>_` describes all classes.
 
 For example:
@@ -77,12 +77,12 @@ For example:
   df = pd.DataFrame(data.data, columns=data.feature_names)
   df["species"] = data.target
 
-  from ads.dataset.factory import DatasetFactory
+  from ads.dataset.dataset_with_target import ADSDatasetWithTarget
 
   # these two are equivalent:
-  ds = DatasetFactory.open(df, target="species")
+  ds = ADSDatasetWithTarget(df, target="species")
   # OR
-  ds = DatasetFactory.from_dataframe(df, target="species")
+  ds = ADSDatasetWithTarget.from_dataframe(df, target="species")
 
 The ``ds`` (``ADSDataset``) object is ``Pandas`` like. For example, you can use ``ds.head()``. It's
 an encapsulation of a `Pandas` Dataframe with immutability. Any attempt to
@@ -93,7 +93,7 @@ modify the data yields a new copy-on-write of the ``ADSDataset``.
    to memory. ADS also samples the dataset for visualization purposes, computes
    co-correlation of the columns in the dataset, and performs type discovery on the
    different columns in the dataset. That is why loading a dataset with
-   ``DatasetFactory`` can be slower than simply reading the same dataset
+   ``ADSDataset`` can be slower than simply reading the same dataset
    with ``Pandas``. In return, you get the added data visualizations and data
    profiling benefits of the ``ADSDataset`` object.
 
@@ -113,10 +113,12 @@ modify the data yields a new copy-on-write of the ``ADSDataset``.
 
   pd.DataFrame({'c1':[1,2,3], 'target': ['yes', 'no', 'yes']}).to_csv('Users/ysz/data/sample.csv')
 
-  ds = DatasetFactory.open('Users/ysz/data/sample.csv',
-                          target = 'target',
-                          type_discovery = False, # turn off ADS type discovery
-                          types = {'target': 'category'}) # specify target type
+  ds = ADSDatasetWithTarget(
+    df=pd.read_csv('Users/ysz/data/sample.csv'),
+    target='target',
+    type_discovery=False, # turn off ADS type discovery
+    types={'target': 'category'} # specify target type
+  )
 
 
 

--- a/tests/unitary/with_extras/dataset/data/orcl_attrition.csv
+++ b/tests/unitary/with_extras/dataset/data/orcl_attrition.csv
@@ -1,0 +1,9 @@
+Age,Attrition,TravelForWork,SalaryLevel,JobFunction,CommuteLength,EducationalLevel,EducationField,Directs,EmployeeNumber,EnvironmentSatisfaction,Gender,HourlyRate,JobInvolvement,JobLevel,JobRole,JobSatisfaction,MaritalStatus,MonthlyIncome,MonthlyRate,NumCompaniesWorked,Over18,OverTime,PercentSalaryHike,PerformanceRating,RelationshipSatisfaction,WeeklyWorkedHours,StockOptionLevel,YearsinIndustry,TrainingTimesLastYear,WorkLifeBalance,YearsOnJob,YearsAtCurrentLevel,YearsSinceLastPromotion,YearsWithCurrManager
+42,Yes,infrequent,5054,Product Management,2,L2,Life Sciences,1,1,2,Female,94,3,2,Sales Executive,4,Single,5993,19479,8,Y,Yes,11,3,1,80,0,8,0,1,6,4,0,5
+50,No,often,1278,Software Developer,9,L1,Life Sciences,1,2,3,Male,61,2,2,Research Scientist,2,Married,5130,24907,1,Y,No,23,4,4,80,1,10,3,3,10,7,1,7
+38,Yes,infrequent,6296,Software Developer,3,L2,Other,1,4,4,Male,92,2,1,Laboratory Technician,3,Single,2090,2396,6,Y,Yes,15,3,2,80,0,7,3,3,0,0,0,0
+34,No,often,6384,Software Developer,4,L4,Life Sciences,1,5,4,Female,56,3,1,Research Scientist,3,Married,2909,23159,1,Y,Yes,11,3,3,80,0,8,3,3,8,7,3,0
+28,No,infrequent,2710,Software Developer,3,L1,Medical,1,7,1,Male,40,3,1,Laboratory Technician,2,Married,3468,16632,9,Y,No,12,3,4,80,1,6,3,3,2,2,2,2
+33,No,often,4608,Software Developer,3,L2,Life Sciences,1,8,4,Male,79,3,1,Laboratory Technician,4,Single,3068,11864,0,Y,No,13,3,3,80,0,8,2,2,7,7,3,6
+60,No,infrequent,6072,Software Developer,4,L3,Medical,1,10,3,Female,81,4,1,Laboratory Technician,1,Married,2670,9964,4,Y,Yes,20,4,1,80,3,12,3,2,1,0,0,0
+31,No,infrequent,6228,Software Developer,25,L1,Life Sciences,1,11,4,Male,67,3,1,Laboratory Technician,3,Divorced,2693,13335,1,Y,No,22,4,2,80,1,1,2,3,1,0,0,0

--- a/tests/unitary/with_extras/dataset/test_dataset_dataset.py
+++ b/tests/unitary/with_extras/dataset/test_dataset_dataset.py
@@ -5,10 +5,12 @@
 
 import os
 import tempfile
+from typing import Tuple
 
 import pandas as pd
 import pytest
 from ads.dataset.dataset import ADSDataset
+from ads.dataset.pipeline import TransformerPipeline
 from ads.dataset.target import TargetVariable
 import mock, sys
 
@@ -52,3 +54,33 @@ class TestADSDataset:
             with pytest.raises(ModuleNotFoundError):
                 test_df = pd.DataFrame()
                 TargetVariable(test_df, "", None)
+
+    def test_initialize_dataset(self):
+        employees = ADSDataset(
+            df=pd.read_csv("oci://hosted-ds-datasets@bigdatadatasciencelarge/synthetic/orcl_attrition.csv"),
+            name="test_dataset",
+            description="test_description",
+            storage_options={'config':{},'region':'us-ashburn-1'}
+        )
+        assert isinstance(employees, ADSDataset)
+        assert isinstance(employees.df, pd.DataFrame)
+        assert isinstance(employees.shape, Tuple)
+        assert employees.name == "test_dataset"
+        assert employees.description == "test_description"
+        assert "type_discovery" in employees.init_kwargs
+        assert isinstance(employees.transformer_pipeline, TransformerPipeline)
+
+    def test_from_dataframe(self):
+        employees = ADSDataset.from_dataframe(
+            df=pd.read_csv("oci://hosted-ds-datasets@bigdatadatasciencelarge/synthetic/orcl_attrition.csv"),
+            name="test_dataset",
+            description="test_description",
+            storage_options={'config':{},'region':'us-ashburn-1'}
+        )
+        assert isinstance(employees, ADSDataset)
+        assert isinstance(employees.df, pd.DataFrame)
+        assert isinstance(employees.shape, Tuple)
+        assert employees.name == "test_dataset"
+        assert employees.description == "test_description"
+        assert "type_discovery" in employees.init_kwargs
+        assert isinstance(employees.transformer_pipeline, TransformerPipeline)

--- a/tests/unitary/with_extras/dataset/test_dataset_dataset.py
+++ b/tests/unitary/with_extras/dataset/test_dataset_dataset.py
@@ -57,7 +57,7 @@ class TestADSDataset:
 
     def test_initialize_dataset(self):
         employees = ADSDataset(
-            df=pd.read_csv("oci://hosted-ds-datasets@bigdatadatasciencelarge/synthetic/orcl_attrition.csv"),
+            df=pd.read_csv(self.get_data_path()),
             name="test_dataset",
             description="test_description",
             storage_options={'config':{},'region':'us-ashburn-1'}
@@ -72,7 +72,7 @@ class TestADSDataset:
 
     def test_from_dataframe(self):
         employees = ADSDataset.from_dataframe(
-            df=pd.read_csv("oci://hosted-ds-datasets@bigdatadatasciencelarge/synthetic/orcl_attrition.csv"),
+            df=pd.read_csv(self.get_data_path()),
             name="test_dataset",
             description="test_description",
             storage_options={'config':{},'region':'us-ashburn-1'}
@@ -84,3 +84,7 @@ class TestADSDataset:
         assert employees.description == "test_description"
         assert "type_discovery" in employees.init_kwargs
         assert isinstance(employees.transformer_pipeline, TransformerPipeline)
+
+    def get_data_path(self):
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        return os.path.join(current_dir, "data", "orcl_attrition.csv")

--- a/tests/unitary/with_extras/dataset/test_dataset_target.py
+++ b/tests/unitary/with_extras/dataset/test_dataset_target.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+from typing import Tuple
+import pandas as pd
+from ads.dataset.classification_dataset import BinaryClassificationDataset
+from ads.dataset.dataset_with_target import ADSDatasetWithTarget
+from ads.dataset.pipeline import TransformerPipeline
+from ads.dataset.target import TargetVariable
+
+
+class TestADSDatasetTarget:
+    def test_initialize_dataset_target(self):
+        employees = ADSDatasetWithTarget(
+            df=pd.read_csv("oci://hosted-ds-datasets@bigdatadatasciencelarge/synthetic/orcl_attrition.csv"),
+            target="Attrition",
+            name="test_dataset",
+            description="test_description",
+            storage_options={'config':{},'region':'us-ashburn-1'}
+        )
+
+        assert isinstance(employees, ADSDatasetWithTarget)
+        assert isinstance(employees.df, pd.DataFrame)
+        assert isinstance(employees.shape, Tuple)
+        assert isinstance(employees.target, TargetVariable)
+        assert employees.target.type["type"] == "categorical"
+        assert employees.name == "test_dataset"
+        assert employees.description == "test_description"
+        assert "type_discovery" in employees.init_kwargs
+        assert isinstance(employees.transformer_pipeline, TransformerPipeline)
+
+    def test_dataset_target_from_dataframe(self):
+        employees = ADSDatasetWithTarget.from_dataframe(
+            df=pd.read_csv("oci://hosted-ds-datasets@bigdatadatasciencelarge/synthetic/orcl_attrition.csv"),
+            target="Attrition",
+            storage_options={'config':{},'region':'us-ashburn-1'}
+        ).set_positive_class('Yes')
+
+        assert isinstance(employees, BinaryClassificationDataset)
+        assert isinstance(employees.df, pd.DataFrame)
+        assert isinstance(employees.shape, Tuple)
+        assert isinstance(employees.target, TargetVariable)
+        assert employees.target.type["type"] == "categorical"
+        assert "type_discovery" in employees.init_kwargs
+        assert isinstance(employees.transformer_pipeline, TransformerPipeline)

--- a/tests/unitary/with_extras/dataset/test_dataset_target.py
+++ b/tests/unitary/with_extras/dataset/test_dataset_target.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
+import os
 from typing import Tuple
 import pandas as pd
 from ads.dataset.classification_dataset import BinaryClassificationDataset
@@ -14,7 +15,7 @@ from ads.dataset.target import TargetVariable
 class TestADSDatasetTarget:
     def test_initialize_dataset_target(self):
         employees = ADSDatasetWithTarget(
-            df=pd.read_csv("oci://hosted-ds-datasets@bigdatadatasciencelarge/synthetic/orcl_attrition.csv"),
+            df=pd.read_csv(self.get_data_path()),
             target="Attrition",
             name="test_dataset",
             description="test_description",
@@ -33,7 +34,7 @@ class TestADSDatasetTarget:
 
     def test_dataset_target_from_dataframe(self):
         employees = ADSDatasetWithTarget.from_dataframe(
-            df=pd.read_csv("oci://hosted-ds-datasets@bigdatadatasciencelarge/synthetic/orcl_attrition.csv"),
+            df=pd.read_csv(self.get_data_path()),
             target="Attrition",
             storage_options={'config':{},'region':'us-ashburn-1'}
         ).set_positive_class('Yes')
@@ -45,3 +46,7 @@ class TestADSDatasetTarget:
         assert employees.target.type["type"] == "categorical"
         assert "type_discovery" in employees.init_kwargs
         assert isinstance(employees.transformer_pipeline, TransformerPipeline)
+
+    def get_data_path(self):
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        return os.path.join(current_dir, "data", "orcl_attrition.csv")


### PR DESCRIPTION
### Modified ADS dataset class to allow initialize ADSDataset and ADSDatasetWithTarget from constructor and from_dataframe

- Initialize ads dataset instance from `ADSDataset` constructor
- Initialize ads dataset with target from `ADSDatasetWithTarget` constructor
- Build ads dataset instance from `from_dataframe()` of `ADSDataset`
- Build ads dataset with target from `from_dataframe()` of `ADSDatasetWithTarget`

Example
```
# Build ads dataset with target from `from_dataframe()` of `ADSDatasetWithTarget`
employees = ADSDatasetWithTarget.from_dataframe(
    df=pd.read_csv("oci://hosted-ds-datasets@bigdatadatasciencelarge/synthetic/orcl_attrition.csv"),
    target="Attrition",
    storage_options={'config':{},'region':'us-ashburn-1'}
).set_positive_class('Yes')

# Initialize ads dataset with target from `ADSDatasetWithTarget` constructor
employees = ADSDatasetWithTarget(
    df=pd.read_csv("oci://hosted-ds-datasets@bigdatadatasciencelarge/synthetic/orcl_attrition.csv"),
    target="Attrition",
    storage_options={'config':{},'region':'us-ashburn-1'}
)

# Initialize ads dataset instance from `ADSDataset` constructor
employees = ADSDataset(
    df=pd.read_csv("oci://hosted-ds-datasets@bigdatadatasciencelarge/synthetic/orcl_attrition.csv"),
    name="test_dataset",
    description="test_description",
    storage_options={'config':{},'region':'us-ashburn-1'}
)

# Build ads dataset instance from `from_dataframe()` of `ADSDataset`
employees = ADSDataset.from_dataframe(
    df=pd.read_csv("oci://hosted-ds-datasets@bigdatadatasciencelarge/synthetic/orcl_attrition.csv"),
    name="test_dataset",
    description="test_description",
    storage_options={'config':{},'region':'us-ashburn-1'}
)
```