### PR TITLE
Fix inconsistencies in model deployment documentation

### DIFF
--- a/ads/model/deployment/model_deployment.py
+++ b/ads/model/deployment/model_deployment.py
@@ -165,7 +165,7 @@ class ModelDeployment(Builder):
 
     Examples
     --------
-    Build model deployment from builder apis:
+    >>> # Build model deployment from builder apis:
     >>> ds_model_deployment = (ModelDeployment()
     ...    .with_display_name("TestModelDeployment")
     ...    .with_description("Testing the test model deployment")
@@ -211,7 +211,7 @@ class ModelDeployment(Builder):
     >>> ds_model_deployment.list(status="ACTIVE")
     >>> ds_model_deployment.delete()
 
-    Build model deployment from yaml
+    >>> # Build model deployment from yaml
     >>> ds_model_deployment = ModelDeployment.from_yaml(uri=<path_to_yaml>)
     """
 

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -1990,7 +1990,7 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
 
         Example
         -------
-        # This is an example to deploy model on container runtime
+        >>> # This is an example to deploy model on container runtime
         >>> model = GenericModel(estimator=estimator, artifact_dir=tempfile.mkdtemp())
         >>> model.summary_status()
         >>> model.prepare(
@@ -2851,10 +2851,11 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         ----------
         uri: str
             The destination location for the model artifacts, which can be a local path or
-            OCI object storage URI.
-            Examples:
+            OCI object storage URI. Examples:
+
             >>> upload_artifact(uri="/some/local/folder/")
             >>> upload_artifact(uri="oci://bucket@namespace/prefix/")
+
         auth: (Dict, optional). Defaults to `None`.
             The default authetication is set using `ads.set_auth` API. If you need to override the
             default, use the `ads.common.auth.api_keys` or `ads.common.auth.resource_principal` to create appropriate

--- a/docs/source/user_guide/model_registration/_template/deploy.rst
+++ b/docs/source/user_guide/model_registration/_template/deploy.rst
@@ -1,5 +1,10 @@
 You can use the ``.deploy()`` method to deploy a model. You must first save the model to the model catalog, and then deploy it.
 
+.. admonition:: Deployment with Flex shape
+    :class: note
+
+    It is mandatory to provide ``ocpus`` and ``memory_in_gb`` values, when deploy with Flex instance shapes. They are set in ``deployment_ocpus`` and ``deployment_memory_in_gbs`` of the ``deploy()`` method.
+
 The ``.deploy()`` method returns a ``ModelDeployment`` object.  Specify deployment attributes such as display name, instance type, number of instances,  maximum router bandwidth, and logging groups.  The API takes the following parameters:
 
 See `API documentation <../../ads.model.html#id1>`__ for more details about the parameters.

--- a/docs/source/user_guide/model_registration/frameworks/genericmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/genericmodel.rst
@@ -77,6 +77,10 @@ By default, the ``GenericModel`` serializes to a pickle file. The following exam
         deployment_log_group_id="ocid1.loggroup.oc1.xxx.xxxxx",
         deployment_access_log_id="ocid1.log.oc1.xxx.xxxxx",
         deployment_predict_log_id="ocid1.log.oc1.xxx.xxxxx",
+        # It is mandatory to set 'deployment_ocpus' and 'deployment_memory_in_gbs' if Flex shape used
+        # deployment_instance_shape="VM.Standard.E4.Flex",
+        # deployment_ocpus=<number>,
+        # deployment_memory_in_gbs=<number>,
     )
 
     print(f"Endpoint: {generic_model.model_deployment.url}")

--- a/docs/source/user_guide/model_registration/frameworks/huggingfacemodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/huggingfacemodel.rst
@@ -114,6 +114,21 @@ Deploy and Generate Endpoint
     ... )
     >>> print(f"Endpoint: {huggingface_pipeline_model.model_deployment.url}")
 
+Deploy with Flex Shape
+======================
+
+It is mandatory to provide ``deployment_ocpus`` and ``deployment_memory_in_gbs`` values, when deploy with Flex instance shapes.
+
+.. code-block:: python3
+
+    # Deploy with Flex shape
+    huggingface_pipeline_model.deploy(
+        display_name="HuggingFace Pipeline Model For Classification",
+        deployment_instance_shape="VM.Standard.E4.Flex",
+        deployment_ocpus=<number>,
+        deployment_memory_in_gbs=<number>,
+    )
+
 Run Prediction against Endpoint
 ===============================
 

--- a/docs/source/user_guide/model_registration/frameworks/lightgbmmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/lightgbmmodel.rst
@@ -109,6 +109,21 @@ Deploy and Generate Endpoint
     https://modeldeployment.{region}.oci.customer-oci.com/ocid1.datasciencemodeldeployment.oc1.xxx.xxxxx
 
 
+Deploy with Flex Shape
+======================
+
+It is mandatory to provide ``deployment_ocpus`` and ``deployment_memory_in_gbs`` values, when deploy with Flex instance shapes.
+
+.. code-block:: python3
+
+    # Deploy with Flex shape
+    lightgbm_model.deploy(
+        display_name="LightGBM Model For Classification",
+        deployment_instance_shape="VM.Standard.E4.Flex",
+        deployment_ocpus=<number>,
+        deployment_memory_in_gbs=<number>,
+    )
+
 Run Prediction against Endpoint
 ===============================
 

--- a/docs/source/user_guide/model_registration/frameworks/pytorchmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/pytorchmodel.rst
@@ -228,6 +228,21 @@ Deploy and Generate Endpoint
 
     https://modeldeployment.{region}.oci.customer-oci.com/ocid1.datasciencemodeldeployment.oc1.xxx.xxxxx
 
+Deploy with Flex Shape
+======================
+
+It is mandatory to provide ``deployment_ocpus`` and ``deployment_memory_in_gbs`` values, when deploy with Flex instance shapes.
+
+.. code-block:: python3
+
+    # Deploy with Flex shape
+    pytorch_model.deploy(
+        display_name="PyTorch Model For Classification",
+        deployment_instance_shape="VM.Standard.E4.Flex",
+        deployment_ocpus=<number>,
+        deployment_memory_in_gbs=<number>,
+    )
+
 Run Prediction against Endpoint
 ===============================
 

--- a/docs/source/user_guide/model_registration/frameworks/sklearnmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/sklearnmodel.rst
@@ -100,6 +100,20 @@ Deploy and Generate Endpoint
     >>> print(f"Endpoint: {sklearn_model.model_deployment.url}")
     https://modeldeployment.{region}.oci.customer-oci.com/ocid1.datasciencemodeldeployment.oc1.xxx.xxxxx
 
+Deploy with Flex Shape
+======================
+
+It is mandatory to provide ``deployment_ocpus`` and ``deployment_memory_in_gbs`` values, when deploy with Flex instance shapes.
+
+.. code-block:: python3
+
+    # Deploy with Flex shape
+    sklearn_model.deploy(
+        display_name="Random Forest Model For Classification",
+        deployment_instance_shape="VM.Standard.E4.Flex",
+        deployment_ocpus=<number>,
+        deployment_memory_in_gbs=<number>,
+    )
 
 Run Prediction against Endpoint
 ===============================

--- a/docs/source/user_guide/model_registration/frameworks/sparkpipelinemodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/sparkpipelinemodel.rst
@@ -128,6 +128,20 @@ Deploy and Generate Endpoint
 
     # https://modeldeployment.{region}.oci.customer-oci.com/ocid1.datasciencemodeldeployment.oc1.xxx.xxxxx
 
+Deploy with Flex Shape
+======================
+
+It is mandatory to provide ``deployment_ocpus`` and ``deployment_memory_in_gbs`` values, when deploy with Flex instance shapes.
+
+.. code-block:: python3
+
+    # Deploy with Flex shape
+    spark_model.deploy(
+        display_name="Spark Pipeline Model For Classification",
+        deployment_instance_shape="VM.Standard.E4.Flex",
+        deployment_ocpus=<number>,
+        deployment_memory_in_gbs=<number>,
+    )
 
 Run Prediction against Endpoint
 ===============================

--- a/docs/source/user_guide/model_registration/frameworks/tensorflowmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/tensorflowmodel.rst
@@ -107,6 +107,20 @@ Deploy and Generate Endpoint
 
     https://modeldeployment.{region}.oci.customer-oci.com/ocid1.datasciencemodeldeployment.oc1.xxx.xxxxx
 
+Deploy with Flex Shape
+======================
+
+It is mandatory to provide ``deployment_ocpus`` and ``deployment_memory_in_gbs`` values, when deploy with Flex instance shapes.
+
+.. code-block:: python3
+
+    # Deploy with Flex shape
+    tensorflow_model.deploy(
+        display_name="TensorFlow Model For Classification",
+        deployment_instance_shape="VM.Standard.E4.Flex",
+        deployment_ocpus=<number>,
+        deployment_memory_in_gbs=<number>,
+    )
 
 Run Prediction against Endpoint
 ===============================

--- a/docs/source/user_guide/model_registration/frameworks/xgboostmodel.rst
+++ b/docs/source/user_guide/model_registration/frameworks/xgboostmodel.rst
@@ -110,6 +110,20 @@ Deploy and Generate Endpoint
 
     https://modeldeployment.{region}.oci.customer-oci.com/ocid1.datasciencemodeldeployment.oc1.xxx.xxxxx
 
+Deploy with Flex Shape
+======================
+
+It is mandatory to provide ``deployment_ocpus`` and ``deployment_memory_in_gbs`` values, when deploy with Flex instance shapes.
+
+.. code-block:: python3
+
+    # Deploy with Flex shape
+    xgb_model.deploy(
+        display_name="XGBoost Model For Classification",
+        deployment_instance_shape="VM.Standard.E4.Flex",
+        deployment_ocpus=<number>,
+        deployment_memory_in_gbs=<number>,
+    )
 
 Run Prediction against Endpoint
 ===============================

--- a/docs/source/user_guide/model_registration/model_deploy.rst
+++ b/docs/source/user_guide/model_registration/model_deploy.rst
@@ -49,6 +49,10 @@ Here is an example of deploying LightGBM model:
             deployment_log_group_id="ocid1.loggroup.oc1.xxx.xxxxx",
             deployment_access_log_id="ocid1.log.oc1.xxx.xxxxx",
             deployment_predict_log_id="ocid1.log.oc1.xxx.xxxxx",
+            # It is mandatory to set 'deployment_ocpus' and 'deployment_memory_in_gbs' if Flex shape used
+            # deployment_instance_shape="VM.Standard.E4.Flex",
+            # deployment_ocpus=<number>,
+            # deployment_memory_in_gbs=<number>,
         )
 
     # Get endpoint of deployed model


### PR DESCRIPTION
### Description

When user provides flex shape, it is mandatory to provide ocpus and memory_in_gb. The documentation does not provide an example of how to use flex shape. This PR adds such examples into documentation.

Jira: https://jira.oci.oraclecorp.com/browse/ODSC-38615

### What was done

- added note to deploy.rst
- added parameters with comments to code blocks about Flex shape
- updated all pages for frameworks with section about deployment with Flex shape
- fix code example blocks in docstrings (in .py files)