### PR TITLE
Added support for mounting object storage service for job.

### DIFF
--- a/ads/common/dsc_file_system.py
+++ b/ads/common/dsc_file_system.py
@@ -228,6 +228,8 @@ class OCIObjectStorage(DSCFileSystem):
 
 class DSCFileSystemManager:
 
+    storage_mount_dest = set()
+
     @classmethod
     def initialize(cls, arguments: dict) -> dict:
         """Initialize and update arguments to dsc model.
@@ -246,6 +248,12 @@ class DSCFileSystemManager:
             raise ValueError(
                 "Parameter `dest` is required for mounting file storage system."
             )
+
+        if arguments["dest"] in cls.storage_mount_dest:
+            raise ValueError(
+                "Duplicate `dest` found. Please specify different `dest` for each file system to be mounted."
+            )
+        cls.storage_mount_dest.add(arguments["dest"])
 
         # case oci://bucket@namespace/prefix
         if arguments["src"].startswith("oci://") and "@" in arguments["src"]:

--- a/ads/jobs/builders/infrastructure/dsc_job.py
+++ b/ads/jobs/builders/infrastructure/dsc_job.py
@@ -35,7 +35,7 @@ from ads.jobs.builders.runtimes.artifact import Artifact
 from ads.jobs.builders.runtimes.container_runtime import ContainerRuntime
 from ads.jobs.builders.runtimes.python_runtime import GitPythonRuntime
 
-from ads.common.dsc_file_system import OCIFileStorage, DSCFileSystemManager
+from ads.common.dsc_file_system import OCIFileStorage, DSCFileSystemManager, OCIObjectStorage
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +43,7 @@ SLEEP_INTERVAL = 3
 WAIT_SECONDS_AFTER_FINISHED = 90
 MAXIMUM_MOUNT_COUNT = 5
 FILE_STORAGE_TYPE = "FILE_STORAGE"
+OBJECT_STORAGE_TYPE = "OBJECT_STORAGE"
 
 
 class DSCJob(OCIDataScienceMixin, oci.data_science.models.Job):
@@ -911,7 +912,10 @@ class DataScienceJob(Infrastructure):
         v.split(".", maxsplit=1)[-1]: k for k, v in payload_attribute_map.items()
     }
 
-    storage_mount_type_dict = {FILE_STORAGE_TYPE: OCIFileStorage}
+    storage_mount_type_dict = {
+        FILE_STORAGE_TYPE: OCIFileStorage,
+        OBJECT_STORAGE_TYPE: OCIObjectStorage,
+    }
 
     @staticmethod
     def standardize_spec(spec):

--- a/tests/unitary/default_setup/jobs/test_jobs_mount_file_system.py
+++ b/tests/unitary/default_setup/jobs/test_jobs_mount_file_system.py
@@ -83,7 +83,11 @@ job = (
             {
                 "src" : "2.2.2.2:test_export_path_two",
                 "dest" : "test_mount_two",
-            },  
+            }, 
+            {
+                "src" : "oci://bucket_name@namespace/synthetic/",
+                "dest" : "test_mount_three",
+            } 
         )
     )
     .with_runtime(
@@ -111,6 +115,8 @@ spec:
         dest: test_mount_one
       - src: 2.2.2.2:test_export_path_two
         dest: test_mount_two
+      - src: oci://bucket_name@namespace/synthetic/
+        dest: test_mount_three
       subnetId: ocid1.subnet.oc1.iad.xxxx
     type: dataScienceJob
   name: My Job
@@ -141,6 +147,11 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
         assert dsc_file_storage_two["src"] == "2.2.2.2:test_export_path_two"
         assert dsc_file_storage_two["dest"] == "test_mount_two"
 
+        dsc_object_storage = job.infrastructure.storage_mount[2]
+        assert isinstance(dsc_object_storage, dict)
+        assert dsc_object_storage["src"] == "oci://bucket_name@namespace/synthetic/"
+        assert dsc_object_storage["dest"] == "test_mount_three"
+
     def test_data_science_job_from_yaml(self):
         job_from_yaml = Job.from_yaml(job_yaml_string)
 
@@ -154,6 +165,11 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
         assert isinstance(dsc_file_storage_two, dict)
         assert dsc_file_storage_two["src"] == "2.2.2.2:test_export_path_two"
         assert dsc_file_storage_two["dest"] == "test_mount_two"
+
+        dsc_object_storage = job.infrastructure.storage_mount[2]
+        assert isinstance(dsc_object_storage, dict)
+        assert dsc_object_storage["src"] == "oci://bucket_name@namespace/synthetic/"
+        assert dsc_object_storage["dest"] == "test_mount_three"
 
     def test_data_science_job_to_dict(self):
         assert job.to_dict() == {
@@ -189,6 +205,10 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
                                 "src" : "2.2.2.2:test_export_path_two",
                                 "dest" : "test_mount_two",
                             },
+                            {
+                                "src" : "oci://bucket_name@namespace/synthetic/",
+                                "dest" : "test_mount_three",
+                            } 
                         ],
                     },
                 },
@@ -265,7 +285,7 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
 
         assert (
             len(dsc_job_payload_copy.job_storage_mount_configuration_details_list)
-            == 2
+            == 3
         )
         assert dsc_job_payload_copy.job_storage_mount_configuration_details_list[
             0


### PR DESCRIPTION
### Added support for mounting object storage service for job.

- Implemented new class `OCIObjectStorage` for mounting OSS

### Example
```
job = (
    Job(name="My Job")
    .with_infrastructure(
        DataScienceJob()
        .with_storage_mount(
            {
                "src": "oci://<bucket>@<namespace>/<prefix>",
                "dest":"test_mount_object_storage",
            }
        )
        ...
    )
    ...
)
```

### YAML
```
kind: job
spec:
  infrastructure:
    kind: infrastructure
    spec:
      ...
      storageMount:
      - dest: test_mount_object_storage
        src: oci://<bucket>@<namespace>/<prefix>
    type: dataScienceJob
  name: My Job
  ...
```