### PR TITLE
Uptake python to 3.8 in Dockerfile for job-local image

### DIFF
--- a/ads/opctl/docker/Dockerfile.job
+++ b/ads/opctl/docker/Dockerfile.job
@@ -62,7 +62,6 @@ ENV LANG=$LANG
 ENV SHELL=/bin/bash
 
 # set /opt folder permissions for $DATASCIENCE_USER. Conda is going to live in this folder.
-ARG MINICONDA_VER=4.8.3
 RUN chown $DATASCIENCE_USER /opt
 
 USER $DATASCIENCE_USER
@@ -71,7 +70,7 @@ RUN curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.s
     && /bin/bash /home/datascience/miniconda.sh -f -b -p /opt/conda \
     && rm /home/datascience/miniconda.sh \
     && ls  /opt/**/* \
-    && /opt/conda/bin/conda install python=3.7 anaconda \
+    && /opt/conda/bin/conda install python=3.8 anaconda \
     && /opt/conda/bin/conda clean -yaf
 
 WORKDIR /
@@ -91,7 +90,7 @@ WORKDIR /home/datascience
 USER $DATASCIENCE_USER
 
 ####### WRAP UP ###############################
-RUN python -c 'import sys; assert(sys.version_info[:2]) == (3, 7), "Python 3.7 is not detected"'
+RUN python -c 'import sys; assert(sys.version_info[:2]) == (3, 8), "Python 3.8 is not detected"'
 WORKDIR /
 
 RUN conda list

--- a/ads/opctl/docker/Dockerfile.job.gpu
+++ b/ads/opctl/docker/Dockerfile.job.gpu
@@ -107,7 +107,6 @@ ENV LANG=$LANG
 ENV SHELL=/bin/bash
 
 # set /opt folder permissions for $DATASCIENCE_USER. Conda is going to live in this folder.
-ARG MINICONDA_VER=4.8.3
 RUN chown $DATASCIENCE_USER /opt
 
 USER $DATASCIENCE_USER
@@ -116,7 +115,7 @@ RUN curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.s
     && /bin/bash /home/datascience/miniconda.sh -f -b -p /opt/conda \
     && rm /home/datascience/miniconda.sh \
     && ls  /opt/**/* \
-    && /opt/conda/bin/conda install python=3.7 anaconda \
+    && /opt/conda/bin/conda install python=3.8 anaconda \
     && /opt/conda/bin/conda clean -yaf
 
 WORKDIR /
@@ -136,7 +135,7 @@ WORKDIR /home/datascience
 USER $DATASCIENCE_USER
 
 ####### WRAP UP ###############################
-RUN python -c 'import sys; assert(sys.version_info[:2]) == (3, 7), "Python 3.7 is not detected"'
+RUN python -c 'import sys; assert(sys.version_info[:2]) == (3, 8), "Python 3.8 is not detected"'
 WORKDIR /
 
 RUN conda list


### PR DESCRIPTION
### Descirption

Builfind job-local failed (command: `ads opctl build-image job-local` from https://accelerated-data-science.readthedocs.io/en/latest/user_guide/cli/opctl/localdev/jobs_container_image.html) for the reason it try to create python 3.7 env. We need to uptake it to python 3.8

Jira: https://jira.oci.oraclecorp.com/browse/ODSC-43016

### What was done

- updated python to 3.8 in Dockerfile.job
- updated python to 3.8 in Dockerfile.job.gpu

### Validation

1. conda create --name job_image python=3.8
2. conda activate job_image
3. python3 -m pip install "oracle-ads[opctl]"
4. ads opctl build-image job-local

Observed that image builded successfully:
```
$ ads opctl build-image job-local
Sending build context to Docker daemon  667.6kB

Step 1/36 : FROM  --platform=linux/amd64 ghcr.io/oracle/oraclelinux:7-slim
 ---> 1d56b1a0fd84
Step 2/36 : ENV DATASCIENCE_USER datascience
 ---> Using cache
 ---> 8ed35faba9ba

...

Step 36/36 : USER datascience
 ---> Running in 2a18a21c58b6
Removing intermediate container 2a18a21c58b6
 ---> 1c104b217923
Successfully built 1c104b217923
Successfully tagged ml-job:latest
```
