### PR TITLE
ODSC-42687. Add ads entry point to invoke ads.cli:cli

### DIFF
--- a/ads/ads
+++ b/ads/ads
@@ -1,2 +1,0 @@
-export OCI_PYTHON_SDK_NO_SERVICE_IMPORTS=1
-python3 -m ads.cli "$@"

--- a/setup.py
+++ b/setup.py
@@ -170,5 +170,9 @@ setup(
         "Github": "https://github.com/oracle/accelerated-data-science",
         "Documentation": "https://accelerated-data-science.readthedocs.io/en/latest/index.html",
     },
-    scripts=["ads/ads"],
+    entry_points={
+        'console_scripts': [
+            'ads=ads.cli:cli'
+        ]
+    },
 )


### PR DESCRIPTION
### Description

When we install ADS to dase environment in image (PR: https://bitbucket.oci.oraclecorp.com/projects/ODSC/repos/odsc_jupyter/pull-requests/119/overview), we want to be able to run ads commands in terminal same way as we run odsc commands. This is possible with "entry_points" parameter (https://packaging.python.org/en/latest/specifications/entry-points/#entry-points).

Jira: https://jira.oci.oraclecorp.com/browse/ODSC-42687

### What was done 

- changed "scripts" to "entry_points" in setup.py
- removed ads/ads file, which was used by scripts in setup.py

Reason why ads/ads removed - the ads/ads file running 2 commands:

1. assigns value to env variable, which is no longer needed, this behavior is by default after oci version older than v2.88.1: https://docs.oracle.com/en-us/iaas/tools/python/2.104.0/sdk_behaviors/enable_selective_service_imports.html?highlight=oci_python_sdk_no_service_imports
2. invoking ads.cli which is now being iinvoked by entry_points console_scripts in setup.py (added in this PR)

### Validation

1. builded whl file
2. builded image with ads from this whl file installed in base env (same way as in PR: https://bitbucket.oci.oraclecorp.com/projects/ODSC/repos/odsc_jupyter/pull-requests/119/overview, but provided whl during image building

added to jupyter.jaml:
```
  - pip:
    - /tmp/oracle_ads-2.8.6rc0-py3-none-any.whl[opctl]
```

added to Dockerfile:
```
COPY oracle_ads-2.8.6rc0-py3-none-any.whl /tmp
RUN conda env update -q -n root -f /opt/jupyter.yaml && conda clean -yaf && rm -rf /home/datascience/.cache/pip
```

3. run docker container
4. in docker container checked version of ads and if ads commands running:

```
(base) bash-4.2$ ads --help
Usage: ads [OPTIONS] COMMAND [ARGS]...

Options:
  --version   Show the version and exit.
  -h, --help  Show this message and exit.

Commands:
  jobs
  opctl
  pipeline
(base) bash-4.2$ ads jobs --help
Usage: ads jobs [OPTIONS] COMMAND [ARGS]...

Options:
  -h, --help  Show this message and exit.

Commands:
  delete
  run
  watch
(base) bash-4.2$ ads opctl --help
Usage: ads opctl [OPTIONS] COMMAND [ARGS]...

Options:
  -h, --help  Show this message and exit.

Commands:
  activate              Activates a data science service.
  build-image
  cancel
  check                 Run diagnostics to check if your setup meets all...
  conda
  configure
  deactivate            Deactivates a data science service.
  delete
  distributed-training
  init                  Generates a starter specification template YAML...
  init-operator
  init-vscode           Generates devcontainer.json with docker details...
  model
  predict               Make prediction using the model with the payload.
  publish-image
  run                   Runs the workload on the targeted backend.
  spark
  watch                 ``tail`` logs form a job run, dataflow run or...
(base) bash-4.2$ ads pipeline --help
Usage: ads pipeline [OPTIONS] COMMAND [ARGS]...

Options:
  -h, --help  Show this message and exit.

Commands:
  delete
  run
  watch
(base) bash-4.2$ conda list | grep ads
libopenblas               0.3.21          pthreads_h78a6416_3    conda-forge
oracle-ads                2.8.6rc0                 pypi_0    pypi
(base) bash-4.2$ 
```

5. created empty env (without ADS), activated it and checked ads command works:

```
(base) bash-4.2$ odsc conda create -n empty_env
...
(base) bash-4.2$ conda activate /home/datascience/conda/empty_env_v1_0
(/home/datascience/conda/empty_env_v1_0) bash-4.2$ ads --help
Usage: ads [OPTIONS] COMMAND [ARGS]...

Options:
  --version   Show the version and exit.
  -h, --help  Show this message and exit.

Commands:
  jobs
  opctl
  pipeline
(/home/datascience/conda/empty_env_v1_0) bash-4.2$ conda list | grep ads
(/home/datascience/conda/empty_env_v1_0) bash-4.2$ 
```

6. created env with ads (without optcl) and checked if ads commands works - it shows error message (this is expected, because underlying import expect docker library to be installed. This is not wanted behavior and we will fix it with this ticket: https://jira.oci.oraclecorp.com/browse/ODSC-43438).

```
(base) bash-4.2$ odsc conda create -n env_w_ads -f my_env.yaml 
...
(base) bash-4.2$ conda activate /home/datascience/conda/env_w_ads_v1_0
(/home/datascience/conda/env_w_ads_v1_0) bash-4.2$ conda list | grep ads
# packages in environment at /home/datascience/conda/env_w_ads_v1_0:
oracle-ads                2.8.5                    pypi_0    pypi
(/home/datascience/conda/env_w_ads_v1_0) bash-4.2$ ads --help
OpenBLAS WARNING - could not determine the L2 cache size on this system, assuming 256k
OpenBLAS WARNING - could not determine the L2 cache size on this system, assuming 256k
Please run `pip install oracle-ads[opctl]` to install the required dependencies for ADS CLI.
(/home/datascience/conda/env_w_ads_v1_0) bash-4.2$ python
```



