### PR TITLE
Support uploading large artifact for model deployment.

### DIFF
--- a/ads/model/deployment/model_deployment.py
+++ b/ads/model/deployment/model_deployment.py
@@ -70,7 +70,6 @@ MODEL_DEPLOYMENT_INSTANCE_MEMORY_IN_GBS = 16
 MODEL_DEPLOYMENT_INSTANCE_COUNT = 1
 MODEL_DEPLOYMENT_BANDWIDTH_MBPS = 10
 
-MAX_ARTIFACT_SIZE_IN_BYTES = 2147483648  # 2GB
 
 class ModelDeploymentLogType:
     PREDICT = "predict"
@@ -1567,13 +1566,6 @@ class ModelDeployment(Builder):
 
         model_id = runtime.model_uri
         if not model_id.startswith("ocid"):
-            if ads_utils.folder_size(runtime.model_uri) > MAX_ARTIFACT_SIZE_IN_BYTES:
-                if not runtime.bucket_uri:
-                    raise ValueError(
-                        f"The model artifacts size is greater than `{MAX_ARTIFACT_SIZE_IN_BYTES}`. "
-                        "The `bucket_uri` needs to be specified to copy artifacts to the object storage bucket. "
-                        "Example: `runtime.with_bucket_uri(oci://<bucket_name>@<namespace>/prefix/)`"
-                    )
             
             from ads.model.datascience_model import DataScienceModel
             

--- a/ads/model/deployment/model_deployment.py
+++ b/ads/model/deployment/model_deployment.py
@@ -1583,7 +1583,7 @@ class ModelDeployment(Builder):
                 or COMPARTMENT_OCID,
                 project_id=self.infrastructure.project_id or PROJECT_OCID,
                 artifact=runtime.model_uri,
-            ).upload_artifact(
+            ).create(
                 bucket_uri=runtime.bucket_uri,
                 auth=runtime.auth,
                 region=runtime.region,

--- a/ads/model/deployment/model_deployment_runtime.py
+++ b/ads/model/deployment/model_deployment_runtime.py
@@ -36,6 +36,18 @@ class ModelDeploymentRuntime(Builder):
         The output stream ids of model deployment.
     model_uri: str
         The model uri of model deployment.
+    bucket_uri: str
+        The OCI Object Storage URI where large size model artifacts will be copied to.
+    auth: Dict
+        The default authentication is set using `ads.set_auth` API.
+    region: str
+        The destination Object Storage bucket region.
+    overwrite_existing_artifact: bool
+        Whether overwrite existing target bucket artifact or not.
+    remove_existing_artifact: bool
+        Whether artifacts uploaded to object storage bucket need to be removed or not.
+    timeout: int
+        The connection timeout in seconds for the client.
 
     Methods
     -------
@@ -49,6 +61,18 @@ class ModelDeploymentRuntime(Builder):
         Sets the output stream ids of model deployment
     with_model_uri(model_uri)
         Sets the model uri of model deployment
+    with_bucket_uri(bucket_uri)
+        Sets the bucket uri when uploading large size model.
+    with_auth(auth)
+        Sets the default authentication when uploading large size model.
+    with_region(region)
+        Sets the region when uploading large size model.
+    with_overwrite_existing_artifact(overwrite_existing_artifact)
+        Sets whether to overwrite existing artifact when uploading large size model.
+    with_remove_existing_artifact(remove_existing_artifact)
+        Sets whether to remove existing artifact when uploading large size model.
+    with_timeout(timeout)
+        Sets the connection timeout when uploading large size model.
     """
 
     CONST_MODEL_ID = "modelId"
@@ -60,6 +84,12 @@ class ModelDeploymentRuntime(Builder):
     CONST_INPUT_STREAM_IDS = "inputStreamIds"
     CONST_OUTPUT_STREAM_IDS = "outputStreamIds"
     CONST_ENVIRONMENT_CONFIG_DETAILS = "environmentConfigurationDetails"
+    CONST_BUCKET_URI = "bucketUri"
+    CONST_AUTH = "auth"
+    CONST_REGION = "region"
+    CONST_OVERWRITE_EXISTING_ARTIFACT = "overwriteExistingArtifact"
+    CONST_REMOVE_EXISTING_ARTIFACT = "removeExistingArtifact"
+    CONST_TIMEOUT = "timeout"
 
     attribute_map = {
         CONST_ENV: "env",
@@ -68,6 +98,12 @@ class ModelDeploymentRuntime(Builder):
         CONST_OUTPUT_STREAM_IDS: "output_stream_ids",
         CONST_DEPLOYMENT_MODE: "deployment_mode",
         CONST_MODEL_URI: "model_uri",
+        CONST_BUCKET_URI: "bucket_uri",
+        CONST_AUTH: "auth",
+        CONST_REGION: "region",
+        CONST_OVERWRITE_EXISTING_ARTIFACT: "overwrite_existing_artifact",
+        CONST_REMOVE_EXISTING_ARTIFACT: "remove_existing_artifact",
+        CONST_TIMEOUT: "timeout"
     }
 
     ENVIRONMENT_CONFIG_DETAILS_PATH = (
@@ -236,7 +272,172 @@ class ModelDeploymentRuntime(Builder):
             The ModelDeploymentRuntime instance (self).
         """
         return self.set_spec(self.CONST_MODEL_URI, model_uri)
+    
+    @property
+    def bucket_uri(self) -> str:
+        """The bucket uri of model.
 
+        Returns
+        -------
+        str
+            The bucket uri of model.
+        """
+        return self.get_spec(self.CONST_BUCKET_URI, None)
+
+    def with_bucket_uri(self, bucket_uri: str) -> "ModelDeploymentRuntime":
+        """Sets the bucket uri of model.
+
+        Parameters
+        ----------
+        bucket_uri: str
+            The bucket uri of model.
+
+        Returns
+        -------
+        ModelDeploymentRuntime
+            The ModelDeploymentRuntime instance (self).
+        """
+        return self.set_spec(self.CONST_BUCKET_URI, bucket_uri)
+    
+    @property
+    def auth(self) -> Dict:
+        """The auth when uploading large-size model.
+
+        Returns
+        -------
+        Dict
+            The auth when uploading large-size model.
+        """
+        return self.get_spec(self.CONST_AUTH, {})
+    
+    def with_auth(self, auth: Dict) -> "ModelDeploymentRuntime":
+        """Sets the auth when uploading large-size model.
+
+        Parameters
+        ----------
+        auth: Dict
+            The auth when uploading large-size model.
+
+        Returns
+        -------
+        ModelDeploymentRuntime
+            The ModelDeploymentRuntime instance (self).
+        """
+        return self.set_spec(self.CONST_AUTH, auth)
+    
+    @property
+    def region(self) -> str:
+        """The region when uploading large-size model.
+
+        Returns
+        -------
+        str
+            The region when uploading large-size model.
+        """
+        return self.get_spec(self.CONST_REGION, None)
+    
+    def with_region(self, region: str) -> "ModelDeploymentRuntime":
+        """Sets the region when uploading large-size model.
+
+        Parameters
+        ----------
+        region: str
+            The region when uploading large-size model.
+
+        Returns
+        -------
+        ModelDeploymentRuntime
+            The ModelDeploymentRuntime instance (self).
+        """
+        return self.set_spec(self.CONST_REGION, region)
+    
+    @property
+    def overwrite_existing_artifact(self) -> bool:
+        """Overwrite existing artifact when uploading large size model.
+
+        Returns
+        -------
+        bool
+            Overwrite existing artifact when uploading large size model.
+        """
+        return self.get_spec(self.CONST_OVERWRITE_EXISTING_ARTIFACT, True)
+    
+    def with_overwrite_existing_artifact(
+        self, 
+        overwrite_existing_artifact: bool
+    ) -> "ModelDeploymentRuntime":
+        """Sets whether to overwrite existing artifact when uploading large size model.
+
+        Parameters
+        ----------
+        overwrite_existing_artifact: bool
+            Overwrite existing artifact when uploading large size model.
+
+        Returns
+        -------
+        ModelDeploymentRuntime
+            The ModelDeploymentRuntime instance (self).
+        """
+        return self.set_spec(
+            self.CONST_OVERWRITE_EXISTING_ARTIFACT,
+            overwrite_existing_artifact
+        )
+    
+    @property
+    def remove_existing_artifact(self) -> bool:
+        """Remove existing artifact when uploading large size model.
+
+        Returns
+        -------
+        bool
+            Remove existing artifact when uploading large size model.
+        """
+        return self.get_spec(self.CONST_REMOVE_EXISTING_ARTIFACT, True)
+    
+    def with_remove_existing_artifact(
+        self,
+        remove_existing_artifact: bool
+    ) -> "ModelDeploymentRuntime":
+        """Sets whether to remove existing artifact when uploading large size model.
+
+        Parameters
+        ----------
+        remove_existing_artifact: bool
+            Remove existing artifact when uploading large size model.
+
+        Returns
+        -------
+        ModelDeploymentRuntime
+            The ModelDeploymentRuntime instance (self).
+        """
+        return self.set_spec(self.CONST_REMOVE_EXISTING_ARTIFACT, remove_existing_artifact)
+    
+    @property
+    def timeout(self) -> int:
+        """The timeout when uploading large-size model.
+
+        Returns
+        -------
+        int
+            The timeout when uploading large-size model.
+        """
+        return self.get_spec(self.CONST_TIMEOUT, None)
+    
+    def with_timeout(self, timeout: int) -> "ModelDeploymentRuntime":
+        """Sets the timeout when uploading large-size model.
+
+        Parameters
+        ----------
+        timeout: int
+            The timeout when uploading large-size model.
+
+        Returns
+        -------
+        ModelDeploymentRuntime
+            The ModelDeploymentRuntime instance (self).
+        """
+        return self.set_spec(self.CONST_TIMEOUT, timeout)
+    
     def init(self) -> "ModelDeploymentRuntime":
         """Initializes a starter specification for the runtime.
 

--- a/docs/source/user_guide/model_registration/model_deploy_byoc.rst
+++ b/docs/source/user_guide/model_registration/model_deploy_byoc.rst
@@ -114,7 +114,13 @@ Below is an example of deploying model on container runtime using ``ModelDeploym
         .with_health_check_port(5000)
         .with_env({"key":"value"})
         .with_deployment_mode("HTTPS_ONLY")
-        .with_model_uri("<MODEL_URI>")
+        .with_model_uri("<path_to_artifact>")
+        .with_auth({"auth_key":"auth_value"})
+        .with_region("us-ashburn-1")
+        .with_overwrite_existing_artifact(True)
+        .with_remove_existing_artifact(True)
+        .with_timeout(100)
+        .with_bucket_uri("oci://<bucket>@<namespace>/<prefix>")
     )
 
     # configure model deployment
@@ -169,7 +175,7 @@ Below is an example of deploying model on container runtime using ``ModelDeploym
         kind: runtime
         type: container
         spec:
-          modelUri: <MODEL_URI>
+          modelUri: <path_to_artifact>
           image: iad.ocir.io/<namespace>/<image>:<tag>
           imageDigest: <IMAGE_DIGEST>
           entrypoint: ["python","/opt/ds/model/deployed_model/api.py"]
@@ -177,6 +183,13 @@ Below is an example of deploying model on container runtime using ``ModelDeploym
           healthCheckPort: 5000
           env:
             WEB_CONCURRENCY: "10"
+          auth:
+            auth_key: auth_value
+          region: us-ashburn-1
+          overwriteExistingArtifact: True
+          removeExistingArtifact: True
+          timeout: 100
+          bucketUri: oci://<bucket>@<namespace>/<prefix>
           deploymentMode: HTTPS_ONLY
     """
 

--- a/tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py
+++ b/tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py
@@ -537,17 +537,17 @@ spec:
             },
         }
 
-    @patch.object(DataScienceModel, "upload_artifact")
-    def test_build_model_deployment_configuration_details(self, mock_upload_artifact):
+    @patch.object(DataScienceModel, "create")
+    def test_build_model_deployment_configuration_details(self, mock_create):
         dsc_model = MagicMock()
         dsc_model.id = "fakeid.datasciencemodel.oc1.iad.xxx"
-        mock_upload_artifact.return_value = dsc_model
+        mock_create.return_value = dsc_model
         model_deployment = self.initialize_model_deployment()
         model_deployment_configuration_details = (
             model_deployment._build_model_deployment_configuration_details()
         )
 
-        mock_upload_artifact.assert_called()
+        mock_create.assert_called()
         assert model_deployment_configuration_details == {
             "deploymentType": "SINGLE_MODEL",
             "modelConfigurationDetails": {
@@ -593,17 +593,17 @@ spec:
             },
         }
 
-    @patch.object(DataScienceModel, "upload_artifact")
-    def test_build_model_deployment_details(self, mock_upload_artifact):
+    @patch.object(DataScienceModel, "create")
+    def test_build_model_deployment_details(self, mock_create):
         dsc_model = MagicMock()
         dsc_model.id = "fakeid.datasciencemodel.oc1.iad.xxx"
-        mock_upload_artifact.return_value = dsc_model
+        mock_create.return_value = dsc_model
         model_deployment = self.initialize_model_deployment()
         create_model_deployment_details = (
             model_deployment._build_model_deployment_details()
         )
 
-        mock_upload_artifact.assert_called()
+        mock_create.assert_called()
 
         assert isinstance(
             create_model_deployment_details,
@@ -886,17 +886,17 @@ spec:
 
         assert new_model_deployment.to_dict() == model_deployment.to_dict()
 
-    @patch.object(DataScienceModel, "upload_artifact")
-    def test_update_model_deployment_details(self, mock_upload_artifact):
+    @patch.object(DataScienceModel, "create")
+    def test_update_model_deployment_details(self, mock_create):
         dsc_model = MagicMock()
         dsc_model.id = "fakeid.datasciencemodel.oc1.iad.xxx"
-        mock_upload_artifact.return_value = dsc_model        
+        mock_create.return_value = dsc_model        
         model_deployment = self.initialize_model_deployment()
         update_model_deployment_details = (
             model_deployment._update_model_deployment_details()
         )
 
-        mock_upload_artifact.assert_called()
+        mock_create.assert_called()
 
         assert isinstance(
             update_model_deployment_details,
@@ -1130,13 +1130,13 @@ spec:
         oci.data_science.DataScienceClient,
         "create_model_deployment",
     )
-    @patch.object(DataScienceModel, "upload_artifact")
+    @patch.object(DataScienceModel, "create")
     def test_deploy(
-        self, mock_upload_artifact, mock_create_model_deployment, mock_sync
+        self, mock_create, mock_create_model_deployment, mock_sync
     ):
         dsc_model = MagicMock()
         dsc_model.id = "fakeid.datasciencemodel.oc1.iad.xxx"
-        mock_upload_artifact.return_value = dsc_model
+        mock_create.return_value = dsc_model
         response = MagicMock()
         response.data = OCI_MODEL_DEPLOYMENT_RESPONSE
         mock_create_model_deployment.return_value = response
@@ -1146,7 +1146,7 @@ spec:
             model_deployment._build_model_deployment_details()
         )
         model_deployment.deploy(wait_for_completion=False)
-        mock_upload_artifact.assert_called()
+        mock_create.assert_called()
         mock_create_model_deployment.assert_called_with(create_model_deployment_details)
         mock_sync.assert_called()
 
@@ -1155,13 +1155,13 @@ spec:
         oci.data_science.DataScienceClient,
         "create_model_deployment",
     )
-    @patch.object(DataScienceModel, "upload_artifact")
+    @patch.object(DataScienceModel, "create")
     def test_deploy_failed(
-        self, mock_upload_artifact, mock_create_model_deployment, mock_sync
+        self, mock_create, mock_create_model_deployment, mock_sync
     ):
         dsc_model = MagicMock()
         dsc_model.id = "fakeid.datasciencemodel.oc1.iad.xxx"
-        mock_upload_artifact.return_value = dsc_model
+        mock_create.return_value = dsc_model
         response = oci.response.Response(
             status=MagicMock(),
             headers=MagicMock(),
@@ -1182,7 +1182,7 @@ spec:
             match=f"Model deployment {response.data.id} failed to deploy: {response.data.lifecycle_details}",
         ):
             model_deployment.deploy(wait_for_completion=False)
-            mock_upload_artifact.assert_called()
+            mock_create.assert_called()
             mock_create_model_deployment.assert_called_with(
                 create_model_deployment_details
             )
@@ -1238,16 +1238,16 @@ spec:
         oci.data_science.DataScienceClientCompositeOperations,
         "update_model_deployment_and_wait_for_state",
     )
-    @patch.object(DataScienceModel, "upload_artifact")
+    @patch.object(DataScienceModel, "create")
     def test_update(
         self,
-        mock_upload_artifact,
+        mock_create,
         mock_update_model_deployment_and_wait_for_state,
         mock_sync,
     ):
         dsc_model = MagicMock()
         dsc_model.id = "fakeid.datasciencemodel.oc1.iad.xxx"
-        mock_upload_artifact.return_value = dsc_model
+        mock_create.return_value = dsc_model
         response = MagicMock()
         response.data = OCI_MODEL_DEPLOYMENT_RESPONSE
         mock_update_model_deployment_and_wait_for_state.return_value = response
@@ -1257,7 +1257,7 @@ spec:
             model_deployment._update_model_deployment_details()
         )
         model_deployment.update(wait_for_completion=True)
-        mock_upload_artifact.assert_called()
+        mock_create.assert_called()
         mock_update_model_deployment_and_wait_for_state.assert_called_with(
             "test_model_deployment_id",
             update_model_deployment_details,
@@ -1389,18 +1389,18 @@ spec:
         oci.data_science.DataScienceClient,
         "create_model_deployment",
     )
-    @patch.object(DataScienceModel, "upload_artifact")
+    @patch.object(DataScienceModel, "create")
     @patch.object(utils, "folder_size")
     def test_model_deployment_with_large_size_artifact(
         self, 
         mock_folder_size,
-        mock_upload_artifact, 
+        mock_create, 
         mock_create_model_deployment, 
         mock_sync
     ):
         dsc_model = MagicMock()
         dsc_model.id = "fakeid.datasciencemodel.oc1.iad.xxx"
-        mock_upload_artifact.return_value = dsc_model
+        mock_create.return_value = dsc_model
         model_deployment = self.initialize_model_deployment()
         (
             model_deployment.runtime
@@ -1435,7 +1435,7 @@ spec:
             model_deployment._build_model_deployment_details()
         )
         model_deployment.deploy(wait_for_completion=False)
-        mock_upload_artifact.assert_called_with(
+        mock_create.assert_called_with(
             bucket_uri="test_bucket_uri",
             auth={"test_key":"test_value"},
             region="test_region",

--- a/tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py
+++ b/tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py
@@ -14,8 +14,9 @@ from unittest.mock import MagicMock, patch
 from ads.common.oci_datascience import OCIDataScienceMixin
 from ads.common.oci_logging import ConsolidatedLog, OCILog
 from ads.common.oci_mixin import OCIModelMixin
-from ads.model.deployment.common.utils import OCIClientManager, State
+from ads.model.deployment.common.utils import State
 from ads.common.oci_datascience import DSCNotebookSession
+from ads.model.datascience_model import DataScienceModel
 
 from ads.model.deployment.model_deployment import (
     ModelDeployment,
@@ -534,22 +535,17 @@ spec:
             },
         }
 
-    @patch.object(OCIClientManager, "prepare_artifact")
-    def test_build_model_deployment_configuration_details(self, mock_prepare_artifact):
-        mock_prepare_artifact.return_value = "fakeid.datasciencemodel.oc1.iad.xxx"
+    @patch.object(DataScienceModel, "upload_artifact")
+    def test_build_model_deployment_configuration_details(self, mock_upload_artifact):
+        dsc_model = MagicMock()
+        dsc_model.id = "fakeid.datasciencemodel.oc1.iad.xxx"
+        mock_upload_artifact.return_value = dsc_model
         model_deployment = self.initialize_model_deployment()
         model_deployment_configuration_details = (
             model_deployment._build_model_deployment_configuration_details()
         )
 
-        mock_prepare_artifact.assert_called_with(
-            model_uri=model_deployment.runtime.model_uri,
-            properties={
-                "display_name": model_deployment.display_name,
-                "compartment_id": model_deployment.infrastructure.compartment_id,
-                "project_id": model_deployment.infrastructure.project_id,
-            },
-        )
+        mock_upload_artifact.assert_called()
         assert model_deployment_configuration_details == {
             "deploymentType": "SINGLE_MODEL",
             "modelConfigurationDetails": {
@@ -595,22 +591,17 @@ spec:
             },
         }
 
-    @patch.object(OCIClientManager, "prepare_artifact")
-    def test_build_model_deployment_details(self, mock_prepare_artifact):
-        mock_prepare_artifact.return_value = "fakeid.datasciencemodel.oc1.iad.xxx"
+    @patch.object(DataScienceModel, "upload_artifact")
+    def test_build_model_deployment_details(self, mock_upload_artifact):
+        dsc_model = MagicMock()
+        dsc_model.id = "fakeid.datasciencemodel.oc1.iad.xxx"
+        mock_upload_artifact.return_value = dsc_model
         model_deployment = self.initialize_model_deployment()
         create_model_deployment_details = (
             model_deployment._build_model_deployment_details()
         )
 
-        mock_prepare_artifact.assert_called_with(
-            model_uri=model_deployment.runtime.model_uri,
-            properties={
-                "display_name": model_deployment.display_name,
-                "compartment_id": model_deployment.infrastructure.compartment_id,
-                "project_id": model_deployment.infrastructure.project_id,
-            },
-        )
+        mock_upload_artifact.assert_called()
 
         assert isinstance(
             create_model_deployment_details,
@@ -893,22 +884,17 @@ spec:
 
         assert new_model_deployment.to_dict() == model_deployment.to_dict()
 
-    @patch.object(OCIClientManager, "prepare_artifact")
-    def test_update_model_deployment_details(self, mock_prepare_artifact):
-        mock_prepare_artifact.return_value = "fakeid.datasciencemodel.oc1.iad.xxx"
+    @patch.object(DataScienceModel, "upload_artifact")
+    def test_update_model_deployment_details(self, mock_upload_artifact):
+        dsc_model = MagicMock()
+        dsc_model.id = "fakeid.datasciencemodel.oc1.iad.xxx"
+        mock_upload_artifact.return_value = dsc_model        
         model_deployment = self.initialize_model_deployment()
         update_model_deployment_details = (
             model_deployment._update_model_deployment_details()
         )
 
-        mock_prepare_artifact.assert_called_with(
-            model_uri=model_deployment.runtime.model_uri,
-            properties={
-                "display_name": model_deployment.display_name,
-                "compartment_id": model_deployment.infrastructure.compartment_id,
-                "project_id": model_deployment.infrastructure.project_id,
-            },
-        )
+        mock_upload_artifact.assert_called()
 
         assert isinstance(
             update_model_deployment_details,
@@ -1142,11 +1128,13 @@ spec:
         oci.data_science.DataScienceClient,
         "create_model_deployment",
     )
-    @patch.object(OCIClientManager, "prepare_artifact")
+    @patch.object(DataScienceModel, "upload_artifact")
     def test_deploy(
-        self, mock_prepare_artifact, mock_create_model_deployment, mock_sync
+        self, mock_upload_artifact, mock_create_model_deployment, mock_sync
     ):
-        mock_prepare_artifact.return_value = "fakeid.datasciencemodel.oc1.iad.xxx"
+        dsc_model = MagicMock()
+        dsc_model.id = "fakeid.datasciencemodel.oc1.iad.xxx"
+        mock_upload_artifact.return_value = dsc_model
         response = MagicMock()
         response.data = OCI_MODEL_DEPLOYMENT_RESPONSE
         mock_create_model_deployment.return_value = response
@@ -1156,7 +1144,7 @@ spec:
             model_deployment._build_model_deployment_details()
         )
         model_deployment.deploy(wait_for_completion=False)
-        mock_prepare_artifact.assert_called()
+        mock_upload_artifact.assert_called()
         mock_create_model_deployment.assert_called_with(create_model_deployment_details)
         mock_sync.assert_called()
 
@@ -1165,11 +1153,13 @@ spec:
         oci.data_science.DataScienceClient,
         "create_model_deployment",
     )
-    @patch.object(OCIClientManager, "prepare_artifact")
+    @patch.object(DataScienceModel, "upload_artifact")
     def test_deploy_failed(
-        self, mock_prepare_artifact, mock_create_model_deployment, mock_sync
+        self, mock_upload_artifact, mock_create_model_deployment, mock_sync
     ):
-        mock_prepare_artifact.return_value = "fakeid.datasciencemodel.oc1.iad.xxx"
+        dsc_model = MagicMock()
+        dsc_model.id = "fakeid.datasciencemodel.oc1.iad.xxx"
+        mock_upload_artifact.return_value = dsc_model
         response = oci.response.Response(
             status=MagicMock(),
             headers=MagicMock(),
@@ -1190,7 +1180,7 @@ spec:
             match=f"Model deployment {response.data.id} failed to deploy: {response.data.lifecycle_details}",
         ):
             model_deployment.deploy(wait_for_completion=False)
-            mock_prepare_artifact.assert_called()
+            mock_upload_artifact.assert_called()
             mock_create_model_deployment.assert_called_with(
                 create_model_deployment_details
             )
@@ -1246,14 +1236,16 @@ spec:
         oci.data_science.DataScienceClientCompositeOperations,
         "update_model_deployment_and_wait_for_state",
     )
-    @patch.object(OCIClientManager, "prepare_artifact")
+    @patch.object(DataScienceModel, "upload_artifact")
     def test_update(
         self,
-        mock_prepare_artifact,
+        mock_upload_artifact,
         mock_update_model_deployment_and_wait_for_state,
         mock_sync,
     ):
-        mock_prepare_artifact.return_value = "fakeid.datasciencemodel.oc1.iad.xxx"
+        dsc_model = MagicMock()
+        dsc_model.id = "fakeid.datasciencemodel.oc1.iad.xxx"
+        mock_upload_artifact.return_value = dsc_model
         response = MagicMock()
         response.data = OCI_MODEL_DEPLOYMENT_RESPONSE
         mock_update_model_deployment_and_wait_for_state.return_value = response
@@ -1263,7 +1255,7 @@ spec:
             model_deployment._update_model_deployment_details()
         )
         model_deployment.update(wait_for_completion=True)
-        mock_prepare_artifact.assert_called()
+        mock_upload_artifact.assert_called()
         mock_update_model_deployment_and_wait_for_state.assert_called_with(
             "test_model_deployment_id",
             update_model_deployment_details,
@@ -1389,3 +1381,57 @@ spec:
 
         model_deployment.infrastructure.with_subnet_id("test_id")
         assert model_deployment.infrastructure.subnet_id == "test_id"
+
+    @patch.object(OCIDataScienceMixin, "sync")
+    @patch.object(
+        oci.data_science.DataScienceClient,
+        "create_model_deployment",
+    )
+    @patch.object(DataScienceModel, "upload_artifact")
+    def test_model_deployment_with_large_size_artifact(
+        self, 
+        mock_upload_artifact, 
+        mock_create_model_deployment, 
+        mock_sync
+    ):
+        dsc_model = MagicMock()
+        dsc_model.id = "fakeid.datasciencemodel.oc1.iad.xxx"
+        mock_upload_artifact.return_value = dsc_model
+        model_deployment = self.initialize_model_deployment()
+        (
+            model_deployment.runtime
+            .with_bucket_uri("test_bucket_uri")
+            .with_auth({"test_key":"test_value"})
+            .with_region("test_region")
+            .with_overwrite_existing_artifact(True)
+            .with_remove_existing_artifact(True)
+            .with_timeout(100)
+        )
+
+        runtime_dict = model_deployment.runtime.to_dict()["spec"]
+        assert runtime_dict["bucketUri"] == "test_bucket_uri"
+        assert runtime_dict["auth"] == {"test_key": "test_value"}
+        assert runtime_dict["region"] == "test_region"
+        assert runtime_dict["overwriteExistingArtifact"] == True
+        assert runtime_dict["removeExistingArtifact"] == True
+        assert runtime_dict["timeout"] == 100
+
+        response = MagicMock()
+        response.data = OCI_MODEL_DEPLOYMENT_RESPONSE
+        mock_create_model_deployment.return_value = response
+        model_deployment = self.initialize_model_deployment()
+        model_deployment.set_spec(model_deployment.CONST_ID, "test_model_deployment_id")
+        create_model_deployment_details = (
+            model_deployment._build_model_deployment_details()
+        )
+        model_deployment.deploy(wait_for_completion=False)
+        mock_upload_artifact.assert_called_with(
+            bucket_uri="test_bucket_uri",
+            auth={"test_key":"test_value"},
+            region="test_region",
+            overwrite_existing_artifact=True,
+            remove_existing_artifact=True,
+            timeout=100
+        )
+        mock_create_model_deployment.assert_called_with(create_model_deployment_details)
+        mock_sync.assert_called()


### PR DESCRIPTION
### Support uploading large artifact for model deployment.

- Added spec in `ModelDeploymentRuntime` class to support uploading large artifact
- Apply the API in `DataScienceModel` to upload artifact

### Example

```
ModelDeploymentContainerRuntime()
...
.with_model_uri("path_to_artifact")
.with_auth({"test_key":"test_value"})
.with_region("test_region")
.with_overwrite_existing_artifact(True)
.with_remove_existing_artifact(True)
.with_timeout(100)
.with_bucket_uri("test_bucket_uri")
...
```