### PR TITLE
Hotfix for readthedocs builder

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs configuration file
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
## Description

When readthedocs tried to build documentation it failed for the reason of having very-very old OpenSSL on board (6 years old). Investigation showed that by default readthedocs will use old ubuntu for builders (which are alos 6 years old). We need to specify newer version of ubuntu and also we need fresher version of python *by default readthedocs installing pythoin3.7).

This ^ can be fixed by special configuration yaml file - documentation: https://docs.readthedocs.io/en/stable/config-file/v2.html#. In this yaml we spoeficy new ubuntu and python 3.9

## What was done

- added .readthedocs.yaml with ubuntu-22.04 and python 3.9