### PR TITLE
ODSC-39272. Fix for links of See API documentation

### DIFF
--- a/docs/source/user_guide/cli/authentication.rst
+++ b/docs/source/user_guide/cli/authentication.rst
@@ -139,3 +139,5 @@ More signers can be created using the ``create_signer()`` method. With the ``aut
   signer_callable = oci.auth.signers.InstancePrincipalsSecurityTokenSigner
   signer_kwargs = dict(log_requests=True) # will log the request url and response data when retrieving
   auth = ads.auth.create_signer(signer_callable=signer_callable, signer_kwargs=signer_kwargs)
+
+``AuthContext`` context class can also be used to specify the desired type of authentication. It supports API key configuration, resource principal, and instance principal authentication, as well as predefined signers, callable signers, or API keys configurations from specified locations. See `API Documentation <../../ads.common.html#ads.common.auth.AuthContext>`__ for more details.

--- a/docs/source/user_guide/model_registration/frameworks/huggingfacemodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/huggingfacemodel.rst
@@ -5,7 +5,7 @@ HuggingFacePipelineModel
 
 .. versionadded:: 2.8.2
 
-See `API Documentation <../../../ads.model_framework.html#ads.model.framework.huggingface_model.HuggingFacePipelineModel>`__
+See `API Documentation <../../../ads.model.framework.html#ads.model.framework.huggingface_model.HuggingFacePipelineModel>`__
 
 Overview
 ========
@@ -75,7 +75,7 @@ Prepare Model Artifact
 
 Instantiate a ``HuggingFacePipelineModel()`` object with HuggingFace pipelines. All the pipelines related files are saved under the ``artifact_dir``.
 
-For more detailed information on what parameters that ``HuggingFacePipelineModel`` takes, refer to the `API Documentation <../../../ads.model_framework.html#ads.model.framework.huggingface_model.HuggingFacePipelineModel>`__
+For more detailed information on what parameters that ``HuggingFacePipelineModel`` takes, refer to the `API Documentation <../../../ads.model.framework.html#ads.model.framework.huggingface_model.HuggingFacePipelineModel>`__
 
 
 

--- a/docs/source/user_guide/model_registration/frameworks/lightgbmmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/lightgbmmodel.rst
@@ -3,7 +3,7 @@
 LightGBMModel
 *************
 
-See `API Documentation <../../../ads.model_framework.html#ads.model.framework.lightgbm_model.LightGBMModel>`__
+See `API Documentation <../../../ads.model.framework.html#ads.model.framework.lightgbm_model.LightGBMModel>`__
 
 
 Overview

--- a/docs/source/user_guide/model_registration/frameworks/pytorchmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/pytorchmodel.rst
@@ -3,7 +3,7 @@
 PyTorchModel
 ************
 
-See `API Documentation <../../../ads.model_framework.html#ads.model.framework.pytorch_model.PyTorchModel>`__
+See `API Documentation <../../../ads.model.framework.html#ads.model.framework.pytorch_model.PyTorchModel>`__
 
 Overview
 ========

--- a/docs/source/user_guide/model_registration/frameworks/sklearnmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/sklearnmodel.rst
@@ -3,7 +3,7 @@
 SklearnModel
 ************
 
-See `API Documentation <../../../ads.model_framework.html#ads.model.framework.sklearn_model.SklearnModel>`__
+See `API Documentation <../../../ads.model.framework.html#ads.model.framework.sklearn_model.SklearnModel>`__
 
 
 Overview

--- a/docs/source/user_guide/model_registration/frameworks/sparkpipelinemodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/sparkpipelinemodel.rst
@@ -3,7 +3,7 @@
 SparkPipelineModel
 *******************
 
-See `API Documentation <../../../ads.model_framework.html#ads.model.framework.spark_model.SparkPipelineModel>`__
+See `API Documentation <../../../ads.model.framework.html#ads.model.framework.spark_model.SparkPipelineModel>`__
 
 Overview
 ========

--- a/docs/source/user_guide/model_registration/frameworks/tensorflowmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/tensorflowmodel.rst
@@ -3,7 +3,7 @@
 TensorFlowModel
 ***************
 
-See `API Documentation <../../../ads.model_framework.html#ads.model.framework.tensorflow_model.TensorFlowModel>`__
+See `API Documentation <../../../ads.model.framework.html#ads.model.framework.tensorflow_model.TensorFlowModel>`__
 
 Overview
 ========

--- a/docs/source/user_guide/model_registration/frameworks/xgboostmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/xgboostmodel.rst
@@ -3,7 +3,7 @@
 XGBoostModel
 ************
 
-See `API Documentation <../../../ads.model_framework.html#ads.model.framework.xgboost_model.XGBoostModel>`__
+See `API Documentation <../../../ads.model.framework.html#ads.model.framework.xgboost_model.XGBoostModel>`__
 
 Overview
 ========


### PR DESCRIPTION
### Description

Several links to API documentation in model frameworks were broken. Apart of what was reported in bug ticket searched for other similar broken links to fix them all.

Jira: https://jira.oci.oraclecorp.com/browse/ODSC-39272

### What was done

- change model_framework to model.framework in links to API documentation for frameworks
- added recent change to cli/authentication.rst, which was wrongly added into incorrect configuration/authentication.rst (approved and merged in this PR: https://github.com/oracle/accelerated-data-science/pull/158/files)

### Validation

In Github rendered rst files can't validation those links. For validation builded docs locally and checked - links working - not 404 error when click API Documentation on (for example) huggingfacemodel page:
![image](https://user-images.githubusercontent.com/49763871/236900660-828dd856-d74a-4b36-b1ae-dfaf0327bd84.png)

