### PR TITLE
Added support for private key content for set_auth()

### DIFF
--- a/ads/common/auth.py
+++ b/ads/common/auth.py
@@ -117,7 +117,7 @@ def set_auth(
     >>> ads.set_auth("api_key", oci_config_location = "other_config_location") # use non-default oci_config_location
 
     >>> ads.set_auth("api_key", client_kwargs={"timeout": 60}) # default signer with connection and read timeouts set to 60 seconds for the client.
-    >>> ads.set_auth("api_key", )
+    >>> ads.set_auth("api_key", signer_kwargs={"key_content": "private_key_content"}) # Create config using key content
     >>> other_config = oci.config.from_file("other_config_location", "OTHER_PROFILE") # Create non-default config
     >>> ads.set_auth(config=other_config) # Set api keys type of authentication based on provided config
 

--- a/ads/common/auth.py
+++ b/ads/common/auth.py
@@ -66,6 +66,7 @@ class AuthState(metaclass=SingletonMeta):
         )
         self.oci_config = self.oci_config or {}
         self.oci_signer = self.oci_signer
+        self.oci_signer_callable = self.oci_signer_callable
         self.oci_signer_kwargs = self.oci_signer_kwargs or {}
         self.oci_client_kwargs = self.oci_client_kwargs or {}
 

--- a/ads/common/auth.py
+++ b/ads/common/auth.py
@@ -65,8 +65,6 @@ class AuthState(metaclass=SingletonMeta):
             "OCI_CONFIG_PROFILE", DEFAULT_PROFILE
         )
         self.oci_config = self.oci_config or {}
-        self.oci_signer = self.oci_signer
-        self.oci_signer_callable = self.oci_signer_callable
         self.oci_signer_kwargs = self.oci_signer_kwargs or {}
         self.oci_client_kwargs = self.oci_client_kwargs or {}
 

--- a/ads/common/auth.py
+++ b/ads/common/auth.py
@@ -517,17 +517,12 @@ class APIKey(AuthSignerGenerator):
         """
         if self.oci_config:
             configuration = ads.telemetry.update_oci_client_config(self.oci_config)
+        elif self.signer_kwargs:
+            configuration = ads.telemetry.update_oci_client_config(self.signer_kwargs)
         else:
-            try:
-                configuration = ads.telemetry.update_oci_client_config(
-                    oci.config.from_file(self.oci_config_location, self.oci_key_profile)
-                )
-            except:
-                if not os.path.exists(os.path.expanduser(self.oci_config_location)):
-                    logger.info(f"Failed to get config from folder {self.oci_config_location}. Using 'signer_kwargs' instead.")
-                    configuration = ads.telemetry.update_oci_client_config(self.signer_kwargs)
-                else:
-                    raise
+            configuration = ads.telemetry.update_oci_client_config(
+                oci.config.from_file(self.oci_config_location, self.oci_key_profile)
+            )
             
         logger.info(f"Using 'api_key' authentication.")
         return {

--- a/docs/source/user_guide/cli/authentication.rst
+++ b/docs/source/user_guide/cli/authentication.rst
@@ -82,6 +82,21 @@ The ``~/.oci/config`` configuration allow for multiple configurations to be stor
   ads.set_auth("api_key") # default signer is set to API Keys
   ads.set_auth("api_key", profile = "TEST") # default signer is set to API Keys and to use TEST profile
   ads.set_auth("api_key", oci_config_location = "~/.test_oci/config") # default signer is set to API Keys and to use non-default oci_config_location
+  private_key_content = """
+  -----BEGIN RSA PRIVATE KEY-----
+  MIIBIjANBgkqhkiG9w0BAQE...
+  ...
+  -----END RSA PRIVATE KEY-----
+  """
+  config = dict(
+    user="ocid1.user.oc1..xxx",
+    fingerprint="35:67:25:90:89:87:45:78:bf:4h:g5:13:16:32:4d:f4",
+    tenancy="ocid1.tenancy.oc1..xxx",
+    region="us-ashburn-1",
+    key_content=private_key_content,
+  )
+  ads.set_auth(config = config) # default signer is set to API Keys with private key content
+  
   ads.set_auth("resource_principal")  # default signer is set to resource principal authentication
   ads.set_auth("instance_principal")  # default signer is set to instance principal authentication
 
@@ -139,21 +154,5 @@ More signers can be created using the ``create_signer()`` method. With the ``aut
   signer_callable = oci.auth.signers.InstancePrincipalsSecurityTokenSigner
   signer_kwargs = dict(log_requests=True) # will log the request url and response data when retrieving
   auth = ads.auth.create_signer(signer_callable=signer_callable, signer_kwargs=signer_kwargs)
-  
-  # Example 4. Create signer that carries oci config in signer_kwargs. You can either pass key_file or key_content to signer_kwargs.
-  private_key_content = """
-  -----BEGIN RSA PRIVATE KEY-----
-  MIIBIjANBgkqhkiG9w0BAQE...
-  ...
-  -----END RSA PRIVATE KEY-----
-  """
-  signer_kwargs = dict(
-    user="ocid1.user.oc1..xxx",
-    fingerprint="35:67:25:90:89:87:45:78:bf:4h:g5:13:16:32:4d:f4",
-    tenancy="ocid1.tenancy.oc1..xxx",
-    region="us-ashburn-1",
-    key_content=private_key_content,
-  )
-  auth = ads.auth.create_signer(signer_kwargs=signer_kwargs)
 
 ``AuthContext`` context class can also be used to specify the desired type of authentication. It supports API key configuration, resource principal, and instance principal authentication, as well as predefined signers, callable signers, or API keys configurations from specified locations. See `API Documentation <../../ads.common.html#ads.common.auth.AuthContext>`__ for more details.

--- a/docs/source/user_guide/cli/authentication.rst
+++ b/docs/source/user_guide/cli/authentication.rst
@@ -121,7 +121,7 @@ In the this example, the default authentication uses API keys specified with the
   os_auth = authutil.resource_principal() # use resource principal to as the preferred way to access object store
 
 
-More signers can be created using the ``create_signer()`` method. With the ``auth_type`` parameter set to ``instance_principal``, the method will return a signer that uses instance principals. For other signers there are ``signer`` or ``signer_callable`` parameters. Here are examples:
+More signers can be created using the ``create_signer()`` method. With the ``auth_type`` parameter set to ``instance_principal``, the method will return a signer that uses instance principals. For other signers there are ``signer``, ``signer_callable`` or ``signer_kwargs`` parameters. Here are examples:
 
 .. code-block:: python
 
@@ -139,5 +139,21 @@ More signers can be created using the ``create_signer()`` method. With the ``aut
   signer_callable = oci.auth.signers.InstancePrincipalsSecurityTokenSigner
   signer_kwargs = dict(log_requests=True) # will log the request url and response data when retrieving
   auth = ads.auth.create_signer(signer_callable=signer_callable, signer_kwargs=signer_kwargs)
+  
+  # Example 4. Create signer that carries oci config in signer_kwargs. You can either pass key_file or key_content to signer_kwargs.
+  private_key_content = """
+  -----BEGIN RSA PRIVATE KEY-----
+  MIIBIjANBgkqhkiG9w0BAQE...
+  ...
+  -----END RSA PRIVATE KEY-----
+  """
+  signer_kwargs = dict(
+    "user": "ocid1.user.oc1..xxx",
+    "fingerprint": "35:67:25:90:89:87:45:78:bf:4h:g5:13:16:32:4d:f4",
+    "tenancy": "ocid1.tenancy.oc1..xxx",
+    "region": "us-ashburn-1",
+    "key_content": private_key_content,
+  )
+  auth = ads.auth.create_signer(signer_kwargs=signer_kwargs)
 
 ``AuthContext`` context class can also be used to specify the desired type of authentication. It supports API key configuration, resource principal, and instance principal authentication, as well as predefined signers, callable signers, or API keys configurations from specified locations. See `API Documentation <../../ads.common.html#ads.common.auth.AuthContext>`__ for more details.

--- a/docs/source/user_guide/cli/authentication.rst
+++ b/docs/source/user_guide/cli/authentication.rst
@@ -148,11 +148,11 @@ More signers can be created using the ``create_signer()`` method. With the ``aut
   -----END RSA PRIVATE KEY-----
   """
   signer_kwargs = dict(
-    "user": "ocid1.user.oc1..xxx",
-    "fingerprint": "35:67:25:90:89:87:45:78:bf:4h:g5:13:16:32:4d:f4",
-    "tenancy": "ocid1.tenancy.oc1..xxx",
-    "region": "us-ashburn-1",
-    "key_content": private_key_content,
+    user="ocid1.user.oc1..xxx",
+    fingerprint="35:67:25:90:89:87:45:78:bf:4h:g5:13:16:32:4d:f4",
+    tenancy="ocid1.tenancy.oc1..xxx",
+    region="us-ashburn-1",
+    key_content=private_key_content,
   )
   auth = ads.auth.create_signer(signer_kwargs=signer_kwargs)
 

--- a/tests/unitary/default_setup/auth/test_auth.py
+++ b/tests/unitary/default_setup/auth/test_auth.py
@@ -114,6 +114,7 @@ class TestEDAMixin(TestCase):
         assert signer["config"]["key_content"] == "test_key_content"
         assert "additional_user_agent" in signer["config"]
         assert signer["signer"] != None
+        set_auth()
 
 class TestOCIMixin(TestCase):
     def tearDown(self) -> None:

--- a/tests/unitary/default_setup/auth/test_auth.py
+++ b/tests/unitary/default_setup/auth/test_auth.py
@@ -41,58 +41,58 @@ MOCK_CONFIG_FROM_FILE = {
 
 
 class TestEDAMixin(TestCase):
+    @mock.patch("oci.config.validate_config")
     @mock.patch("oci.config.from_file")
     @mock.patch("os.path.exists")
     @mock.patch("oci.signer.load_private_key_from_file")
     def test_set_auth_overwrite_profile(
-        self, mock_load_key_file, mock_path_exists, mock_config_from_file
+        self, mock_load_key_file, mock_path_exists, mock_config_from_file, mock_validate_config
     ):
-        with pytest.raises(oci.exceptions.InvalidConfig):
-            mock_config_from_file.return_value = MOCK_CONFIG_FROM_FILE
-            set_auth(profile="TEST")
-            default_signer()
-            mock_config_from_file.assert_called_with("~/.oci/config", "TEST")
-            set_auth(profile="DEFAULT")
+        mock_config_from_file.return_value = MOCK_CONFIG_FROM_FILE
+        set_auth(profile="TEST")
+        default_signer()
+        mock_config_from_file.assert_called_with("~/.oci/config", "TEST")
+        set_auth(profile="DEFAULT")
 
+    @mock.patch("oci.config.validate_config")
     @mock.patch("oci.config.from_file")
     @mock.patch("os.path.exists")
     @mock.patch("oci.signer.load_private_key_from_file")
     def test_set_auth_overwrite_config_location(
-        self, mock_load_key_file, mock_path_exists, mock_config_from_file
+        self, mock_load_key_file, mock_path_exists, mock_config_from_file, mock_validate_config
     ):
-        with pytest.raises(oci.exceptions.InvalidConfig):
-            mock_config_from_file.return_value = MOCK_CONFIG_FROM_FILE
-            mock_path_exists.return_value = True
-            set_auth(oci_config_location="test_path")
-            default_signer()
-            mock_config_from_file.assert_called_with("test_path", "DEFAULT")
-            set_auth()
+        mock_config_from_file.return_value = MOCK_CONFIG_FROM_FILE
+        mock_path_exists.return_value = True
+        set_auth(oci_config_location="test_path")
+        default_signer()
+        mock_config_from_file.assert_called_with("test_path", "DEFAULT")
+        set_auth()
 
+    @mock.patch("oci.config.validate_config")
     @mock.patch("oci.config.from_file")
     @mock.patch("oci.signer.Signer")
-    def test_api_keys_using_test_profile(self, mock_signer, mock_config_from_file):
-        with pytest.raises(oci.exceptions.InvalidConfig):
-            api_keys("test_path", "TEST_PROFILE")
-            mock_config_from_file.assert_called_with("test_path", "TEST_PROFILE")
+    def test_api_keys_using_test_profile(self, mock_signer, mock_config_from_file, mock_validate_config):
+        api_keys("test_path", "TEST_PROFILE")
+        mock_config_from_file.assert_called_with("test_path", "TEST_PROFILE")
 
+    @mock.patch("oci.config.validate_config")
     @mock.patch("oci.config.from_file")
     @mock.patch("oci.signer.Signer")
-    def test_api_keys_using_default_profile(self, mock_signer, mock_config_from_file):
-        with pytest.raises(oci.exceptions.InvalidConfig):
-            api_keys("test_path")
-            mock_config_from_file.assert_called_with("test_path", "DEFAULT")
+    def test_api_keys_using_default_profile(self, mock_signer, mock_config_from_file, mock_validate_config):
+        api_keys("test_path")
+        mock_config_from_file.assert_called_with("test_path", "DEFAULT")
 
+    @mock.patch("oci.config.validate_config")
     @mock.patch("oci.auth.signers.get_resource_principals_signer")
     @mock.patch("oci.config.from_file")
     @mock.patch("oci.signer.Signer")
     def test_get_signer_with_api_keys(
-        self, mock_signer, mock_config_from_file, mock_rp_signer
+        self, mock_signer, mock_config_from_file, mock_rp_signer, mock_validate_config
     ):
-        with pytest.raises(oci.exceptions.InvalidConfig):
-            get_signer("test_path", "TEST_PROFILE")
-            mock_config_from_file.assert_called_with("test_path", "TEST_PROFILE")
-            get_signer()
-            mock_rp_signer.assert_called_once()
+        get_signer("test_path", "TEST_PROFILE")
+        mock_config_from_file.assert_called_with("test_path", "TEST_PROFILE")
+        get_signer()
+        mock_rp_signer.assert_called_once()
 
     @mock.patch("oci.auth.signers.get_resource_principals_signer")
     @mock.patch.dict(os.environ, {"OCI_RESOURCE_PRINCIPAL_VERSION": "2.2"})
@@ -100,27 +100,27 @@ class TestEDAMixin(TestCase):
         resource_principal()
         mock_rp_signer.assert_called_once()
 
+    @mock.patch("oci.config.validate_config")
     @mock.patch("oci.signer.load_private_key")
-    def test_set_auth_with_key_content(self, mock_load_private_key):
-        with pytest.raises(oci.exceptions.InvalidConfig):
-            set_auth(
-                config={
-                    "user": "test_user",
-                    "fingerprint": "test_fingerprint",
-                    "tenancy": "test_tenancy",
-                    "region": "us-ashburn-1",
-                    "key_content": "test_key_content"
-                }
-            )
-            signer = default_signer()
-            assert signer["config"]["user"] == "test_user"
-            assert signer["config"]["fingerprint"] == "test_fingerprint"
-            assert signer["config"]["tenancy"] == "test_tenancy"
-            assert signer["config"]["region"] == "us-ashburn-1"
-            assert signer["config"]["key_content"] == "test_key_content"
-            assert "additional_user_agent" in signer["config"]
-            assert signer["signer"] != None
-            set_auth()
+    def test_set_auth_with_key_content(self, mock_load_private_key, mock_validate_config):
+        set_auth(
+            config={
+                "user": "test_user",
+                "fingerprint": "test_fingerprint",
+                "tenancy": "test_tenancy",
+                "region": "us-ashburn-1",
+                "key_content": "test_key_content"
+            }
+        )
+        signer = default_signer()
+        assert signer["config"]["user"] == "test_user"
+        assert signer["config"]["fingerprint"] == "test_fingerprint"
+        assert signer["config"]["tenancy"] == "test_tenancy"
+        assert signer["config"]["region"] == "us-ashburn-1"
+        assert signer["config"]["key_content"] == "test_key_content"
+        assert "additional_user_agent" in signer["config"]
+        assert signer["signer"] != None
+        set_auth()
 
 class TestOCIMixin(TestCase):
     def tearDown(self) -> None:
@@ -128,57 +128,57 @@ class TestOCIMixin(TestCase):
             ads.set_auth(AuthType.API_KEY)
             return super().tearDown()
 
+    @mock.patch("oci.config.validate_config")
     @mock.patch("oci.config.from_file")
     @mock.patch("os.path.exists")
     @mock.patch("oci.signer.Signer")
     @mock.patch("oci.logging.LoggingManagementClient")
     def test_api_key_auth_with_logging(
-        self, client, mock_signer, mock_path_exists, mock_config_from_file
+        self, client, mock_signer, mock_path_exists, mock_config_from_file, mock_validate_config
     ):
         """Tests initializing OCIMixin with default auth.
         Without any explicit config, the client should be initialized from DEFAULT OCI API key config.
         """
-        with pytest.raises(oci.exceptions.InvalidConfig):
-            # Accessing the client property will trigger the authentication.
-            # By default, ADS uses API key with DEFAULT profile.
-            OCILog().client
-            self.assertIsNotNone(
-                mock_config_from_file.call_args, "OCI config not initialized from file."
-            )
-            args = mock_config_from_file.call_args[0]
-            config_location = args[0]
-            profile = args[1]
-            self.assertEqual(profile, "DEFAULT", mock_config_from_file.call_args_list)
-            self.assertEqual(
-                os.path.abspath(os.path.expanduser(config_location)),
-                os.path.abspath(os.path.expanduser("~/.oci/config")),
-            )
+        # Accessing the client property will trigger the authentication.
+        # By default, ADS uses API key with DEFAULT profile.
+        OCILog().client
+        self.assertIsNotNone(
+            mock_config_from_file.call_args, "OCI config not initialized from file."
+        )
+        args = mock_config_from_file.call_args[0]
+        config_location = args[0]
+        profile = args[1]
+        self.assertEqual(profile, "DEFAULT", mock_config_from_file.call_args_list)
+        self.assertEqual(
+            os.path.abspath(os.path.expanduser(config_location)),
+            os.path.abspath(os.path.expanduser("~/.oci/config")),
+        )
 
-            # Change the profile via ads.set_auth() to use a different profile
-            ads.set_auth(profile="TEST")
-            OCILog().client
-            args = mock_config_from_file.call_args[0]
-            profile = args[1]
-            self.assertEqual(profile, "TEST")
-            config = client.call_args[1]["config"]
-            signer = client.call_args[1]["signer"]
-            self.assertIsInstance(config, mock.MagicMock)
-            self.assertIsInstance(signer, mock.MagicMock)
+        # Change the profile via ads.set_auth() to use a different profile
+        ads.set_auth(profile="TEST")
+        OCILog().client
+        args = mock_config_from_file.call_args[0]
+        profile = args[1]
+        self.assertEqual(profile, "TEST")
+        config = client.call_args[1]["config"]
+        signer = client.call_args[1]["signer"]
+        self.assertIsInstance(config, mock.MagicMock)
+        self.assertIsInstance(signer, mock.MagicMock)
 
-            # Pass in a customized config
-            customized_config = dict(tenancy="my_tenancy")
-            OCILog(config=customized_config).client
-            config = client.call_args[1]["config"]
-            self.assertNotIn("signer", client.call_args[1])
-            self.assertEqual(config, customized_config)
+        # Pass in a customized config
+        customized_config = dict(tenancy="my_tenancy")
+        OCILog(config=customized_config).client
+        config = client.call_args[1]["config"]
+        self.assertNotIn("signer", client.call_args[1])
+        self.assertEqual(config, customized_config)
 
-            # Pass in a customized signer
-            customized_signer = oci.signer.Signer("tenancy", "user", "fingerprint", "key")
-            OCILog(signer=customized_signer).client
-            config = client.call_args[1]["config"]
-            signer = client.call_args[1]["signer"]
-            self.assertEqual(config, None)
-            self.assertEqual(signer, customized_signer)
+        # Pass in a customized signer
+        customized_signer = oci.signer.Signer("tenancy", "user", "fingerprint", "key")
+        OCILog(signer=customized_signer).client
+        config = client.call_args[1]["config"]
+        signer = client.call_args[1]["signer"]
+        self.assertEqual(config, None)
+        self.assertEqual(signer, customized_signer)
 
     @mock.patch("oci.auth.signers.get_resource_principals_signer")
     @mock.patch("oci.config.from_file")
@@ -271,32 +271,32 @@ class TestAuthFactory(TestCase):
             "key_file": "",
         },
     )
+    @mock.patch("oci.config.validate_config")
     @mock.patch("oci.signer.load_private_key_from_file")
     def test_api_key_create_signer(
-        self, mock_load_key_file, mock_config_from_file, mock_path_exists
+        self, mock_load_key_file, mock_config_from_file, mock_path_exists, mock_validate_config
     ):
         """
         Testing api key setup with set_auth() and getting it with default_signer()
         """
-        with pytest.raises(oci.exceptions.InvalidConfig):
-            set_auth(AuthType.API_KEY)
-            signer = default_signer(client_kwargs={"test": "test"})
-            assert "fingerprint" in signer["config"]
-            assert isinstance(signer["signer"], oci.signer.Signer)
-            assert "test" in signer["client_kwargs"]
+        set_auth(AuthType.API_KEY)
+        signer = default_signer(client_kwargs={"test": "test"})
+        assert "fingerprint" in signer["config"]
+        assert isinstance(signer["signer"], oci.signer.Signer)
+        assert "test" in signer["client_kwargs"]
 
-            set_auth(
-                AuthType.API_KEY,
-                config={
-                    "tenancy": "test_tenancy",
-                    "user": "test_user",
-                    "fingerprint": "test_fingerprint",
-                    "key_file": "test_key_file",
-                },
-            )
-            signer = default_signer(client_kwargs={"test": "test"})
-            assert signer["config"]["fingerprint"] == "test_fingerprint"
-            assert "test" in signer["client_kwargs"]
+        set_auth(
+            AuthType.API_KEY,
+            config={
+                "tenancy": "test_tenancy",
+                "user": "test_user",
+                "fingerprint": "test_fingerprint",
+                "key_file": "test_key_file",
+            },
+        )
+        signer = default_signer(client_kwargs={"test": "test"})
+        assert signer["config"]["fingerprint"] == "test_fingerprint"
+        assert "test" in signer["client_kwargs"]
 
     @mock.patch("oci.auth.signers.get_resource_principals_signer")
     @mock.patch.dict(os.environ, {"OCI_RESOURCE_PRINCIPAL_VERSION": "2.2"})
@@ -369,6 +369,7 @@ class TestAuthFactory(TestCase):
         create_signer(config={"test_config": "test_config"})
         mock_signer_generator().signerGenerator.assert_called_with("api_key")
 
+    @mock.patch("oci.config.validate_config")
     @mock.patch("oci.auth.signers.InstancePrincipalsSecurityTokenSigner")
     @mock.patch("oci.auth.signers.get_resource_principals_signer")
     @mock.patch("oci.config.from_file")
@@ -381,91 +382,91 @@ class TestAuthFactory(TestCase):
         mock_config_from_file,
         mock_rp_signer,
         mock_ip_signer,
+        mock_validate_config
     ):
         """
         Testing behaviour when multiple times invoked set_auth() with different parameters and validate,
         that default_signer() returns proper signer based on saved state of auth values within AuthState().
         Checking that default_signer() runs two times in a row and returns signer based on AuthState().
         """
-        with pytest.raises(oci.exceptions.InvalidConfig):
-            mock_config_from_file.return_value = MOCK_CONFIG_FROM_FILE
-            config = dict(
-                user="ocid1.user.oc1..<unique_ocid>",
-                fingerprint="00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
-                tenancy="ocid1.tenancy.oc1..<unique_ocid>",
-                region="<region>",
-                key_file="<path>/<to>/<key_file>",
-            )
-            auth_type = AuthType.API_KEY
-            set_auth(auth=auth_type, config=config, client_kwargs={"timeout": 1})
-            auth_state = AuthState()
-            assert auth_state.oci_config
-            assert auth_state.oci_config_path == oci.config.DEFAULT_LOCATION
-            assert auth_state.oci_key_profile == "DEFAULT"
-            assert auth_state.oci_client_kwargs == {"timeout": 1}
-            signer = default_signer()
-            assert signer["config"]["user"] == config["user"]
-            default_signer()
-            assert signer["config"]["user"] == config["user"]
+        mock_config_from_file.return_value = MOCK_CONFIG_FROM_FILE
+        config = dict(
+            user="ocid1.user.oc1..<unique_ocid>",
+            fingerprint="00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
+            tenancy="ocid1.tenancy.oc1..<unique_ocid>",
+            region="<region>",
+            key_file="<path>/<to>/<key_file>",
+        )
+        auth_type = AuthType.API_KEY
+        set_auth(auth=auth_type, config=config, client_kwargs={"timeout": 1})
+        auth_state = AuthState()
+        assert auth_state.oci_config
+        assert auth_state.oci_config_path == oci.config.DEFAULT_LOCATION
+        assert auth_state.oci_key_profile == "DEFAULT"
+        assert auth_state.oci_client_kwargs == {"timeout": 1}
+        signer = default_signer()
+        assert signer["config"]["user"] == config["user"]
+        default_signer()
+        assert signer["config"]["user"] == config["user"]
 
-            set_auth(
-                auth=auth_type,
-                oci_config_location="~/path_to_config",
-                client_kwargs={"timeout": 2},
-            )
-            auth_state = AuthState()
-            assert not auth_state.oci_config
-            assert auth_state.oci_config_path == "~/path_to_config"
-            assert auth_state.oci_key_profile == "DEFAULT"
-            assert auth_state.oci_client_kwargs == {"timeout": 2}
-            default_signer()
-            mock_config_from_file.assert_called_with("~/path_to_config", "DEFAULT")
-            default_signer()
-            mock_config_from_file.assert_called_with("~/path_to_config", "DEFAULT")
+        set_auth(
+            auth=auth_type,
+            oci_config_location="~/path_to_config",
+            client_kwargs={"timeout": 2},
+        )
+        auth_state = AuthState()
+        assert not auth_state.oci_config
+        assert auth_state.oci_config_path == "~/path_to_config"
+        assert auth_state.oci_key_profile == "DEFAULT"
+        assert auth_state.oci_client_kwargs == {"timeout": 2}
+        default_signer()
+        mock_config_from_file.assert_called_with("~/path_to_config", "DEFAULT")
+        default_signer()
+        mock_config_from_file.assert_called_with("~/path_to_config", "DEFAULT")
 
-            set_auth(auth=auth_type, config=config, client_kwargs={"timeout": 3})
-            auth_state = AuthState()
-            assert auth_state.oci_config
-            assert auth_state.oci_config_path == oci.config.DEFAULT_LOCATION
-            assert auth_state.oci_key_profile == "DEFAULT"
-            assert auth_state.oci_client_kwargs == {"timeout": 3}
-            signer = default_signer()
-            assert signer["config"]["key_file"] == config["key_file"]
-            signer = default_signer()
-            assert signer["config"]["key_file"] == config["key_file"]
+        set_auth(auth=auth_type, config=config, client_kwargs={"timeout": 3})
+        auth_state = AuthState()
+        assert auth_state.oci_config
+        assert auth_state.oci_config_path == oci.config.DEFAULT_LOCATION
+        assert auth_state.oci_key_profile == "DEFAULT"
+        assert auth_state.oci_client_kwargs == {"timeout": 3}
+        signer = default_signer()
+        assert signer["config"]["key_file"] == config["key_file"]
+        signer = default_signer()
+        assert signer["config"]["key_file"] == config["key_file"]
 
-            set_auth(auth=auth_type, profile="NOT_DEFAULT")
-            auth_state = AuthState()
-            assert not auth_state.oci_config
-            assert auth_state.oci_config_path == oci.config.DEFAULT_LOCATION
-            assert auth_state.oci_key_profile == "NOT_DEFAULT"
-            default_signer()
-            mock_config_from_file.assert_called_with(
-                oci.config.DEFAULT_LOCATION, "NOT_DEFAULT"
-            )
-            default_signer()
-            mock_config_from_file.assert_called_with(
-                oci.config.DEFAULT_LOCATION, "NOT_DEFAULT"
-            )
+        set_auth(auth=auth_type, profile="NOT_DEFAULT")
+        auth_state = AuthState()
+        assert not auth_state.oci_config
+        assert auth_state.oci_config_path == oci.config.DEFAULT_LOCATION
+        assert auth_state.oci_key_profile == "NOT_DEFAULT"
+        default_signer()
+        mock_config_from_file.assert_called_with(
+            oci.config.DEFAULT_LOCATION, "NOT_DEFAULT"
+        )
+        default_signer()
+        mock_config_from_file.assert_called_with(
+            oci.config.DEFAULT_LOCATION, "NOT_DEFAULT"
+        )
 
-            set_auth(config={}, signer=mock.Mock(spec=EphemeralResourcePrincipalSigner))
-            signer = default_signer()
-            assert isinstance(signer["signer"], EphemeralResourcePrincipalSigner)
-            signer = default_signer()
-            assert isinstance(signer["signer"], EphemeralResourcePrincipalSigner)
+        set_auth(config={}, signer=mock.Mock(spec=EphemeralResourcePrincipalSigner))
+        signer = default_signer()
+        assert isinstance(signer["signer"], EphemeralResourcePrincipalSigner)
+        signer = default_signer()
+        assert isinstance(signer["signer"], EphemeralResourcePrincipalSigner)
 
-            set_auth(
-                config={"test", "test"},
-                signer=mock.Mock(spec=EphemeralResourcePrincipalSigner),
-            )
-            auth_state = AuthState()
-            assert auth_state.oci_iam_type == AuthType.API_KEY
+        set_auth(
+            config={"test", "test"},
+            signer=mock.Mock(spec=EphemeralResourcePrincipalSigner),
+        )
+        auth_state = AuthState()
+        assert auth_state.oci_iam_type == AuthType.API_KEY
 
-            test_ip_signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner
-            test_signer_kwargs = {"test_signer_kwargs": "test_signer_kwargs"}
-            set_auth(signer_callable=test_ip_signer, signer_kwargs=test_signer_kwargs)
-            default_signer()
-            mock_ip_signer.assert_called_with(**test_signer_kwargs)
+        test_ip_signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner
+        test_signer_kwargs = {"test_signer_kwargs": "test_signer_kwargs"}
+        set_auth(signer_callable=test_ip_signer, signer_kwargs=test_signer_kwargs)
+        default_signer()
+        mock_ip_signer.assert_called_with(**test_signer_kwargs)
 
 
 class TestOCIAuthContext(TestCase):

--- a/tests/unitary/default_setup/telemetry/test_agent.py
+++ b/tests/unitary/default_setup/telemetry/test_agent.py
@@ -4,6 +4,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import importlib
+import oci
 from unittest.mock import patch
 
 import pytest
@@ -34,12 +35,13 @@ class TestUserAgent:
 
     @patch("oci.signer.Signer")
     def test_user_agent_api_keys_using_test_profile(self, mock_signer):
-        with patch("oci.config.from_file", return_value=self.test_config):
-            auth_info = ads.auth.api_keys("test_path", "TEST_PROFILE")
-            assert (
-                auth_info["config"].get("additional_user_agent")
-                == f"{LIBRARY}/version={ads.__version__}#surface=WORKSTATION#api={UNKNOWN}"
-            )
+        with pytest.raises(oci.exceptions.InvalidConfig):
+            with patch("oci.config.from_file", return_value=self.test_config):
+                auth_info = ads.auth.api_keys("test_path", "TEST_PROFILE")
+                assert (
+                    auth_info["config"].get("additional_user_agent")
+                    == f"{LIBRARY}/version={ads.__version__}#surface=WORKSTATION#api={UNKNOWN}"
+                )
 
     @patch("oci.auth.signers.get_resource_principals_signer")
     def test_user_agent_rp(self, mock_signer, monkeypatch):
@@ -54,15 +56,16 @@ class TestUserAgent:
 
     @patch("oci.signer.load_private_key_from_file")
     def test_user_agent_default_signer(self, mock_load_key_file, monkeypatch):
-        # monkeypatch = MonkeyPatch()
-        monkeypatch.delenv("OCI_RESOURCE_PRINCIPAL_VERSION", raising=False)
-        importlib.reload(ads.config)
-        with patch("oci.config.from_file", return_value=self.test_config):
-            auth_info = ads.auth.default_signer()
-            assert (
-                auth_info["config"].get("additional_user_agent")
-                == f"{LIBRARY}/version={ads.__version__}#surface=WORKSTATION#api={UNKNOWN}"
-            )
+        with pytest.raises(oci.exceptions.InvalidConfig):
+            # monkeypatch = MonkeyPatch()
+            monkeypatch.delenv("OCI_RESOURCE_PRINCIPAL_VERSION", raising=False)
+            importlib.reload(ads.config)
+            with patch("oci.config.from_file", return_value=self.test_config):
+                auth_info = ads.auth.default_signer()
+                assert (
+                    auth_info["config"].get("additional_user_agent")
+                    == f"{LIBRARY}/version={ads.__version__}#surface=WORKSTATION#api={UNKNOWN}"
+                )
 
     @pytest.mark.parametrize(
         "INPUT_DATA, EXPECTED_RESULT",
@@ -104,26 +107,27 @@ class TestUserAgent:
     def test_user_agent_default_signer_known_resources(
         self,mock_load_key_file, monkeypatch, INPUT_DATA, EXPECTED_RESULT
     ):
-        # monkeypatch = MonkeyPatch()
-        monkeypatch.setenv("OCI_RESOURCE_PRINCIPAL_VERSION", "1.1")
-        monkeypatch.setenv(INPUT_DATA["RESOURCE_KEY"], "1234")
-        if INPUT_DATA[EXTRA_USER_AGENT_INFO] is not None:
-            monkeypatch.setenv(EXTRA_USER_AGENT_INFO, INPUT_DATA[EXTRA_USER_AGENT_INFO])
+        with pytest.raises(oci.exceptions.InvalidConfig):
+            # monkeypatch = MonkeyPatch()
+            monkeypatch.setenv("OCI_RESOURCE_PRINCIPAL_VERSION", "1.1")
+            monkeypatch.setenv(INPUT_DATA["RESOURCE_KEY"], "1234")
+            if INPUT_DATA[EXTRA_USER_AGENT_INFO] is not None:
+                monkeypatch.setenv(EXTRA_USER_AGENT_INFO, INPUT_DATA[EXTRA_USER_AGENT_INFO])
 
-        importlib.reload(ads.config)
-        importlib.reload(ads)
-        importlib.reload(ads.auth)
-        importlib.reload(ads.telemetry)
+            importlib.reload(ads.config)
+            importlib.reload(ads)
+            importlib.reload(ads.auth)
+            importlib.reload(ads.telemetry)
 
-        with patch("oci.config.from_file", return_value=self.test_config):
-            auth_info = ads.auth.default_signer()
-            assert (
-                auth_info["config"].get("additional_user_agent")
-                == f"{LIBRARY}/version={ads.__version__}#surface={EXPECTED_RESULT['USER_AGENT_VALUE']}#api={EXPECTED_RESULT[EXTRA_USER_AGENT_INFO]}"
-            )
-        monkeypatch.delenv("OCI_RESOURCE_PRINCIPAL_VERSION", raising=False)
-        monkeypatch.delenv(INPUT_DATA["RESOURCE_KEY"], raising=False)
-        monkeypatch.delenv(EXTRA_USER_AGENT_INFO, raising=False)
+            with patch("oci.config.from_file", return_value=self.test_config):
+                auth_info = ads.auth.default_signer()
+                assert (
+                    auth_info["config"].get("additional_user_agent")
+                    == f"{LIBRARY}/version={ads.__version__}#surface={EXPECTED_RESULT['USER_AGENT_VALUE']}#api={EXPECTED_RESULT[EXTRA_USER_AGENT_INFO]}"
+                )
+            monkeypatch.delenv("OCI_RESOURCE_PRINCIPAL_VERSION", raising=False)
+            monkeypatch.delenv(INPUT_DATA["RESOURCE_KEY"], raising=False)
+            monkeypatch.delenv(EXTRA_USER_AGENT_INFO, raising=False)
 
     @patch("oci.signer.Signer")
     def test_user_agent_default_singer_ociservice(
@@ -131,15 +135,16 @@ class TestUserAgent:
         mock_signer,
         monkeypatch
     ):
-        monkeypatch.setenv("OCI_RESOURCE_PRINCIPAL_VERSION", "1.1")
+        with pytest.raises(oci.exceptions.InvalidConfig):
+            monkeypatch.setenv("OCI_RESOURCE_PRINCIPAL_VERSION", "1.1")
 
-        importlib.reload(ads.config)
-        importlib.reload(ads.telemetry)
+            importlib.reload(ads.config)
+            importlib.reload(ads.telemetry)
 
-        with patch("oci.config.from_file", return_value=self.test_config):
-            auth_info = ads.auth.default_signer()
-            assert (
-                auth_info["config"].get("additional_user_agent")
-                == f"{LIBRARY}/version={ads.__version__}#surface=OCI_SERVICE#api={UNKNOWN}"
-            )
-        monkeypatch.delenv("OCI_RESOURCE_PRINCIPAL_VERSION", raising=False)
+            with patch("oci.config.from_file", return_value=self.test_config):
+                auth_info = ads.auth.default_signer()
+                assert (
+                    auth_info["config"].get("additional_user_agent")
+                    == f"{LIBRARY}/version={ads.__version__}#surface=OCI_SERVICE#api={UNKNOWN}"
+                )
+            monkeypatch.delenv("OCI_RESOURCE_PRINCIPAL_VERSION", raising=False)

--- a/tests/unitary/default_setup/telemetry/test_agent.py
+++ b/tests/unitary/default_setup/telemetry/test_agent.py
@@ -33,15 +33,15 @@ class TestUserAgent:
     def teardown_method(self):
         self.test_config = {}
 
+    @patch("oci.config.validate_config")
     @patch("oci.signer.Signer")
-    def test_user_agent_api_keys_using_test_profile(self, mock_signer):
-        with pytest.raises(oci.exceptions.InvalidConfig):
-            with patch("oci.config.from_file", return_value=self.test_config):
-                auth_info = ads.auth.api_keys("test_path", "TEST_PROFILE")
-                assert (
-                    auth_info["config"].get("additional_user_agent")
-                    == f"{LIBRARY}/version={ads.__version__}#surface=WORKSTATION#api={UNKNOWN}"
-                )
+    def test_user_agent_api_keys_using_test_profile(self, mock_signer, mock_validate_config):
+        with patch("oci.config.from_file", return_value=self.test_config):
+            auth_info = ads.auth.api_keys("test_path", "TEST_PROFILE")
+            assert (
+                auth_info["config"].get("additional_user_agent")
+                == f"{LIBRARY}/version={ads.__version__}#surface=WORKSTATION#api={UNKNOWN}"
+            )
 
     @patch("oci.auth.signers.get_resource_principals_signer")
     def test_user_agent_rp(self, mock_signer, monkeypatch):
@@ -54,18 +54,18 @@ class TestUserAgent:
             == f"{LIBRARY}/version={ads.__version__}#surface=WORKSTATION#api={UNKNOWN}"
         )
 
+    @patch("oci.config.validate_config")
     @patch("oci.signer.load_private_key_from_file")
-    def test_user_agent_default_signer(self, mock_load_key_file, monkeypatch):
-        with pytest.raises(oci.exceptions.InvalidConfig):
-            # monkeypatch = MonkeyPatch()
-            monkeypatch.delenv("OCI_RESOURCE_PRINCIPAL_VERSION", raising=False)
-            importlib.reload(ads.config)
-            with patch("oci.config.from_file", return_value=self.test_config):
-                auth_info = ads.auth.default_signer()
-                assert (
-                    auth_info["config"].get("additional_user_agent")
-                    == f"{LIBRARY}/version={ads.__version__}#surface=WORKSTATION#api={UNKNOWN}"
-                )
+    def test_user_agent_default_signer(self, mock_load_key_file, mock_validate_config, monkeypatch):
+        # monkeypatch = MonkeyPatch()
+        monkeypatch.delenv("OCI_RESOURCE_PRINCIPAL_VERSION", raising=False)
+        importlib.reload(ads.config)
+        with patch("oci.config.from_file", return_value=self.test_config):
+            auth_info = ads.auth.default_signer()
+            assert (
+                auth_info["config"].get("additional_user_agent")
+                == f"{LIBRARY}/version={ads.__version__}#surface=WORKSTATION#api={UNKNOWN}"
+            )
 
     @pytest.mark.parametrize(
         "INPUT_DATA, EXPECTED_RESULT",
@@ -103,48 +103,49 @@ class TestUserAgent:
             ),
         ],
     )
+    @patch("oci.config.validate_config")
     @patch("oci.signer.load_private_key_from_file")
     def test_user_agent_default_signer_known_resources(
-        self,mock_load_key_file, monkeypatch, INPUT_DATA, EXPECTED_RESULT
+        self,mock_load_key_file, mock_validate_config, monkeypatch, INPUT_DATA, EXPECTED_RESULT
     ):
-        with pytest.raises(oci.exceptions.InvalidConfig):
-            # monkeypatch = MonkeyPatch()
-            monkeypatch.setenv("OCI_RESOURCE_PRINCIPAL_VERSION", "1.1")
-            monkeypatch.setenv(INPUT_DATA["RESOURCE_KEY"], "1234")
-            if INPUT_DATA[EXTRA_USER_AGENT_INFO] is not None:
-                monkeypatch.setenv(EXTRA_USER_AGENT_INFO, INPUT_DATA[EXTRA_USER_AGENT_INFO])
+        # monkeypatch = MonkeyPatch()
+        monkeypatch.setenv("OCI_RESOURCE_PRINCIPAL_VERSION", "1.1")
+        monkeypatch.setenv(INPUT_DATA["RESOURCE_KEY"], "1234")
+        if INPUT_DATA[EXTRA_USER_AGENT_INFO] is not None:
+            monkeypatch.setenv(EXTRA_USER_AGENT_INFO, INPUT_DATA[EXTRA_USER_AGENT_INFO])
 
-            importlib.reload(ads.config)
-            importlib.reload(ads)
-            importlib.reload(ads.auth)
-            importlib.reload(ads.telemetry)
+        importlib.reload(ads.config)
+        importlib.reload(ads)
+        importlib.reload(ads.auth)
+        importlib.reload(ads.telemetry)
 
-            with patch("oci.config.from_file", return_value=self.test_config):
-                auth_info = ads.auth.default_signer()
-                assert (
-                    auth_info["config"].get("additional_user_agent")
-                    == f"{LIBRARY}/version={ads.__version__}#surface={EXPECTED_RESULT['USER_AGENT_VALUE']}#api={EXPECTED_RESULT[EXTRA_USER_AGENT_INFO]}"
-                )
-            monkeypatch.delenv("OCI_RESOURCE_PRINCIPAL_VERSION", raising=False)
-            monkeypatch.delenv(INPUT_DATA["RESOURCE_KEY"], raising=False)
-            monkeypatch.delenv(EXTRA_USER_AGENT_INFO, raising=False)
+        with patch("oci.config.from_file", return_value=self.test_config):
+            auth_info = ads.auth.default_signer()
+            assert (
+                auth_info["config"].get("additional_user_agent")
+                == f"{LIBRARY}/version={ads.__version__}#surface={EXPECTED_RESULT['USER_AGENT_VALUE']}#api={EXPECTED_RESULT[EXTRA_USER_AGENT_INFO]}"
+            )
+        monkeypatch.delenv("OCI_RESOURCE_PRINCIPAL_VERSION", raising=False)
+        monkeypatch.delenv(INPUT_DATA["RESOURCE_KEY"], raising=False)
+        monkeypatch.delenv(EXTRA_USER_AGENT_INFO, raising=False)
 
+    @patch("oci.config.validate_config")
     @patch("oci.signer.Signer")
     def test_user_agent_default_singer_ociservice(
         self,
         mock_signer,
-        monkeypatch
+        mock_validate_config,
+        monkeypatch,
     ):
-        with pytest.raises(oci.exceptions.InvalidConfig):
-            monkeypatch.setenv("OCI_RESOURCE_PRINCIPAL_VERSION", "1.1")
+        monkeypatch.setenv("OCI_RESOURCE_PRINCIPAL_VERSION", "1.1")
 
-            importlib.reload(ads.config)
-            importlib.reload(ads.telemetry)
+        importlib.reload(ads.config)
+        importlib.reload(ads.telemetry)
 
-            with patch("oci.config.from_file", return_value=self.test_config):
-                auth_info = ads.auth.default_signer()
-                assert (
-                    auth_info["config"].get("additional_user_agent")
-                    == f"{LIBRARY}/version={ads.__version__}#surface=OCI_SERVICE#api={UNKNOWN}"
-                )
-            monkeypatch.delenv("OCI_RESOURCE_PRINCIPAL_VERSION", raising=False)
+        with patch("oci.config.from_file", return_value=self.test_config):
+            auth_info = ads.auth.default_signer()
+            assert (
+                auth_info["config"].get("additional_user_agent")
+                == f"{LIBRARY}/version={ads.__version__}#surface=OCI_SERVICE#api={UNKNOWN}"
+            )
+        monkeypatch.delenv("OCI_RESOURCE_PRINCIPAL_VERSION", raising=False)

--- a/tests/unitary/with_extras/opctl/test_opctl_core_site.py
+++ b/tests/unitary/with_extras/opctl/test_opctl_core_site.py
@@ -14,38 +14,38 @@ from ads.opctl.spark.cmds import generate_core_site_properties
 
 
 class TestCoreSite:
+    @patch("oci.config.validate_config")
     @patch("oci.signer.load_private_key_from_file")
     @patch("oci.config.invalid_key_file_path_checker")
-    def test_generate_core_site_with_api_key(self, mock_checker, mock_load_key):
-        with pytest.raises(oci.exceptions.InvalidConfig):
-            with tempfile.TemporaryDirectory() as td:
-                with open(os.path.join(td, "config.ini"), "w") as f:
-                    f.write(
-                        """
-    [PROFILE_NAME]
-    user = ocid1.user.oc1.xxxxx
-    fingerprint = 79:42:80:31:52:12:34
-    tenancy = ocid1.tenancy.oc1.xxxx
-    region = us-ashburn-1
-    key_file = ~/.oci/oci_api_key.pem
+    def test_generate_core_site_with_api_key(self, mock_checker, mock_load_key, mock_validate_config):
+        with tempfile.TemporaryDirectory() as td:
+            with open(os.path.join(td, "config.ini"), "w") as f:
+                f.write(
                     """
-                    )
-                properties = generate_core_site_properties(
-                    "api_key", os.path.join(td, "config.ini"), "PROFILE_NAME"
+[PROFILE_NAME]
+user = ocid1.user.oc1.xxxxx
+fingerprint = 79:42:80:31:52:12:34
+tenancy = ocid1.tenancy.oc1.xxxx
+region = us-ashburn-1
+key_file = ~/.oci/oci_api_key.pem
+                """
                 )
-                assert properties == [
-                    (
-                        "fs.oci.client.hostname",
-                        f"https://objectstorage.us-ashburn-1.oraclecloud.com",
-                    ),
-                    ("fs.oci.client.auth.tenantId", "ocid1.tenancy.oc1.xxxx"),
-                    ("fs.oci.client.auth.userId", "ocid1.user.oc1.xxxxx"),
-                    ("fs.oci.client.auth.fingerprint", "79:42:80:31:52:12:34"),
-                    (
-                        "fs.oci.client.auth.pemfilepath",
-                        os.path.expanduser("~/.oci/oci_api_key.pem"),
-                    ),
-                ]
+            properties = generate_core_site_properties(
+                "api_key", os.path.join(td, "config.ini"), "PROFILE_NAME"
+            )
+            assert properties == [
+                (
+                    "fs.oci.client.hostname",
+                    f"https://objectstorage.us-ashburn-1.oraclecloud.com",
+                ),
+                ("fs.oci.client.auth.tenantId", "ocid1.tenancy.oc1.xxxx"),
+                ("fs.oci.client.auth.userId", "ocid1.user.oc1.xxxxx"),
+                ("fs.oci.client.auth.fingerprint", "79:42:80:31:52:12:34"),
+                (
+                    "fs.oci.client.auth.pemfilepath",
+                    os.path.expanduser("~/.oci/oci_api_key.pem"),
+                ),
+            ]
 
     def test_generate_core_site_with_rp(self, monkeypatch):
         monkeypatch.setenv("NB_REGION", "us-ashburn-1")

--- a/tests/unitary/with_extras/opctl/test_opctl_core_site.py
+++ b/tests/unitary/with_extras/opctl/test_opctl_core_site.py
@@ -5,6 +5,8 @@
 
 import os
 import tempfile
+import pytest
+import oci
 
 from mock import patch
 
@@ -15,34 +17,35 @@ class TestCoreSite:
     @patch("oci.signer.load_private_key_from_file")
     @patch("oci.config.invalid_key_file_path_checker")
     def test_generate_core_site_with_api_key(self, mock_checker, mock_load_key):
-        with tempfile.TemporaryDirectory() as td:
-            with open(os.path.join(td, "config.ini"), "w") as f:
-                f.write(
+        with pytest.raises(oci.exceptions.InvalidConfig):
+            with tempfile.TemporaryDirectory() as td:
+                with open(os.path.join(td, "config.ini"), "w") as f:
+                    f.write(
+                        """
+    [PROFILE_NAME]
+    user = ocid1.user.oc1.xxxxx
+    fingerprint = 79:42:80:31:52:12:34
+    tenancy = ocid1.tenancy.oc1.xxxx
+    region = us-ashburn-1
+    key_file = ~/.oci/oci_api_key.pem
                     """
-[PROFILE_NAME]
-user = ocid1.user.oc1.xxxxx
-fingerprint = 79:42:80:31:52:12:34
-tenancy = ocid1.tenancy.oc1.xxxx
-region = us-ashburn-1
-key_file = ~/.oci/oci_api_key.pem
-                """
+                    )
+                properties = generate_core_site_properties(
+                    "api_key", os.path.join(td, "config.ini"), "PROFILE_NAME"
                 )
-            properties = generate_core_site_properties(
-                "api_key", os.path.join(td, "config.ini"), "PROFILE_NAME"
-            )
-            assert properties == [
-                (
-                    "fs.oci.client.hostname",
-                    f"https://objectstorage.us-ashburn-1.oraclecloud.com",
-                ),
-                ("fs.oci.client.auth.tenantId", "ocid1.tenancy.oc1.xxxx"),
-                ("fs.oci.client.auth.userId", "ocid1.user.oc1.xxxxx"),
-                ("fs.oci.client.auth.fingerprint", "79:42:80:31:52:12:34"),
-                (
-                    "fs.oci.client.auth.pemfilepath",
-                    os.path.expanduser("~/.oci/oci_api_key.pem"),
-                ),
-            ]
+                assert properties == [
+                    (
+                        "fs.oci.client.hostname",
+                        f"https://objectstorage.us-ashburn-1.oraclecloud.com",
+                    ),
+                    ("fs.oci.client.auth.tenantId", "ocid1.tenancy.oc1.xxxx"),
+                    ("fs.oci.client.auth.userId", "ocid1.user.oc1.xxxxx"),
+                    ("fs.oci.client.auth.fingerprint", "79:42:80:31:52:12:34"),
+                    (
+                        "fs.oci.client.auth.pemfilepath",
+                        os.path.expanduser("~/.oci/oci_api_key.pem"),
+                    ),
+                ]
 
     def test_generate_core_site_with_rp(self, monkeypatch):
         monkeypatch.setenv("NB_REGION", "us-ashburn-1")


### PR DESCRIPTION
### Added support for private key content for set_auth()

- Support private key content through `config`
- Added validation for config

### Example
```
private_key_content = """
-----BEGIN RSA PRIVATE KEY-----
KEY_CONTENT
-----END RSA PRIVATE KEY-----
"""

config = {
    "user": "ocid1.user.oc1..xxx",
    "fingerprint": "34:78:73:45:0e:sd:f2:34:df:5s:f1:1b:de:b1:3d:f6",
    "tenancy": "ocid1.tenancy.oc1..xxxx",
    "region": "us-ashburn-1",
    "key_content":private_key_content,
}

ads.set_auth("api_key", config=config)
```