### PR TITLE
bugfix/ODSC-43563/entryscript_mounted_as_directory

### DIFF
--- a/ads/opctl/backend/local.py
+++ b/ads/opctl/backend/local.py
@@ -426,9 +426,9 @@ class LocalBackend(Backend):
             with open(os.path.join(td, "entryscript.sh"), "w") as f:
                 f.write(
                     f"""
-    #!/bin/bash
-    source {os.path.join(DEFAULT_IMAGE_CONDA_DIR, slug, 'bin/activate')}
-    {command}
+#!/bin/bash
+source {os.path.join(DEFAULT_IMAGE_CONDA_DIR, slug, 'bin/activate')}
+{command}
                         """
                 )
             bind_volumes[os.path.join(td, "entryscript.sh")] = {

--- a/ads/opctl/backend/local.py
+++ b/ads/opctl/backend/local.py
@@ -715,9 +715,8 @@ class LocalModelDeploymentBackend(LocalBackend):
             )
 
         # conda
-        conda_slug, conda_path = self.config["execution"].get(
-            "conda_slug"
-        ), self.config["execution"].get("conda_path")
+        conda_slug = self.config["execution"].get("conda_slug")
+        conda_path = self.config["execution"].get("conda_path")
         if not conda_slug and not conda_path and ocid:
             conda_slug, conda_path = self._get_conda_info_from_custom_metadata(ocid)
         if not conda_slug and not conda_path:

--- a/ads/opctl/backend/local.py
+++ b/ads/opctl/backend/local.py
@@ -54,6 +54,7 @@ from ads.pipeline.ads_pipeline import Pipeline, PipelineStep
 from ads.common.oci_client import OCIClientFactory
 from ads.config import NO_CONTAINER
 
+
 class CondaPackNotFound(Exception):  # pragma: no cover
     pass
 
@@ -219,7 +220,9 @@ class LocalBackend(Backend):
             )
             if os.path.exists(os.path.join(conda_pack_path, "spark-defaults.conf")):
                 env_vars["SPARK_CONF_DIR"] = os.path.join(DEFAULT_IMAGE_CONDA_DIR, slug)
-            logger.info(f"Running with conda pack in a container with command {command}")
+            logger.info(
+                f"Running with conda pack in a container with command {command}"
+            )
             return self._activate_conda_env_and_run(
                 image, slug, command, bind_volumes, env_vars
             )
@@ -419,14 +422,13 @@ class LocalBackend(Backend):
                 build_image("job-local", gpu=False)
             else:
                 build_image("job-local", gpu=True)
-
-        with tempfile.TemporaryDirectory() as td:
+        with tempfile.TemporaryDirectory(dir=os.path.expanduser("~")) as td:
             with open(os.path.join(td, "entryscript.sh"), "w") as f:
                 f.write(
                     f"""
-#!/bin/bash
-source {os.path.join(DEFAULT_IMAGE_CONDA_DIR, slug, 'bin/activate')}
-{command}
+    #!/bin/bash
+    source {os.path.join(DEFAULT_IMAGE_CONDA_DIR, slug, 'bin/activate')}
+    {command}
                         """
                 )
             bind_volumes[os.path.join(td, "entryscript.sh")] = {
@@ -681,11 +683,11 @@ class LocalModelDeploymentBackend(LocalBackend):
         None
             Nothing.
         """
-        
+
         # model artifact in artifact directory
         artifact_directory = self.config["execution"].get("artifact_directory")
         ocid = self.config["execution"].get("ocid")
-        
+
         model_folder = os.path.expanduser(
             self.config["execution"].get("model_save_folder", DEFAULT_MODEL_FOLDER)
         )
@@ -711,20 +713,24 @@ class LocalModelDeploymentBackend(LocalBackend):
                 timeout=timeout,
                 force_overwrite=True,
             )
-                
+
         # conda
-        conda_slug, conda_path = self.config["execution"].get("conda_slug"), self.config["execution"].get("conda_path")
+        conda_slug, conda_path = self.config["execution"].get(
+            "conda_slug"
+        ), self.config["execution"].get("conda_path")
         if not conda_slug and not conda_path and ocid:
             conda_slug, conda_path = self._get_conda_info_from_custom_metadata(ocid)
         if not conda_slug and not conda_path:
             conda_slug, conda_path = self._get_conda_info_from_runtime(
                 artifact_dir=artifact_directory
             )
-        if 'conda_slug' not in self.config["execution"]:
-            self.config["execution"]["conda_slug"] = conda_path.split("/")[-1] if conda_path else conda_slug 
+        if "conda_slug" not in self.config["execution"]:
+            self.config["execution"]["conda_slug"] = (
+                conda_path.split("/")[-1] if conda_path else conda_slug
+            )
 
         self.config["execution"]["image"] = ML_JOB_IMAGE
-        
+
         # bind_volumnes
         bind_volumes = {}
         SCRIPT = "script.py"
@@ -735,39 +741,45 @@ class LocalModelDeploymentBackend(LocalBackend):
                     os.path.dirname(self.config["execution"]["oci_config"])
                 ): {"bind": os.path.join(DEFAULT_IMAGE_HOME_DIR, ".oci")}
             }
-            
+
             self.config["execution"]["source_folder"] = os.path.abspath(
                 os.path.join(dir_path, "..")
             )
             self.config["execution"]["entrypoint"] = SCRIPT
             bind_volumes[artifact_directory] = {"bind": DEFAULT_MODEL_DEPLOYMENT_FOLDER}
-        
+
         # extra cmd
         data = self.config["execution"].get("payload")
         extra_cmd = f"--payload '{data}' " + f"--auth {self.auth_type} "
         if self.auth_type != "resource_principal":
             extra_cmd += f"--profile {self.profile}"
-        
+
         if is_in_notebook_session() or NO_CONTAINER:
             # _run_with_conda_pack has code to handle notebook session case,
-            # however, it activate the conda pack and then run the script. 
+            # however, it activate the conda pack and then run the script.
             # For the deployment, we just take the current conda env and run it.
             # Hence we just handle the notebook case directly here.
             script_path = os.path.join(os.path.join(dir_path, ".."), SCRIPT)
-            cmd = f"python {script_path} " + f"--artifact-directory {artifact_directory} " + extra_cmd
+            cmd = (
+                f"python {script_path} "
+                + f"--artifact-directory {artifact_directory} "
+                + extra_cmd
+            )
             logger.info(f"Running in a notebook or NO_CONTAINER with command {cmd}")
             run_command(cmd=cmd, shell=True)
         else:
-            extra_cmd = f"--artifact-directory {DEFAULT_MODEL_DEPLOYMENT_FOLDER} "+ extra_cmd
+            extra_cmd = (
+                f"--artifact-directory {DEFAULT_MODEL_DEPLOYMENT_FOLDER} " + extra_cmd
+            )
             exit_code = self._run_with_conda_pack(
-                    bind_volumes, extra_cmd, install=True, conda_uri=conda_path
-                )
+                bind_volumes, extra_cmd, install=True, conda_uri=conda_path
+            )
             if exit_code != 0:
                 raise RuntimeError(
                     f"`predict` did not complete successfully. Exit code: {exit_code}. "
                     f"Run with the --debug argument to view container logs."
                 )
-                
+
     def _get_conda_info_from_custom_metadata(self, ocid):
         """
         Get conda env info from custom metadata from model catalog.

--- a/ads/opctl/cli.py
+++ b/ads/opctl/cli.py
@@ -30,8 +30,12 @@ from ads.opctl.cmds import run as run_cmd
 from ads.opctl.cmds import run_diagnostics as run_diagnostics_cmd
 from ads.opctl.cmds import watch as watch_cmd
 from ads.opctl.config.merger import ConfigMerger
-from ads.opctl.constants import (BACKEND_NAME, DEFAULT_MODEL_FOLDER,
-                                 RESOURCE_TYPE, RUNTIME_TYPE)
+from ads.opctl.constants import (
+    BACKEND_NAME,
+    DEFAULT_MODEL_FOLDER,
+    RESOURCE_TYPE,
+    RUNTIME_TYPE,
+)
 from ads.opctl.utils import build_image as build_image_cmd
 from ads.opctl.utils import publish_image as publish_image_cmd
 from ads.opctl.utils import suppress_traceback

--- a/docs/source/user_guide/cli/opctl/localdev/local_deployment.rst
+++ b/docs/source/user_guide/cli/opctl/localdev/local_deployment.rst
@@ -39,8 +39,8 @@ This example below demonstrates how to run a local predict using an installed co
 Parameter explanation:
   - ``--ocid``: Run the predict locally in a docker container when you pass in a model id. If you pass in a deployment id, e.g. ``ocid1.datasciencemodeldeployment.oc1.iad.``, it will actually predict against the remote endpoint. In that case, only ``--ocid`` and ``--payload`` are needed.
   - ``--conda-slug myconda_p38_cpu_v1``:  Use the ``myconda_p38_cpu_v1`` conda environment. The environment should be installed in your local already. If you haven't installed it, you can provide the path by ``--conda-path``, for example, ``--conda-path "oci://my-bucket@mytenancy/.../myconda_p38_cpu_v1"``, it will download and install the conda environment in your local. Note that you must publish this conda environment to you own bucket first if you are actually using a service conda pack for your real deployment. We will find to auto detect the conda information from the custom metadata, then the runtime.yaml from your model artifact if ``--conda-slug`` and ``--conda-path`` is not provided. However, if detected conda are service packs, we will throw an error asking you to publish it first. Note, in order to test whether deployemnt will work, you should provide the slug that you will use in real deployment. The local conda environment directory will be automatically mounted into the container and activated before the entrypoint is executed.
-  - ``--payload``: the payload to be passed to your model.
-  - ``--bucket-uri``: is used to download large model artifact to your local machine. Extra policy needs to be placed for this bucket. Check this :doc:`link <./user_guide/model_registration/model_load.html#large-model-artifacts>` for more details. Small artifact does not require this.
+  - ``--payload``: The payload to be passed to your model.
+  - ``--bucket-uri``: Used to download large model artifact to your local machine. Extra policy needs to be placed for this bucket. Check this :doc:`link <./user_guide/model_registration/model_load.html#large-model-artifacts>` for more details. Small artifact does not require this.
 
 .. code-block:: shell
 
@@ -54,7 +54,7 @@ Running your Predict Against the Deployment Endpoint
 ----------------------------------------------------
 .. code-block:: shell
 
-  ads opctl predict "ocid1.datasciencemodeldeployment.oc1.iad.<ocid>" --payload '[[-1.68671955,2.25814541,-0.5068027,0.25248417,0.62665134,0.23441123]]'
+  ads opctl predict --ocid "ocid1.datasciencemodeldeployment.oc1.iad.<ocid>" --payload '[[-1.68671955,2.25814541,-0.5068027,0.25248417,0.62665134,0.23441123]]'
 
 
 Parameter explanation:

--- a/docs/source/user_guide/cli/opctl/localdev/local_deployment.rst
+++ b/docs/source/user_guide/cli/opctl/localdev/local_deployment.rst
@@ -34,11 +34,11 @@ This example below demonstrates how to run a local predict using an installed co
 
 .. code-block:: shell
 
-  ads opctl predict --artifact-directory /folder/your/model/artifacts/are/stored --payload '[[-1.68671955,2.25814541,-0.5068027,0.25248417,0.62665134,0.23441123]]' --conda-slug myconda_p38_cpu_v1
+  ads opctl predict --ocid "ocid1.datasciencemodel.oc1.iad.<ocid>" --payload '[[-1.68671955,2.25814541,-0.5068027,0.25248417,0.62665134,0.23441123]]' --conda-slug myconda_p38_cpu_v1
 
 Parameter explanation:
-  - ``--ocid ocid1.datasciencemodel.oc1.iad.******``: Run the predict locally in a docker container when you pass in a model id. If you pass in a deployment id, e.g. ``ocid1.datasciencemodeldeployment.oc1.iad.``, it will actually predict against the remote endpoint. In that case, only ``--ocid`` and ``--payload`` are needed.
-  - ``--conda-slug myconda_p38_cpu_v1``:  Use the ``myconda_p38_cpu_v1`` conda environment. Note that you must publish this conda environment to you own bucket first if you are actually using a service conda pack for your real deployment. However, you dont have to install it locally. We will find to auto detect the conda information from the custom metadata, then the runtime.yaml from your model artifact if --conda-slug and --conda-path is not provided. However, if detected conda are service packs, we will throw an error asking you to publish it first. You can also provide the conda information directly through --conda-slug or --conda-path. Note, in order to test whether deployemnt will work, you should provide the slug that you will use in real deployment. The local conda environment directory will be automatically mounted into the container and activated before the entrypoint is executed. 
+  - ``--ocid``: Run the predict locally in a docker container when you pass in a model id. If you pass in a deployment id, e.g. ``ocid1.datasciencemodeldeployment.oc1.iad.``, it will actually predict against the remote endpoint. In that case, only ``--ocid`` and ``--payload`` are needed.
+  - ``--conda-slug myconda_p38_cpu_v1``:  Use the ``myconda_p38_cpu_v1`` conda environment. The environment should be installed in your local already. If you haven't installed it, you can provide the path by ``--conda-path``, for example, ``--conda-path "oci://my-bucket@mytenancy/.../myconda_p38_cpu_v1"``, it will download and install the conda environment in your local. Note that you must publish this conda environment to you own bucket first if you are actually using a service conda pack for your real deployment. We will find to auto detect the conda information from the custom metadata, then the runtime.yaml from your model artifact if ``--conda-slug`` and ``--conda-path`` is not provided. However, if detected conda are service packs, we will throw an error asking you to publish it first. Note, in order to test whether deployemnt will work, you should provide the slug that you will use in real deployment. The local conda environment directory will be automatically mounted into the container and activated before the entrypoint is executed.
   - ``--payload``: the payload to be passed to your model.
   - ``--bucket-uri``: is used to download large model artifact to your local machine. Extra policy needs to be placed for this bucket. Check this :doc:`link <./user_guide/model_registration/model_load.html#large-model-artifacts>` for more details. Small artifact does not require this.
 
@@ -54,10 +54,9 @@ Running your Predict Against the Deployment Endpoint
 ----------------------------------------------------
 .. code-block:: shell
 
-  ads opctl predict ocid1.datasciencemodeldeployment.oc1.iad.***** --payload '[[-1.68671955,2.25814541,-0.5068027,0.25248417,0.62665134,0.23441123]]' 
+  ads opctl predict "ocid1.datasciencemodeldeployment.oc1.iad.<ocid>" --payload '[[-1.68671955,2.25814541,-0.5068027,0.25248417,0.62665134,0.23441123]]'
 
 
 Parameter explanation:
-  - ``--ocid ocid1.datasciencemodeldeployment.oc1.iad.******``: Run the predict remotely against the remote endpoint.
+  - ``--ocid ocid1.datasciencemodeldeployment.oc1.iad.<ocid>``: Run the predict remotely against the remote endpoint.
   - ``--payload``: The payload to be passed to your model.
-  

--- a/docs/source/user_guide/cli/opctl/localdev/local_deployment.rst
+++ b/docs/source/user_guide/cli/opctl/localdev/local_deployment.rst
@@ -34,7 +34,7 @@ This example below demonstrates how to run a local predict using an installed co
 
 .. code-block:: shell
 
-  ads opctl predict --ocid "ocid1.datasciencemodel.oc1.iad.<ocid>" --payload '[[-1.68671955,2.25814541,-0.5068027,0.25248417,0.62665134,0.23441123]]' --conda-slug myconda_p38_cpu_v1
+  ads opctl predict --ocid "ocid1.datasciencemodel.oc1.iad.<unique_ID>" --payload '[[-1.68671955,2.25814541,-0.5068027,0.25248417,0.62665134,0.23441123]]' --conda-slug myconda_p38_cpu_v1
 
 Parameter explanation:
   - ``--ocid``: Run the predict locally in a docker container when you pass in a model id. If you pass in a deployment id, e.g. ``ocid1.datasciencemodeldeployment.oc1.iad.``, it will actually predict against the remote endpoint. In that case, only ``--ocid`` and ``--payload`` are needed.
@@ -54,9 +54,9 @@ Running your Predict Against the Deployment Endpoint
 ----------------------------------------------------
 .. code-block:: shell
 
-  ads opctl predict --ocid "ocid1.datasciencemodeldeployment.oc1.iad.<ocid>" --payload '[[-1.68671955,2.25814541,-0.5068027,0.25248417,0.62665134,0.23441123]]'
+  ads opctl predict --ocid "ocid1.datasciencemodeldeployment.oc1.iad.<unique_ID>" --payload '[[-1.68671955,2.25814541,-0.5068027,0.25248417,0.62665134,0.23441123]]'
 
 
 Parameter explanation:
-  - ``--ocid ocid1.datasciencemodeldeployment.oc1.iad.<ocid>``: Run the predict remotely against the remote endpoint.
+  - ``--ocid``: Run the predict remotely against the remote endpoint.
   - ``--payload``: The payload to be passed to your model.


### PR DESCRIPTION
# Description
Jira: https://jira.oci.oraclecorp.com/browse/ODSC-43563
ADS OPCTL will mount a temporary path file `entryscript.sh`, which is used to activate the runtime conda environment, inside /var/folders from the host machine to the container. But when the docker engine doesn't have access to `/var`, it will create a directory with the same name. 
User will see the following log when enable debug mode:
```
`/etc/datascience/entryscript.sh: /etc/datascience/entryscript.sh: is a directory`
```
And local job will fail because of no conda environment.

# Changed
* The `entryscript.sh` should be created inside `os.path.expanduser("~")` directory, which is accessible to the docker engine by default.
* Improved user guide


# Test
local predict successfully.
```
11:07 $ ads opctl predict --ocid ocid1.datasciencemodel.oc1.iad.<ocid>  --payload "[[1,2,3,4]]"  --debug --conda-slug onnx110_p38_cpu_v2 --conda-path oci://mybucket@mytenancy/conda_environments/cpu/ONNX_1.10_for_CPU_on_Python_3.8/2.0/onnx110_p38_cpu_v2
Loading service config for profile DEFAULT.
INFO:ads.opctl:Loading service config for profile DEFAULT.
...
Running with conda pack in a container with command python /etc/datascience/operators/opctl/script.py --artifact-directory /opt/ds/model/deployed_model/ --payload '[[1,2,3,4]]' --auth api_key --profile DEFAULT
INFO:ads.opctl:Running with conda pack in a container with command python /etc/datascience/operators/opctl/script.py --artifact-directory /opt/ds/model/deployed_model/ --payload '[[1,2,3,4]]' --auth api_key --profile DEFAULT
Running container with image: ml-job
INFO:ads.opctl:Running container with image: ml-job
bind_volumes: {'/Users/mingkang/.oci': {'bind': '/home/datascience/.oci'}, '/Users/mingkang/.ads_ops/models/ocid1.datasciencemodel.oc1.iad.<ocid>': {'bind': '/opt/ds/model/deployed_model/'}, '/Users/mingkang/conda/onnx110_p38_cpu_v2': {'bind': '/opt/conda/envs/onnx110_p38_cpu_v2'}, '/Users/mingkang/workspace/github/accelerated-data-science/ads/opctl': {'bind': '/etc/datascience/operators/opctl'}, '/Users/mingkang/tmp4f43p029/entryscript.sh': {'bind': '/etc/datascience/entryscript.sh'}}
...
command: bash /etc/datascience/entryscript.sh
INFO:ads.opctl:command: bash /etc/datascience/entryscript.sh
entrypoint: None
INFO:ads.opctl:entrypoint: None
>>> docker run --rm -v /Users/mingkang/.oci:/home/datascience/.oci -v /Users/mingkang/.ads_ops/models/ocid1.datasciencemodel.oc1.iad.<ocid>:/opt/ds/model/deployed_model/ -v /Users/mingkang/conda/onnx110_p38_cpu_v2:/opt/conda/envs/onnx110_p38_cpu_v2 -v /Users/mingkang/workspace/github/accelerated-data-science/ads/opctl:/etc/datascience/operators/opctl -v /Users/mingkang/tmp4f43p029/entryscript.sh:/etc/datascience/entryscript.sh ml-job bash /etc/datascience/entryscript.sh
...
Container ID: xxx
INFO:ads.opctl:Container ID: xxx
OpenBLAS WARNING - could not determine the L2 cache size on this system, assuming 256k
Fontconfig error: Cannot load default config file: No such file: (null)
2023-06-05 18:12:04.620555000 [W:onnxruntime:, model.cc:180 Model] ONNX Runtime only *guarantees* support for models stamped with opset version 7 or above for opset domain 'ai.onnx'. Please upgrade your model to opset 7 or higher. For now, this opset 1 model may run depending upon legacy support of some older opset version operators.
2023-06-05 18:12:04.729826000 [W:onnxruntime:, ort_transpose_optimizer.cc:24 ApplyImpl] Transpose optimizer failed: Unsupported ONNX opset
2023-06-05 18:12:04.749068000 [W:onnxruntime:, model.cc:180 Model] ONNX Runtime only *guarantees* support for models stamped with opset version 7 or above for opset domain 'ai.onnx'. Please upgrade your model to opset 7 or higher. For now, this opset 1 model may run depending upon legacy support of some older opset version operators.
2023-06-05 18:12:04.750975000 [W:onnxruntime:, ort_transpose_optimizer.cc:24 ApplyImpl] Transpose optimizer failed: Unsupported ONNX opset
WARNING:ads.common:In the future model input will be serialized by `cloudpickle` by default. Currently, model input are serialized into a dictionary containing serialized input data and original data type information.Set `model_input_serializer="cloudpickle"` to use cloudpickle model input serializer.
2023-06-05 18:12:05.069207000 [W:onnxruntime:, model.cc:180 Model] ONNX Runtime only *guarantees* support for models stamped with opset version 7 or above for opset domain 'ai.onnx'. Please upgrade your model to opset 7 or higher. For now, this opset 1 model may run depending upon legacy support of some older opset version operators.
2023-06-05 18:12:05.069925000 [W:onnxruntime:, ort_transpose_optimizer.cc:24 ApplyImpl] Transpose optimizer failed: Unsupported ONNX opset
2023-06-05 18:12:05.083982000 [W:onnxruntime:, model.cc:180 Model] ONNX Runtime only *guarantees* support for models stamped with opset version 7 or above for opset domain 'ai.onnx'. Please upgrade your model to opset 7 or higher. For now, this opset 1 model may run depending upon legacy support of some older opset version operators.
2023-06-05 18:12:05.084474000 [W:onnxruntime:, ort_transpose_optimizer.cc:24 ApplyImpl] Transpose optimizer failed: Unsupported ONNX opset
{'prediction': ['virginica']}
```