### PR TITLE
Fix API, that gives an error if target is not specified

### DIFF
--- a/ads/dataset/dataset.py
+++ b/ads/dataset/dataset.py
@@ -1913,3 +1913,35 @@ class ADSDataset(PandasDataset):
 
         if visualize_features and not is_wide_dataset:
             self._visualize_feature_distribution(features)
+
+    def get_recommendations(self, *args, **kwargs):  # real signature may change
+        """
+        Returns user-friendly error message to set target variable before invoking this API.
+
+        Parameters
+        ----------
+        kwargs
+
+        Returns
+        -------
+        Exception
+            raises an :exc:`Exception`
+
+        """
+        raise Exception("Please set the 'target' variable before invoking this API.")
+
+    def suggest_recommendations(self, *args, **kwargs):  # real signature may change
+        """
+        Returns user-friendly error message to set target variable before invoking this API.
+
+        Parameters
+        ----------
+        kwargs
+
+        Returns
+        -------
+        Exception
+            raises an :exc:`Exception`
+
+        """
+        raise Exception("Please set the 'target' variable before invoking this API.")

--- a/ads/dataset/dataset.py
+++ b/ads/dataset/dataset.py
@@ -172,7 +172,7 @@ class ADSDataset(PandasDataset):
             progress=progress,
             transformer_pipeline=transformer_pipeline,
             interactive=interactive,
-            **kwargs
+            **kwargs,
         )
 
     @property
@@ -1924,11 +1924,15 @@ class ADSDataset(PandasDataset):
 
         Returns
         -------
-        Exception
-            raises an :exc:`Exception`
+        NotImplementedError
+            raises NotImplementedError, if target parameter value not provided
 
         """
-        raise Exception("Please set the 'target' variable before invoking this API.")
+        raise NotImplementedError(
+            "Please set the target using set_target() before invoking this API. See "
+            "https://accelerated-data-science.readthedocs.io/en/latest/ads.dataset.html#ads.dataset.dataset.ADSDataset.set_target "
+            "for the API usage."
+        )
 
     def suggest_recommendations(self, *args, **kwargs):  # real signature may change
         """
@@ -1940,8 +1944,12 @@ class ADSDataset(PandasDataset):
 
         Returns
         -------
-        Exception
-            raises an :exc:`Exception`
+        NotImplementedError
+            raises NotImplementedError, if target parameter value not provided
 
         """
-        raise Exception("Please set the 'target' variable before invoking this API.")
+        raise NotImplementedError(
+            "Please set the target using set_target() before invoking this API. See "
+            "https://accelerated-data-science.readthedocs.io/en/latest/ads.dataset.html#ads.dataset.dataset.ADSDataset.set_target "
+            "for the API usage."
+        )

--- a/tests/unitary/with_extras/dataset/test_dataset_dataset.py
+++ b/tests/unitary/with_extras/dataset/test_dataset_dataset.py
@@ -25,6 +25,10 @@ class TestADSDataset:
     def teardown_class(cls):
         cls.test_dir.cleanup()
 
+    def get_data_path(self):
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        return os.path.join(current_dir, "data", "orcl_attrition.csv")
+
     @pytest.mark.parametrize(
         "test_file_name, expected_file_name",
         [
@@ -85,6 +89,18 @@ class TestADSDataset:
         assert "type_discovery" in employees.init_kwargs
         assert isinstance(employees.transformer_pipeline, TransformerPipeline)
 
-    def get_data_path(self):
-        current_dir = os.path.dirname(os.path.abspath(__file__))
-        return os.path.join(current_dir, "data", "orcl_attrition.csv")
+    def test_get_recommendations_error_message(self):
+        """Test for validation user-friendly error message."""
+        employees = ADSDataset.from_dataframe(df=pd.read_csv(self.get_data_path()))
+
+        err_msg = "Please set the 'target' variable before invoking this API."
+        with pytest.raises(Exception, match=err_msg):
+            employees.get_recommendations()
+
+    def test_suggest_recommendations_error_message(self):
+        """Test for validation user-friendly error message."""
+        employees = ADSDataset.from_dataframe(df=pd.read_csv(self.get_data_path()))
+
+        err_msg = "Please set the 'target' variable before invoking this API."
+        with pytest.raises(Exception, match=err_msg):
+            employees.suggest_recommendations()

--- a/tests/unitary/with_extras/dataset/test_dataset_dataset.py
+++ b/tests/unitary/with_extras/dataset/test_dataset_dataset.py
@@ -89,18 +89,12 @@ class TestADSDataset:
         assert "type_discovery" in employees.init_kwargs
         assert isinstance(employees.transformer_pipeline, TransformerPipeline)
 
-    def test_get_recommendations_error_message(self):
+    def test_get_suggest_recommendations_error_message(self):
         """Test for validation user-friendly error message."""
         employees = ADSDataset.from_dataframe(df=pd.read_csv(self.get_data_path()))
 
         err_msg = "Please set the 'target' variable before invoking this API."
         with pytest.raises(Exception, match=err_msg):
             employees.get_recommendations()
-
-    def test_suggest_recommendations_error_message(self):
-        """Test for validation user-friendly error message."""
-        employees = ADSDataset.from_dataframe(df=pd.read_csv(self.get_data_path()))
-
-        err_msg = "Please set the 'target' variable before invoking this API."
         with pytest.raises(Exception, match=err_msg):
             employees.suggest_recommendations()

--- a/tests/unitary/with_extras/dataset/test_dataset_dataset.py
+++ b/tests/unitary/with_extras/dataset/test_dataset_dataset.py
@@ -93,8 +93,8 @@ class TestADSDataset:
         """Test for validation user-friendly error message."""
         employees = ADSDataset.from_dataframe(df=pd.read_csv(self.get_data_path()))
 
-        err_msg = "Please set the 'target' variable before invoking this API."
-        with pytest.raises(Exception, match=err_msg):
+        err_msg = r"Please set the target using set_target\(\) before invoking this API."
+        with pytest.raises(NotImplementedError, match=err_msg):
             employees.get_recommendations()
-        with pytest.raises(Exception, match=err_msg):
+        with pytest.raises(NotImplementedError, match=err_msg):
             employees.suggest_recommendations()


### PR DESCRIPTION
### Description

Added user-friendly error message when methods suggest_recommendations() or get_recommendations() invoked without specifying target parameter.

Jira: https://jira.oci.oraclecorp.com/browse/ODSC-38735

### What was done

- added suggest_recommendations() with message to the user that the user needs to set the target
- added get_recommendations() with message to the user that the user needs to set the target
- added unittest