### PR TITLE
Added validation for driver and executor shape details.

### DIFF
--- a/ads/jobs/builders/infrastructure/dataflow.py
+++ b/ads/jobs/builders/infrastructure/dataflow.py
@@ -860,6 +860,18 @@ class DataFlow(Infrastructure):
             raise ValueError(
                 "Compartment id is required. Specify compartment id via 'with_compartment_id()'."
             )
+        if "executor_shape" not in payload:
+            payload["executor_shape"] = DEFAULT_SHAPE
+        if "driver_shape" not in payload:
+            payload["driver_shape"] = DEFAULT_SHAPE
+        executor_shape = payload["executor_shape"]
+        executor_shape_config = payload.get("executor_shape_config", {})
+        driver_shape = payload["driver_shape"]
+        driver_shape_config = payload.get("driver_shape_config", {})
+        if executor_shape != driver_shape:
+            raise ValueError("`executor_shape` and `driver_shape` must be from the same shape family.")
+        if (not executor_shape.endswith("Flex") and executor_shape_config) or (not driver_shape.endswith("Flex") and driver_shape_config):
+            raise ValueError("Shape config is not required for non flex shape from user end.")
         payload.pop("id", None)
         logger.debug(f"Creating a DataFlow Application with payload {payload}")
         self.df_app = DataFlowApp(**payload).create()

--- a/ads/jobs/builders/infrastructure/dataflow.py
+++ b/ads/jobs/builders/infrastructure/dataflow.py
@@ -42,6 +42,13 @@ DEFAULT_LANGUAGE = "PYTHON"
 DEFAULT_SPARK_VERSION = "3.2.1"
 DEFAULT_NUM_EXECUTORS = 1
 DEFAULT_SHAPE = "VM.Standard.E3.Flex"
+DATAFLOW_SHAPE_FAMILY = [
+    "Standard.E3",
+    "Standard.E4",
+    "Standard3",
+    "Standard.A1",
+    "Standard2"
+]
 
 
 def conda_pack_name_to_dataflow_config(conda_uri):
@@ -860,6 +867,15 @@ class DataFlow(Infrastructure):
             raise ValueError(
                 "Compartment id is required. Specify compartment id via 'with_compartment_id()'."
             )
+        self._validate_shapes(payload)
+        payload.pop("id", None)
+        logger.debug(f"Creating a DataFlow Application with payload {payload}")
+        self.df_app = DataFlowApp(**payload).create()
+        self.with_id(self.df_app.id)
+        return self
+    
+    @staticmethod
+    def _validate_shapes(payload: Dict):
         if "executor_shape" not in payload:
             payload["executor_shape"] = DEFAULT_SHAPE
         if "driver_shape" not in payload:
@@ -868,15 +884,22 @@ class DataFlow(Infrastructure):
         executor_shape_config = payload.get("executor_shape_config", {})
         driver_shape = payload["driver_shape"]
         driver_shape_config = payload.get("driver_shape_config", {})
-        if executor_shape != driver_shape:
-            raise ValueError("`executor_shape` and `driver_shape` must be from the same shape family.")
-        if (not executor_shape.endswith("Flex") and executor_shape_config) or (not driver_shape.endswith("Flex") and driver_shape_config):
-            raise ValueError("Shape config is not required for non flex shape from user end.")
-        payload.pop("id", None)
-        logger.debug(f"Creating a DataFlow Application with payload {payload}")
-        self.df_app = DataFlowApp(**payload).create()
-        self.with_id(self.df_app.id)
-        return self
+        same_shape_family = False
+        for shape in DATAFLOW_SHAPE_FAMILY:
+            if shape in executor_shape and shape in driver_shape:
+                same_shape_family = True
+                break
+        if not same_shape_family:
+            raise ValueError(
+                "`executor_shape` and `driver_shape` must be from the same shape family."
+            )
+        if (
+            (not executor_shape.endswith("Flex") and executor_shape_config) 
+            or (not driver_shape.endswith("Flex") and driver_shape_config)
+        ):
+            raise ValueError(
+                "Shape config is not required for non flex shape from user end."
+            )
 
     @staticmethod
     def _upload_file(local_path, bucket, overwrite=False):

--- a/tests/unitary/default_setup/jobs/test_jobs_dataflow.py
+++ b/tests/unitary/default_setup/jobs/test_jobs_dataflow.py
@@ -448,7 +448,7 @@ class TestDataFlow(TestDataFlowApp, TestDataFlowRun):
         df.with_driver_shape(
             "VM.Standard2.1"
         ).with_executor_shape(
-            "VM.Standard2.8"
+            "VM.Standard.E4.Flex"
         )
 
         rt = (
@@ -475,7 +475,7 @@ class TestDataFlow(TestDataFlowApp, TestDataFlowRun):
             memory_in_gbs=SAMPLE_PAYLOAD["driver_shape_config"]["memory_in_gbs"],
             ocpus=SAMPLE_PAYLOAD["driver_shape_config"]["ocpus"],
         ).with_executor_shape(
-            "VM.Standard2.1"
+            "VM.Standard2.16"
         ).with_executor_shape_config(
             memory_in_gbs=SAMPLE_PAYLOAD["executor_shape_config"]["memory_in_gbs"],
             ocpus=SAMPLE_PAYLOAD["executor_shape_config"]["ocpus"],

--- a/tests/unitary/default_setup/jobs/test_jobs_dataflow.py
+++ b/tests/unitary/default_setup/jobs/test_jobs_dataflow.py
@@ -37,9 +37,9 @@ SAMPLE_PAYLOAD = dict(
     arguments=["test-df"],
     compartment_id="ocid1.compartment.oc1..<unique_ocid>",
     display_name="test-df",
-    driver_shape="VM.Standard2.1",
+    driver_shape="VM.Standard.E4.Flex",
     driver_shape_config={"memory_in_gbs": 1, "ocpus": 16},
-    executor_shape="VM.Standard2.1",
+    executor_shape="VM.Standard.E4.Flex",
     executor_shape_config={"memory_in_gbs": 1, "ocpus": 16},
     file_uri="oci://test_bucket@test_namespace/test-dataflow/test-dataflow.py",
     num_executors=1,
@@ -124,7 +124,7 @@ class TestDataFlowApp:
                     df.lifecycle_state
                     == oci.data_flow.models.Application.LIFECYCLE_STATE_DELETED
                 )
-                assert len(df.to_yaml()) == 557
+                assert len(df.to_yaml()) == 567
 
     def test_create_df_app_with_default_display_name(
         self,
@@ -403,8 +403,8 @@ class TestDataFlow(TestDataFlowApp, TestDataFlowRun):
         mock_from_ocid.return_value = Application(**SAMPLE_PAYLOAD)
         df = DataFlow.from_id("ocid1.datasciencejob.oc1.iad.<unique_ocid>")
         assert df.name == "test-df"
-        assert df.driver_shape == "VM.Standard2.1"
-        assert df.executor_shape == "VM.Standard2.1"
+        assert df.driver_shape == "VM.Standard.E4.Flex"
+        assert df.executor_shape == "VM.Standard.E4.Flex"
         assert df.private_endpoint_id == "test_private_endpoint"
 
         assert (
@@ -424,7 +424,7 @@ class TestDataFlow(TestDataFlowApp, TestDataFlowRun):
     def test_to_and_from_dict(self, df):
         df_dict = df.to_dict()
         assert df_dict["spec"]["numExecutors"] == 2
-        assert df_dict["spec"]["driverShape"] == "VM.Standard2.1"
+        assert df_dict["spec"]["driverShape"] == "VM.Standard.E4.Flex"
         assert df_dict["spec"]["logsBucketUri"] == "oci://test_bucket@test_namespace/"
         assert df_dict["spec"]["privateEndpointId"] == "test_private_endpoint"
         assert df_dict["spec"]["driverShapeConfig"] == {"memoryInGBs": 1, "ocpus": 16}
@@ -444,6 +444,51 @@ class TestDataFlow(TestDataFlowApp, TestDataFlowRun):
         assert df3_dict["spec"]["sparkVersion"] == "3.2.1"
         assert df3_dict["spec"]["numExecutors"] == 2
 
+    def test_shape_and_details(self, mock_to_dict, mock_client, df):
+        df.with_driver_shape(
+            "VM.Standard2.1"
+        ).with_executor_shape(
+            "VM.Standard2.8"
+        )
+
+        rt = (
+            DataFlowRuntime()
+                .with_script_uri(SAMPLE_PAYLOAD["file_uri"])
+                .with_archive_uri(SAMPLE_PAYLOAD["archive_uri"])
+                .with_custom_conda(
+                    "oci://my_bucket@my_namespace/conda_environments/cpu/PySpark 3.0 and Data Flow/5.0/pyspark30_p37_cpu_v5"
+                )
+                .with_overwrite(True)
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="`executor_shape` and `driver_shape` must be from the same shape family."
+        ):
+            with patch.object(DataFlowApp, "client", mock_client):
+                with patch.object(DataFlowApp, "to_dict", mock_to_dict):
+                    df.create(rt)
+
+        df.with_driver_shape(
+            "VM.Standard2.1"
+        ).with_driver_shape_config(
+            memory_in_gbs=SAMPLE_PAYLOAD["driver_shape_config"]["memory_in_gbs"],
+            ocpus=SAMPLE_PAYLOAD["driver_shape_config"]["ocpus"],
+        ).with_executor_shape(
+            "VM.Standard2.1"
+        ).with_executor_shape_config(
+            memory_in_gbs=SAMPLE_PAYLOAD["executor_shape_config"]["memory_in_gbs"],
+            ocpus=SAMPLE_PAYLOAD["executor_shape_config"]["ocpus"],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="Shape config is not required for non flex shape from user end."
+        ):
+            with patch.object(DataFlowApp, "client", mock_client):
+                with patch.object(DataFlowApp, "to_dict", mock_to_dict):
+                    df.create(rt)
+            
 
 class TestDataFlowNotebookRuntime:
     @pytest.mark.skipif(


### PR DESCRIPTION
### Added validation for driver and executor shape details of DataFlow.

Validation for:
- `executor_shape` and `driver_shape` must be the same shape family.
- No shape config is needed for non-flex shape

<img width="1221" alt="Screenshot 2023-05-30 at 2 28 17 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/fc1a5da6-faf8-467e-896e-45a5151df463">
<img width="1206" alt="Screenshot 2023-05-30 at 2 28 59 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/9d6e5d5a-dd58-4dab-90da-e97f8b39737a">
