### PR TITLE
Fix jobs integration test

### DIFF
--- a/tests/integration/jobs/test_dsc_job.py
+++ b/tests/integration/jobs/test_dsc_job.py
@@ -314,6 +314,10 @@ class DSCJobCreationTestCase(DSCJobTestCaseWithCleanUp):
                 for sk, sv in v.items():
                     expected_infra_spec[attr_map[k]][attr_map[sk]] = sv
                 infra = builder_method(**v)
+                # Shape config is not required for non flex shape from user end.
+                # When we have shape config, we need Flex shape also:
+                if k == "shape_config_details":
+                    infra = infra.with_shape_name("VM.Standard.E3.Flex")
             else:
                 expected_infra_spec[attr_map[k]] = v
                 infra = builder_method(v)


### PR DESCRIPTION
### Description

Overnight integration test failed, this is fix to it.

### Validation 

locally failed test passed successfully:
```
Testing started at 9:29 AM ...
Launching pytest with arguments test_dsc_job.py::DSCJobCreationTestCase::test_create_job_with_dsc_infra_config --no-header --no-summary -q in /Users/lrudenka/github/accelerated-data-science/tests/integration/jobs

============================= test session starts ==============================
collecting ... collected 1 item

test_dsc_job.py::DSCJobCreationTestCase::test_create_job_with_dsc_infra_config 

======================== 1 passed in 108.24s (0:01:48) =========================

Process finished with exit code 0
Project OCID: ocid1.datascienceproject.oc1.iad.amaaaaaav66vvnialdcsyzqby6xbjkcoumfmbvqvql3qbkky57n6mb6r5jda
PASSED [100%]Job YAML saved to oci://ads_jobs_la@ociodscdev/tests/20230606-0930/example_job_ZCSIZU.yaml
Job YAML saved to oci://ads_jobs_la@ociodscdev/tests/20230606-0930/example_job_ZCSIZU.yaml
Job YAML saved to oci://ads_jobs_la@ociodscdev/tests/20230606-0930/example_job_ZCSIZU.yaml
Job YAML saved to oci://ads_jobs_la@ociodscdev/tests/20230606-0930/example_job_ZCSIZU.yaml
Job YAML saved to oci://ads_jobs_la@ociodscdev/tests/20230606-0930/example_job_ZCSIZU.yaml
```