### PR TITLE
Added defined tags for data flow

### DIFF
--- a/ads/jobs/builders/infrastructure/dataflow.py
+++ b/ads/jobs/builders/infrastructure/dataflow.py
@@ -384,6 +384,8 @@ class DataFlow(Infrastructure):
     CONST_OCPUS = "ocpus"
     CONST_ID = "id"
     CONST_PRIVATE_ENDPOINT_ID = "private_endpoint_id"
+    CONST_FREEFORM_TAGS = "freeform_tags"
+    CONST_DEFINED_TAGS = "defined_tags"
 
     attribute_map = {
         CONST_COMPARTMENT_ID: "compartmentId",
@@ -402,6 +404,8 @@ class DataFlow(Infrastructure):
         CONST_OCPUS: CONST_OCPUS,
         CONST_ID: CONST_ID,
         CONST_PRIVATE_ENDPOINT_ID: "privateEndpointId",
+        CONST_FREEFORM_TAGS: "freeformTags",
+        CONST_DEFINED_TAGS: "definedTags"
     }
 
     def __init__(self, spec: dict = None, **kwargs):
@@ -414,7 +418,9 @@ class DataFlow(Infrastructure):
             spec = {
                 k: v
                 for k, v in spec.items()
-                if f"with_{camel_to_snake(k)}" in self.__dir__() and v is not None
+                if (f"with_{camel_to_snake(k)}" in self.__dir__()
+                or (k == "defined_tags" or "freeform_tags"))
+                and v is not None
             }
             defaults.update(spec)
             super().__init__(defaults, **kwargs)
@@ -775,6 +781,36 @@ class DataFlow(Infrastructure):
             the Data Flow instance itself
         """
         return self.set_spec(self.CONST_PRIVATE_ENDPOINT_ID, private_endpoint_id)
+    
+    def with_freeform_tag(self, **kwargs) -> "DataFlow":
+        """Sets freeform tags
+
+        Returns
+        -------
+        DataFlow
+            The DataFlow instance (self)
+        """
+        return self.set_spec(self.CONST_FREEFORM_TAGS, kwargs)
+
+    def with_defined_tag(self, **kwargs) -> "DataFlow":
+        """Sets defined tags
+
+        Returns
+        -------
+        DataFlow
+            The DataFlow instance (self)
+        """
+        return self.set_spec(self.CONST_DEFINED_TAGS, kwargs)
+
+    @property
+    def freeform_tags(self) -> dict:
+        """Freeform tags"""
+        return self.get_spec(self.CONST_FREEFORM_TAGS, {})
+
+    @property
+    def defined_tags(self) -> dict:
+        """Defined tags"""
+        return self.get_spec(self.CONST_DEFINED_TAGS, {})
 
     def __getattr__(self, item):
         if f"with_{item}" in self.__dir__():
@@ -849,7 +885,8 @@ class DataFlow(Infrastructure):
             {
                 "display_name": self.name,
                 "file_uri": runtime.script_uri,
-                "freeform_tags": runtime.freeform_tags,
+                "freeform_tags": runtime.freeform_tags or self.freeform_tags,
+                "defined_tags": runtime.defined_tags or self.defined_tags,
                 "archive_uri": runtime.archive_uri,
                 "configuration": runtime.configuration,
             }
@@ -915,6 +952,7 @@ class DataFlow(Infrastructure):
         args: List[str] = None,
         env_vars: Dict[str, str] = None,
         freeform_tags: Dict[str, str] = None,
+        defined_tags: Dict[str, Dict[str, object]] = None,
         wait: bool = False,
         **kwargs,
     ) -> DataFlowRun:
@@ -932,6 +970,8 @@ class DataFlow(Infrastructure):
             dictionary of environment variables (not used for data flow)
         freeform_tags: Dict[str, str], optional
             freeform tags
+        defined_tags: Dict[str, Dict[str, object]], optional
+            defined tags
         wait: bool, optional
             whether to wait for a run to terminate
         kwargs
@@ -950,7 +990,8 @@ class DataFlow(Infrastructure):
         # Set default display_name if not specified - randomly generated easy to remember name generated
         payload["display_name"] = name if name else utils.get_random_name_for_resource()
         payload["arguments"] = args if args and len(args) > 0 else None
-        payload["freeform_tags"] = freeform_tags
+        payload["freeform_tags"] = freeform_tags or self.freeform_tags
+        payload["defined_tags"] = defined_tags or self.defined_tags
         payload.pop("spark_version", None)
         logger.debug(f"Creating a DataFlow Run with payload {payload}")
         run = DataFlowRun(**payload).create()

--- a/ads/jobs/builders/infrastructure/dataflow.py
+++ b/ads/jobs/builders/infrastructure/dataflow.py
@@ -803,7 +803,9 @@ class DataFlow(Infrastructure):
         return self.set_spec(self.CONST_DEFINED_TAGS, kwargs)
 
     def __getattr__(self, item):
-        if f"with_{item}" in self.__dir__() or (item == self.CONST_DEFINED_TAGS or self.CONST_FREEFORM_TAGS):
+        if item == (self.CONST_DEFINED_TAGS or self.CONST_FREEFORM_TAGS):
+            return self.get_spec(item)
+        elif f"with_{item}" in self.__dir__() and item != ("defined_tag" or "freeform_tag"):
             return self.get_spec(item)
         raise AttributeError(f"Attribute {item} not found.")
 

--- a/ads/jobs/builders/infrastructure/dataflow.py
+++ b/ads/jobs/builders/infrastructure/dataflow.py
@@ -803,9 +803,9 @@ class DataFlow(Infrastructure):
         return self.set_spec(self.CONST_DEFINED_TAGS, kwargs)
 
     def __getattr__(self, item):
-        if item == (self.CONST_DEFINED_TAGS or self.CONST_FREEFORM_TAGS):
+        if item == self.CONST_DEFINED_TAGS or item == self.CONST_FREEFORM_TAGS:
             return self.get_spec(item)
-        elif f"with_{item}" in self.__dir__() and item != ("defined_tag" or "freeform_tag"):
+        elif f"with_{item}" in self.__dir__() and item != "defined_tag" and item != "freeform_tag":
             return self.get_spec(item)
         raise AttributeError(f"Attribute {item} not found.")
 

--- a/ads/jobs/builders/infrastructure/dataflow.py
+++ b/ads/jobs/builders/infrastructure/dataflow.py
@@ -802,18 +802,8 @@ class DataFlow(Infrastructure):
         """
         return self.set_spec(self.CONST_DEFINED_TAGS, kwargs)
 
-    @property
-    def freeform_tags(self) -> dict:
-        """Freeform tags"""
-        return self.get_spec(self.CONST_FREEFORM_TAGS, {})
-
-    @property
-    def defined_tags(self) -> dict:
-        """Defined tags"""
-        return self.get_spec(self.CONST_DEFINED_TAGS, {})
-
     def __getattr__(self, item):
-        if f"with_{item}" in self.__dir__():
+        if f"with_{item}" in self.__dir__() or (item == self.CONST_DEFINED_TAGS or self.CONST_FREEFORM_TAGS):
             return self.get_spec(item)
         raise AttributeError(f"Attribute {item} not found.")
 

--- a/docs/source/user_guide/apachespark/dataflow.rst
+++ b/docs/source/user_guide/apachespark/dataflow.rst
@@ -207,6 +207,8 @@ You can set them using the ``with_{property}`` functions:
 - ``with_spark_version``
 - ``with_warehouse_bucket_uri``
 - ``with_private_endpoint_id`` (`doc <https://docs.oracle.com/en-us/iaas/data-flow/using/pe-allowing.htm#pe-allowing>`__)
+- ``with_defined_tags``
+- ``with_freeform_tags``
 
 For more details, see `Data Flow class documentation <https://docs.oracle.com/en-us/iaas/tools/ads-sdk/latest/ads.jobs.html#module-ads.jobs.builders.infrastructure.dataflow>`__.
 
@@ -229,10 +231,10 @@ create applications.
 
 In the following "hello-world" example, ``DataFlow`` is populated with ``compartment_id``,
 ``driver_shape``, ``driver_shape_config``, ``executor_shape``, ``executor_shape_config``
-and ``spark_version``. ``DataFlowRuntime`` is populated with ``script_uri`` and
-``script_bucket``. The ``script_uri`` specifies the path to the script. It can be
-local or remote (an Object Storage path). If the path is local, then
-``script_bucket`` must be specified additionally because Data Flow
+, ``spark_version``, ``defined_tags`` and ``freeform_tags``. ``DataFlowRuntime`` is 
+populated with ``script_uri`` and ``script_bucket``. The ``script_uri`` specifies the 
+path to the script. It can be local or remote (an Object Storage path). If the path
+is local, then ``script_bucket`` must be specified additionally because Data Flow
 requires a script to be available in Object Storage. ADS
 performs the upload step for you, as long as you give the bucket name
 or the Object Storage path prefix to upload the script. Either can be
@@ -272,6 +274,10 @@ accepted. In the next example, the prefix is given for ``script_bucket``.
 		    .with_executor_shape("VM.Standard.E4.Flex")
 		    .with_executor_shape_config(ocpus=4, memory_in_gbs=64)
             .with_spark_version("3.0.2")
+            .with_defined_tag(
+                **{"Oracle-Tags": {"CreatedBy": "test_name@oracle.com"}}
+            )
+            .with_freeform_tag(test_freeform_key="test_freeform_value")
         )
         runtime_config = (
             DataFlowRuntime()
@@ -393,6 +399,10 @@ In the next example, ``archive_uri`` is given as an Object Storage location.
                 "spark.driverEnv.myEnvVariable": "value1",
                 "spark.executorEnv.myEnvVariable": "value2",
             })
+            .with_defined_tag(
+                **{"Oracle-Tags": {"CreatedBy": "test_name@oracle.com"}}
+            )
+            .with_freeform_tag(test_freeform_key="test_freeform_value")
         )
         runtime_config = (
             DataFlowRuntime()
@@ -566,6 +576,11 @@ into the ``Job.from_yaml()`` function to build a Data Flow job:
         numExecutors: 1
         sparkVersion: 3.2.1
         privateEndpointId: <private_endpoint_ocid>
+        definedTags:
+          Oracle-Tags:
+            CreatedBy: test_name@oracle.com
+        freeformTags:
+          test_freeform_key: test_freeform_value
       type: dataFlow
     name: dataflow_app_name
     runtime:
@@ -647,6 +662,12 @@ into the ``Job.from_yaml()`` function to build a Data Flow job:
             configuration:
                 required: false
                 type: dict
+            definedTags:
+                required: false
+                type: dict
+            freeformTags:
+                required: false
+                type: dict
     type:
         allowed:
             - dataFlow
@@ -694,7 +715,10 @@ into the ``Job.from_yaml()`` function to build a Data Flow job:
             configuration:
                 required: false
                 type: dict
-            freeform_tag:
+            definedTags:
+                required: false
+                type: dict
+            freeformTags:
                 required: false
                 type: dict
             scriptBucket:

--- a/docs/source/user_guide/apachespark/quickstart.rst
+++ b/docs/source/user_guide/apachespark/quickstart.rst
@@ -45,6 +45,10 @@ followed by the spark version, 3.2.1.
             .with_executor_shape("VM.Standard.E4.Flex")
             .with_executor_shape_config(ocpus=4, memory_in_gbs=64)
             .with_spark_version("3.2.1")
+            .with_defined_tag(
+                **{"Oracle-Tags": {"CreatedBy": "test_name@oracle.com"}}
+            )
+            .with_freeform_tag(test_freeform_key="test_freeform_value")
         )
         runtime_config = (
             DataFlowRuntime()
@@ -95,6 +99,11 @@ Assuming you have the following two files written in your current directory as `
                   memory_in_gbs: 64
                 sparkVersion: 3.2.1
                 numExecutors: 1
+                definedTags:
+                  Oracle-Tags:
+                    CreatedBy: test_name@oracle.com
+                freeformTags:
+                  test_freeform_key: test_freeform_value
             type: dataFlow
         runtime:
             kind: runtime
@@ -185,6 +194,10 @@ From a Python Environment
             .with_executor_shape("VM.Standard.E4.Flex")
             .with_executor_shape_config(ocpus=4, memory_in_gbs=64)
             .with_spark_version("3.2.1")
+            .with_defined_tag(
+                **{"Oracle-Tags": {"CreatedBy": "test_name@oracle.com"}}
+            )
+            .with_freeform_tag(test_freeform_key="test_freeform_value")
         )
         runtime_config = (
             DataFlowRuntime()
@@ -275,6 +288,11 @@ Again, assume you have the following two files written in your current directory
                     memory_in_gbs: 64
                 sparkVersion: 3.2.1
                 numExecutors: 1
+                definedTags:
+                    Oracle-Tags:
+                        CreatedBy: test_name@oracle.com
+                freeformTags:
+                    test_freeform_key: test_freeform_value
             type: dataFlow
         runtime:
             kind: runtime

--- a/tests/unitary/default_setup/jobs/test_jobs_dataflow.py
+++ b/tests/unitary/default_setup/jobs/test_jobs_dataflow.py
@@ -320,6 +320,12 @@ class TestDataFlow(TestDataFlowApp, TestDataFlowRun):
                 2
             ).with_private_endpoint_id(
                 "test_private_endpoint"
+            ).with_freeform_tag(
+                test_freeform_tags_key="test_freeform_tags_value",
+            ).with_defined_tag(
+                test_defined_tags_namespace={
+                    "test_defined_tags_key": "test_defined_tags_value"
+                }
             )
         return df
 
@@ -327,6 +333,14 @@ class TestDataFlow(TestDataFlowApp, TestDataFlowRun):
         assert df.language == "PYTHON"
         assert df.spark_version == "3.2.1"
         assert df.num_executors == 2
+        assert df.freeform_tags == {
+            "test_freeform_tags_key": "test_freeform_tags_value"
+        }
+        assert df.defined_tags == {
+            "test_defined_tags_namespace": {
+                "test_defined_tags_key": "test_defined_tags_value"
+            }
+        }
 
         rt = (
             DataFlowRuntime()
@@ -335,9 +349,25 @@ class TestDataFlow(TestDataFlowApp, TestDataFlowRun):
             .with_custom_conda(
                 "oci://my_bucket@my_namespace/conda_environments/cpu/PySpark 3.0 and Data Flow/5.0/pyspark30_p37_cpu_v5"
             )
+            .with_freeform_tag(
+                test_freeform_tags_runtime_key="test_freeform_tags_runtime_value"
+            )
+            .with_defined_tag(
+                test_defined_tags_namespace={
+                    "test_defined_tags_runtime_key": "test_defined_tags_runtime_value"
+                }
+            )
             .with_overwrite(True)
         )
         assert rt.overwrite == True
+        assert rt.freeform_tags == {
+            "test_freeform_tags_runtime_key": "test_freeform_tags_runtime_value"
+        }
+        assert rt.defined_tags == {
+            "test_defined_tags_namespace": {
+                "test_defined_tags_runtime_key": "test_defined_tags_runtime_value"
+            }
+        }
 
         with patch.object(DataFlowApp, "client", mock_client):
             with patch.object(DataFlowApp, "to_dict", mock_to_dict):
@@ -429,6 +459,14 @@ class TestDataFlow(TestDataFlowApp, TestDataFlowRun):
         assert df_dict["spec"]["privateEndpointId"] == "test_private_endpoint"
         assert df_dict["spec"]["driverShapeConfig"] == {"memoryInGBs": 1, "ocpus": 16}
         assert df_dict["spec"]["executorShapeConfig"] == {"memoryInGBs": 1, "ocpus": 16}
+        assert df_dict["spec"]["freeformTags"] == {
+            "test_freeform_tags_key": "test_freeform_tags_value"
+        }
+        assert df_dict["spec"]["definedTags"] == {
+            "test_defined_tags_namespace": {
+                "test_defined_tags_key": "test_defined_tags_value"
+            }
+        }
 
         df_dict["spec"].pop("language")
         df_dict["spec"].pop("numExecutors")


### PR DESCRIPTION
### Added defined tags for data flow

- Added `with_freeform_tag()` and `with_defined_tag()` in `DataFlow` class. Note these two APIs end without `s` similar as [DataScienceJob](https://github.com/oracle/accelerated-data-science/blob/main/ads/jobs/builders/infrastructure/dsc_job.py#L1282-1300).

### Example
```
DataFlow()
.with_driver_shape("VM.Standard.E4.Flex")
.with_driver_shape_config(ocpus=2, memory_in_gbs=32)
.with_executor_shape("VM.Standard.E4.Flex")
.with_executor_shape_config(ocpus=4, memory_in_gbs=64)
.with_spark_version("3.2.1")
.with_freeform_tag(test_freeform_key="test_freeform_value")
.with_defined_tag(**{"Oracle-Tags": {"CreatedBy": "test_name@oracle.com"}})
```
<img width="1421" alt="Screenshot 2023-05-30 at 10 12 54 AM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/bbe8b54e-7764-4b88-8dbd-9564728de05c">

<img width="1426" alt="Screenshot 2023-05-30 at 10 13 51 AM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/622753ba-29f7-4f0d-9984-c05eeba2fa83">
