### PR TITLE
Update ads CLI to explicitly use python3

### DIFF
--- a/ads/ads
+++ b/ads/ads
@@ -1,2 +1,2 @@
 export OCI_PYTHON_SDK_NO_SERVICE_IMPORTS=1
-python -m ads.cli "$@"
+python3 -m ads.cli "$@"


### PR DESCRIPTION
ADS supports `python3` only. When user is using `python2` as default in their system, it might cause trouble for them to run ADS CLI if we don't explicitly call `python3`.