### PR TITLE
 Change link to api_keys.ipynb with instruction using OCI approach

### DIFF
--- a/docs/source/user_guide/cli/authentication.rst
+++ b/docs/source/user_guide/cli/authentication.rst
@@ -37,9 +37,7 @@ You can choose to use the resource principal to authenticate while using the Acc
 
 Use API Key setup when you are working from a local workstation or on platform which does not support resource principals.
 
-This is the default method of authentication. You can also authenticate as your own personal IAM user by creating or uploading OCI configuration and API key files inside your notebook session environment. The OCI configuration file contains the necessary credentials to authenticate your user against the model catalog and other OCI services like Object Storage. The example notebook, `api_keys.ipynb` demonstrates how to create these files.
-
-You can follow the steps in `api_keys.ipynb <https://github.com/oracle-samples/oci-data-science-ai-samples/blob/master/notebook_examples/api_keys.ipynb>`_ for step by step instruction on setting up API Keys.
+This is the default method of authentication. You can also authenticate as your own personal IAM user by creating or uploading OCI configuration and API key files inside your notebook session environment. The OCI configuration file contains the necessary credentials to authenticate your user against the model catalog and other OCI services like Object Storage. You can create this file using a setup dialog or manually using a text editor. See `Setting up the Configuration File <https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm#configfile>`_ for steps to follow.
 
 .. note::
    If you already have an OCI configuration file (``config``) and associated keys, you can upload them directly to the ``/home/datascience/.oci`` directory using the JupyterLab **Upload Files** or the drag-and-drop option.


### PR DESCRIPTION
### Description

In the docs we need to remove link to removed api keys notebook (https://accelerated-data-science.readthedocs.io/en/latest/user_guide/cli/authentication.html) and replace with the OCI approach

Jira: https://jira.oci.oraclecorp.com/browse/ODSC-43602

- added link to Setting up the Configuration File (in service docs) instead of link to removed api_keys.ipynb