### PR TITLE
Update unit tests to set compartment ID if it is not available from environment variables.

### DIFF
--- a/.github/workflows/run-unittests-default_setup.yml
+++ b/.github/workflows/run-unittests-default_setup.yml
@@ -77,7 +77,6 @@ jobs:
         timeout-minutes: 15
         shell: bash
         env:
-          NB_SESSION_COMPARTMENT_OCID: ocid1.compartment.oc1.<unique_ocid>
           NoDependency: True
         run: |
           set -x # print commands that are executed

--- a/.github/workflows/run-unittests-default_setup.yml
+++ b/.github/workflows/run-unittests-default_setup.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     branches:
       - main
-      - 'release/**'
+      - "release/**"
       - develop
     paths:
-      - 'ads/**'
+      - "ads/**"
       - setup.py
-      - '**requirements.txt'
+      - "**requirements.txt"
+      - .github/workflows/run-unittests.yml
+      - .github/workflows/run-unittests-default_setup.yml
 
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/run-unittests.yml
+++ b/.github/workflows/run-unittests.yml
@@ -10,6 +10,8 @@ on:
       - "ads/**"
       - setup.py
       - "**requirements.txt"
+      - .github/workflows/run-unittests.yml
+      - .github/workflows/run-unittests-default_setup.yml
 
 # Cancel in progress workflows on pull_requests.
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/run-unittests.yml
+++ b/.github/workflows/run-unittests.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches:
       - main
-      - 'release/**'
+      - "release/**"
       - develop
     paths:
-      - 'ads/**'
+      - "ads/**"
       - setup.py
-      - '**requirements.txt'
-      - '!docs/**'
+      - "**requirements.txt"
+      - "!docs/**"
 
   pull_request:
 
@@ -88,22 +88,21 @@ jobs:
         shell: bash
         run: |
           set -x # print commands that are executed
-          
+
           sudo apt-get install libkrb5-dev graphviz
           $CONDA/bin/conda init
           source /home/runner/.bashrc
-          
+
           pip install -r dev-requirements.txt
 
       - name: "Run unitary tests folder with maximum ADS dependencies"
         timeout-minutes: 60
         shell: bash
         env:
-          NB_SESSION_COMPARTMENT_OCID: ocid1.compartment.oc1.<unique_ocid>
           CONDA_PREFIX: /usr/share/miniconda
         run: |
           set -x # print commands that are executed
-          
+
           # Setup project and tests folder for cov reports to not be overwritten by another parallel step
           if [[ ! -z "${{ matrix.cov-reports }}" ]]; then
             mkdir -p cov-${{ matrix.name }}
@@ -112,7 +111,7 @@ jobs:
             ln -s ../ads ads
             ln -s ../.coveragerc .coveragerc
           fi
-          
+
           # Run tests
           python -m pytest -v -p no:warnings --durations=5 \
           -n auto --dist loadfile ${{ matrix.cov-reports }} \
@@ -148,18 +147,18 @@ jobs:
       - name: "Calculate overall coverage"
         run: |
           set -x # print commands that are executed
-          
+
           # Prepare default cov body text 
           COV_BODY_INTRO="📌 Overall coverage:\n\n"
           echo COV_BODY="$COV_BODY_INTRO No success to gather report. 😿" >> $GITHUB_ENV
-          
+
           # Combine coverage files
           pip install coverage
           coverage combine cov-reports-unitary/.coverage cov-reports-model/.coverage
-          
+
           # Make html report
           coverage html
-          
+
           # Calculate overall coverage and update body message
           COV=$(grep -E 'pc_cov' htmlcov/index.html | cut -d'>' -f 2 | cut -d'%' -f 1)
           if [[ ! -z $COV ]]; then 
@@ -171,18 +170,18 @@ jobs:
         if: always()
         run: |
           set -x # print commands that are executed
-          
+
           # Prepare default diff body text 
           DIFF_BODY_INTRO="📌 Cov diff with **${{ env.COMPARE_BRANCH }}**:\n\n"
           echo DIFF_BODY="$BODY_INTRO No success to gather report. 😿" >> $GITHUB_ENV
-          
+
           # Prepare file paths to coverage xml files
           # Filenames taken from job.test last step with name - "Save coverage files"
           FILE1="cov-reports-unitary/coverage.xml"; [[ ! -f $FILE1 ]] && FILE1="" 
           FILE2="cov-reports-model/coverage.xml"; [[ ! -f $FILE2 ]] && FILE2=""
           echo "FILE1=$FILE1" >> $GITHUB_ENV
           echo "FILE2=$FILE2" >> $GITHUB_ENV
-          
+
           # Calculate coverage diff and update body message
           pip install diff_cover
           diff-cover $FILE1 $FILE2 --compare-branch=origin/${{ env.COMPARE_BRANCH }} 

--- a/tests/unitary/default_setup/auth/test_auth.py
+++ b/tests/unitary/default_setup/auth/test_auth.py
@@ -80,8 +80,8 @@ class TestEDAMixin(TestCase):
         mock_rp_signer.assert_called_once()
 
     @mock.patch("oci.auth.signers.get_resource_principals_signer")
+    @mock.patch.dict(os.environ, {"OCI_RESOURCE_PRINCIPAL_VERSION": "2.2"})
     def test_resource_principal(self, mock_rp_signer):
-        os.environ["OCI_RESOURCE_PRINCIPAL_VERSION"] = "2.2"
         resource_principal()
         mock_rp_signer.assert_called_once()
 
@@ -264,11 +264,11 @@ class TestAuthFactory(TestCase):
         assert "test" in signer["client_kwargs"]
 
     @mock.patch("oci.auth.signers.get_resource_principals_signer")
+    @mock.patch.dict(os.environ, {"OCI_RESOURCE_PRINCIPAL_VERSION": "2.2"})
     def test_resource_principal_create_signer(self, mock_rp_signer):
         """
         Testing resource principal setup with set_auth() and getting it with default_signer()
         """
-        os.environ["OCI_RESOURCE_PRINCIPAL_VERSION"] = "2.2"
         set_auth(AuthType.RESOURCE_PRINCIPAL)
         signer = default_signer(client_kwargs={"test": "test"})
         assert "additional_user_agent" in signer["config"]

--- a/tests/unitary/default_setup/catalog/test_catalog_notebook.py
+++ b/tests/unitary/default_setup/catalog/test_catalog_notebook.py
@@ -69,20 +69,6 @@ def generate_notebook_list(
 class NotebookCatalogTest(unittest.TestCase):
     """Contains test cases for catalog.notebook"""
 
-    with patch.object(auth, "default_signer"):
-        with patch.object(oci_client, "OCIClientFactory"):
-            notebook_id = "ocid1.notebookcatalog.oc1.iad.<unique_ocid>"
-            comp_id = os.environ.get(
-                "NB_SESSION_COMPARTMENT_OCID", "ocid1.compartment.oc1.iad.<unique_ocid>"
-            )
-            date_time = datetime(2020, 7, 1, 18, 24, 42, 110000, tzinfo=timezone.utc)
-
-            notebook_catalog = NotebookCatalog(compartment_id=comp_id)
-            notebook_catalog.ds_client = MagicMock()
-            notebook_catalog.identity_client = MagicMock()
-
-            nsl = NotebookSummaryList(generate_notebook_list())
-
     @classmethod
     def setUpClass(cls) -> None:
         os.environ[
@@ -90,6 +76,23 @@ class NotebookCatalogTest(unittest.TestCase):
         ] = "ocid1.compartment.oc1.<unique_ocid>"
         reload(ads.config)
         reload(ads.catalog.notebook)
+        # Initialize class properties after reloading
+        with patch.object(auth, "default_signer"):
+            with patch.object(oci_client, "OCIClientFactory"):
+                cls.notebook_id = "ocid1.notebookcatalog.oc1.iad.<unique_ocid>"
+                cls.comp_id = os.environ.get(
+                    "NB_SESSION_COMPARTMENT_OCID",
+                    "ocid1.compartment.oc1.iad.<unique_ocid>",
+                )
+                cls.date_time = datetime(
+                    2020, 7, 1, 18, 24, 42, 110000, tzinfo=timezone.utc
+                )
+
+                cls.notebook_catalog = NotebookCatalog(compartment_id=cls.comp_id)
+                cls.notebook_catalog.ds_client = MagicMock()
+                cls.notebook_catalog.identity_client = MagicMock()
+
+                cls.nsl = NotebookSummaryList(generate_notebook_list())
         return super().setUpClass()
 
     @classmethod

--- a/tests/unitary/default_setup/catalog/test_catalog_notebook.py
+++ b/tests/unitary/default_setup/catalog/test_catalog_notebook.py
@@ -66,13 +66,15 @@ class NotebookCatalogTest(unittest.TestCase):
 
     with patch.object(auth, "default_signer"):
         with patch.object(oci_client, "OCIClientFactory"):
-            notebook_catalog = NotebookCatalog()
+            notebook_id = "ocid1.notebookcatalog.oc1.iad.<unique_ocid>"
+            comp_id = os.environ.get(
+                "NB_SESSION_COMPARTMENT_OCID", "ocid1.compartment.oc1.iad.<unique_ocid>"
+            )
+            date_time = datetime(2020, 7, 1, 18, 24, 42, 110000, tzinfo=timezone.utc)
+
+            notebook_catalog = NotebookCatalog(compartment_id=comp_id)
             notebook_catalog.ds_client = MagicMock()
             notebook_catalog.identity_client = MagicMock()
-
-            notebook_id = "ocid1.notebookcatalog.oc1.iad.<unique_ocid>"
-            comp_id = os.environ.get("NB_SESSION_COMPARTMENT_OCID")
-            date_time = datetime(2020, 7, 1, 18, 24, 42, 110000, tzinfo=timezone.utc)
 
             nsl = NotebookSummaryList(generate_notebook_list())
 

--- a/tests/unitary/default_setup/catalog/test_catalog_notebook.py
+++ b/tests/unitary/default_setup/catalog/test_catalog_notebook.py
@@ -17,10 +17,11 @@ import pytest
 from oci.exceptions import ServiceError
 
 import ads.config
+import ads.catalog.notebook
 from ads.catalog.notebook import NotebookCatalog, NotebookSummaryList
 from ads.common import auth, oci_client
 from ads.common.utils import random_valid_ocid
-from ads.config import NB_SESSION_COMPARTMENT_OCID, PROJECT_OCID
+from ads.config import PROJECT_OCID
 
 
 def generate_notebook_list(
@@ -82,17 +83,21 @@ class NotebookCatalogTest(unittest.TestCase):
 
             nsl = NotebookSummaryList(generate_notebook_list())
 
-    def setUp(self) -> None:
+    @classmethod
+    def setUpClass(cls) -> None:
         os.environ[
             "NB_SESSION_COMPARTMENT_OCID"
         ] = "ocid1.compartment.oc1.<unique_ocid>"
         reload(ads.config)
-        return super().setUp()
+        reload(ads.catalog.notebook)
+        return super().setUpClass()
 
-    def tearDown(self) -> None:
+    @classmethod
+    def tearDownClass(cls) -> None:
         os.environ.pop("NB_SESSION_COMPARTMENT_OCID", None)
         reload(ads.config)
-        return super().tearDown()
+        reload(ads.catalog.notebook)
+        return super().tearDownClass()
 
     @staticmethod
     def generate_notebook_response_data(compartment_id=None, notebook_id=None):
@@ -124,7 +129,10 @@ class NotebookCatalogTest(unittest.TestCase):
     def test_notebook_init_without_compartment_id(self, mock_client, mock_signer):
         """Test notebook catalog initiation without compartment_id."""
         test_notebook_catalog = NotebookCatalog()
-        assert test_notebook_catalog.compartment_id == NB_SESSION_COMPARTMENT_OCID
+        assert (
+            test_notebook_catalog.compartment_id
+            == ads.config.NB_SESSION_COMPARTMENT_OCID
+        )
 
     def test_decorate_notebook_session_attributes(self):
         """Test NotebookCatalog._decorate_notebook_session method."""

--- a/tests/unitary/default_setup/catalog/test_catalog_notebook.py
+++ b/tests/unitary/default_setup/catalog/test_catalog_notebook.py
@@ -75,7 +75,9 @@ class NotebookCatalogTest(unittest.TestCase):
             "NB_SESSION_COMPARTMENT_OCID"
         ] = "ocid1.compartment.oc1.<unique_ocid>"
         reload(ads.config)
-        reload(ads.catalog.notebook)
+        ads.catalog.notebook.NB_SESSION_COMPARTMENT_OCID = (
+            ads.config.NB_SESSION_COMPARTMENT_OCID
+        )
         # Initialize class properties after reloading
         with patch.object(auth, "default_signer"):
             with patch.object(oci_client, "OCIClientFactory"):
@@ -99,7 +101,9 @@ class NotebookCatalogTest(unittest.TestCase):
     def tearDownClass(cls) -> None:
         os.environ.pop("NB_SESSION_COMPARTMENT_OCID", None)
         reload(ads.config)
-        reload(ads.catalog.notebook)
+        ads.catalog.notebook.NB_SESSION_COMPARTMENT_OCID = (
+            ads.config.NB_SESSION_COMPARTMENT_OCID
+        )
         return super().tearDownClass()
 
     @staticmethod

--- a/tests/unitary/default_setup/catalog/test_catalog_project.py
+++ b/tests/unitary/default_setup/catalog/test_catalog_project.py
@@ -15,10 +15,10 @@ import pytest
 from oci.exceptions import ServiceError
 
 import ads.config
+import ads.catalog.project
 from ads.catalog.project import ProjectCatalog, ProjectSummaryList
 from ads.common import auth, oci_client
 from ads.common.utils import random_valid_ocid
-from ads.config import NB_SESSION_COMPARTMENT_OCID
 
 
 def generate_project_list(
@@ -76,17 +76,21 @@ class ProjectCatalogTest(unittest.TestCase):
 
             psl = ProjectSummaryList(generate_project_list())
 
-    def setUp(self) -> None:
+    @classmethod
+    def setUpClass(cls) -> None:
         os.environ[
             "NB_SESSION_COMPARTMENT_OCID"
         ] = "ocid1.compartment.oc1.<unique_ocid>"
         reload(ads.config)
-        return super().setUp()
+        reload(ads.catalog.project)
+        return super().setUpClass()
 
-    def tearDown(self) -> None:
+    @classmethod
+    def tearDownClass(cls) -> None:
         os.environ.pop("NB_SESSION_COMPARTMENT_OCID", None)
         reload(ads.config)
-        return super().tearDown()
+        reload(ads.catalog.project)
+        return super().tearDownClass()
 
     @staticmethod
     def generate_project_response_data(compartment_id=None, project_id=None):
@@ -116,7 +120,10 @@ class ProjectCatalogTest(unittest.TestCase):
     def test_project_init_without_compartment_id(self, mock_client, mock_signer):
         """Test project catalog initiation without compartment_id."""
         test_project_catalog = ProjectCatalog()
-        assert test_project_catalog.compartment_id == NB_SESSION_COMPARTMENT_OCID
+        assert (
+            test_project_catalog.compartment_id
+            == ads.config.NB_SESSION_COMPARTMENT_OCID
+        )
 
     def test_decorate_project_session_attributes(self):
         """Test ProjectCatalog._decorate_project method."""

--- a/tests/unitary/default_setup/catalog/test_catalog_project.py
+++ b/tests/unitary/default_setup/catalog/test_catalog_project.py
@@ -61,13 +61,13 @@ class ProjectCatalogTest(unittest.TestCase):
 
     with patch.object(auth, "default_signer"):
         with patch.object(oci_client, "OCIClientFactory"):
-            pc = ProjectCatalog()
+            project_id = "ocid1.projectcatalog.oc1.iad.<unique_ocid>"
+            comp_id = os.environ.get("NB_SESSION_COMPARTMENT_OCID", "ocid1.compartment.oc1.iad.<unique_ocid>")
+            date_time = datetime(2020, 7, 1, 18, 24, 42, 110000, tzinfo=timezone.utc)
+
+            pc = ProjectCatalog(compartment_id=comp_id)
             pc.ds_client = MagicMock()
             pc.identity_client = MagicMock()
-
-            project_id = "ocid1.projectcatalog.oc1.iad.<unique_ocid>"
-            comp_id = os.environ.get("NB_SESSION_COMPARTMENT_OCID")
-            date_time = datetime(2020, 7, 1, 18, 24, 42, 110000, tzinfo=timezone.utc)
 
             psl = ProjectSummaryList(generate_project_list())
 

--- a/tests/unitary/default_setup/catalog/test_catalog_project.py
+++ b/tests/unitary/default_setup/catalog/test_catalog_project.py
@@ -62,20 +62,6 @@ def generate_project_list(
 class ProjectCatalogTest(unittest.TestCase):
     """Contains test cases for catalog.project"""
 
-    with patch.object(auth, "default_signer"):
-        with patch.object(oci_client, "OCIClientFactory"):
-            project_id = "ocid1.projectcatalog.oc1.iad.<unique_ocid>"
-            comp_id = os.environ.get(
-                "NB_SESSION_COMPARTMENT_OCID", "ocid1.compartment.oc1.iad.<unique_ocid>"
-            )
-            date_time = datetime(2020, 7, 1, 18, 24, 42, 110000, tzinfo=timezone.utc)
-
-            pc = ProjectCatalog(compartment_id=comp_id)
-            pc.ds_client = MagicMock()
-            pc.identity_client = MagicMock()
-
-            psl = ProjectSummaryList(generate_project_list())
-
     @classmethod
     def setUpClass(cls) -> None:
         os.environ[
@@ -83,6 +69,23 @@ class ProjectCatalogTest(unittest.TestCase):
         ] = "ocid1.compartment.oc1.<unique_ocid>"
         reload(ads.config)
         reload(ads.catalog.project)
+        # Initialize class properties after reloading
+        with patch.object(auth, "default_signer"):
+            with patch.object(oci_client, "OCIClientFactory"):
+                cls.project_id = "ocid1.projectcatalog.oc1.iad.<unique_ocid>"
+                cls.comp_id = os.environ.get(
+                    "NB_SESSION_COMPARTMENT_OCID",
+                    "ocid1.compartment.oc1.iad.<unique_ocid>",
+                )
+                cls.date_time = datetime(
+                    2020, 7, 1, 18, 24, 42, 110000, tzinfo=timezone.utc
+                )
+
+                cls.pc = ProjectCatalog(compartment_id=cls.comp_id)
+                cls.pc.ds_client = MagicMock()
+                cls.pc.identity_client = MagicMock()
+
+                cls.psl = ProjectSummaryList(generate_project_list())
         return super().setUpClass()
 
     @classmethod

--- a/tests/unitary/default_setup/catalog/test_catalog_project.py
+++ b/tests/unitary/default_setup/catalog/test_catalog_project.py
@@ -68,7 +68,7 @@ class ProjectCatalogTest(unittest.TestCase):
             "NB_SESSION_COMPARTMENT_OCID"
         ] = "ocid1.compartment.oc1.<unique_ocid>"
         reload(ads.config)
-        reload(ads.catalog.project)
+        ads.catalog.project.NB_SESSION_COMPARTMENT_OCID = ads.config.NB_SESSION_COMPARTMENT_OCID
         # Initialize class properties after reloading
         with patch.object(auth, "default_signer"):
             with patch.object(oci_client, "OCIClientFactory"):
@@ -92,7 +92,7 @@ class ProjectCatalogTest(unittest.TestCase):
     def tearDownClass(cls) -> None:
         os.environ.pop("NB_SESSION_COMPARTMENT_OCID", None)
         reload(ads.config)
-        reload(ads.catalog.project)
+        ads.catalog.project.NB_SESSION_COMPARTMENT_OCID = ads.config.NB_SESSION_COMPARTMENT_OCID
         return super().tearDownClass()
 
     @staticmethod

--- a/tests/unitary/with_extras/vault/test_vault_vault.py
+++ b/tests/unitary/with_extras/vault/test_vault_vault.py
@@ -14,18 +14,12 @@ from oci.secrets.models import SecretBundle, Base64SecretBundleContentDetails
 from oci.vault.models import Secret
 
 import ads.config
+import ads.vault.vault
 from ads.vault.vault import Vault
 
 
 class TestVault:
     """Contains test cases for ads.vault.vault.py"""
-
-    vault = Vault(
-        vault_id="ocid1.vault.oc1.iad.<unique_id>",
-        key_id="ocid1.key.oc1.iad.<unique_id>",
-    )
-    vault.secret_client = MagicMock()
-    vault.vaults_client_composite = MagicMock()
 
     credential = {
         "database_name": "db201910031555_high",
@@ -42,15 +36,25 @@ class TestVault:
     secret_ocid = "ocid1.vaultsecret.oc1.iad.<unique_id>"
     date_time = datetime(2021, 7, 13, 18, 24, 42, 110000, tzinfo=timezone.utc)
 
-    def setup_method(self):
+    @classmethod
+    def setup_class(cls):
         os.environ[
             "NB_SESSION_COMPARTMENT_OCID"
         ] = "ocid1.compartment.oc1.<unique_ocid>"
         reload(ads.config)
+        reload(ads.vault.vault)
+        cls.vault = Vault(
+            vault_id="ocid1.vault.oc1.iad.<unique_id>",
+            key_id="ocid1.key.oc1.iad.<unique_id>",
+        )
+        cls.vault.secret_client = MagicMock()
+        cls.vault.vaults_client_composite = MagicMock()
 
-    def teardown_method(self):
+    @classmethod
+    def teardown_class(cls):
         os.environ.pop("NB_SESSION_COMPARTMENT_OCID", None)
         reload(ads.config)
+        reload(ads.vault.vault)
 
     def test_create_secret(self):
         """Test vault.create_secret()."""

--- a/tests/unitary/with_extras/vault/test_vault_vault.py
+++ b/tests/unitary/with_extras/vault/test_vault_vault.py
@@ -2,15 +2,19 @@
 
 # Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
-
-from ads.vault.vault import Vault
-from collections import namedtuple
-from datetime import datetime, timezone
-from oci.secrets.models import SecretBundle, Base64SecretBundleContentDetails
-from oci.vault.models import Secret
-from unittest.mock import MagicMock
 import base64
 import json
+import os
+from collections import namedtuple
+from datetime import datetime, timezone
+from importlib import reload
+from unittest.mock import MagicMock
+
+from oci.secrets.models import SecretBundle, Base64SecretBundleContentDetails
+from oci.vault.models import Secret
+
+import ads.config
+from ads.vault.vault import Vault
 
 
 class TestVault:
@@ -37,6 +41,16 @@ class TestVault:
 
     secret_ocid = "ocid1.vaultsecret.oc1.iad.<unique_id>"
     date_time = datetime(2021, 7, 13, 18, 24, 42, 110000, tzinfo=timezone.utc)
+
+    def setup_method(self):
+        os.environ[
+            "NB_SESSION_COMPARTMENT_OCID"
+        ] = "ocid1.compartment.oc1.<unique_ocid>"
+        reload(ads.config)
+
+    def teardown_method(self):
+        os.environ.pop("NB_SESSION_COMPARTMENT_OCID", None)
+        reload(ads.config)
 
     def test_create_secret(self):
         """Test vault.create_secret()."""


### PR DESCRIPTION
A couple tests requires environment variables to be set before running them, otherwise there will be an error collecting the tests. I think it is better for the tests to have less dependency on the environment. This PR adds a default value value if the environment variable is not set.