### PR TITLE
Deprecated ModelDeploymentProperties and ModelDeployer classes

### DIFF
--- a/ads/model/deployment/model_deployer.py
+++ b/ads/model/deployment/model_deployer.py
@@ -106,7 +106,7 @@ class ModelDeployer:
         """
         if config:
             warnings.warn(
-                "`config` will be removed in 3.0.0 and will be ignored now. Please use `ads.set_auth()` to config the auth information."
+                "`config` will be deprecated in 3.0.0 and will be ignored now. Please use `ads.set_auth()` to config the auth information."
             )
 
         self.ds_client = None

--- a/ads/model/deployment/model_deployer.py
+++ b/ads/model/deployment/model_deployer.py
@@ -51,6 +51,16 @@ from .common.utils import OCIClientManager, State
 from .model_deployment import DEFAULT_POLL_INTERVAL, DEFAULT_WAIT_TIME, ModelDeployment
 from .model_deployment_properties import ModelDeploymentProperties
 
+warnings.warn(
+    (
+        "The `ads.model.deployment.model_deployer` is deprecated in `oracle-ads 2.8.7` and will be removed in `oracle-ads 3.0`."
+        "Use `ModelDeployment` class in `ads.model.deployment` module for initializing and deploy model deployment. "
+        "Check https://accelerated-data-science.readthedocs.io/en/latest/user_guide/model_registration/introduction.html"
+    ),
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 class ModelDeployer:
     """ModelDeployer is the class responsible for deploying the ModelDeployment
@@ -96,7 +106,7 @@ class ModelDeployer:
         """
         if config:
             warnings.warn(
-                "`config` will be deprecated in 3.0.0 and will be ignored now. Please use `ads.set_auth()` to config the auth information."
+                "`config` will be removed in 3.0.0 and will be ignored now. Please use `ads.set_auth()` to config the auth information."
             )
 
         self.ds_client = None

--- a/ads/model/deployment/model_deployer.py
+++ b/ads/model/deployment/model_deployer.py
@@ -53,8 +53,8 @@ from .model_deployment_properties import ModelDeploymentProperties
 
 warnings.warn(
     (
-        "The `ads.model.deployment.model_deployer` is deprecated in `oracle-ads 2.8.7` and will be removed in `oracle-ads 3.0`."
-        "Use `ModelDeployment` class in `ads.model.deployment` module for initializing and deploy model deployment. "
+        "The `ads.model.deployment.model_deployer` is deprecated in `oracle-ads 2.8.6` and will be removed in `oracle-ads 3.0`."
+        "Use `ModelDeployment` class in `ads.model.deployment` module for initializing and deploying model deployment. "
         "Check https://accelerated-data-science.readthedocs.io/en/latest/user_guide/model_registration/introduction.html"
     ),
     DeprecationWarning,

--- a/ads/model/deployment/model_deployment.py
+++ b/ads/model/deployment/model_deployment.py
@@ -297,17 +297,20 @@ class ModelDeployment(Builder):
 
         if config:
             warnings.warn(
-                "Parameter `config` will be removed from ModelDeployment constructor in 3.0.0 and will be ignored now. Please use `ads.set_auth()` to config the auth information."
+                "Parameter `config` was deprecated in 2.8.2 from ModelDeployment constructor and will be removed in 3.0.0. Please use `ads.set_auth()` to config the auth information. "
+                "Check: https://accelerated-data-science.readthedocs.io/en/latest/user_guide/cli/authentication.html"
             )
 
         if properties:
             warnings.warn(
-                "Parameter `properties` will be removed from ModelDeployment constructor in 3.0.0. Please use `spec` or the builder pattern to initialize model deployment instance."
+                "Parameter `properties` was deprecated in 2.8.2 from ModelDeployment constructor and will be removed in 3.0.0. Please use `spec` or the builder pattern to initialize model deployment instance. "
+                "Check: https://accelerated-data-science.readthedocs.io/en/latest/user_guide/model_registration/quick_start.html"
             )
 
         if model_deployment_url or model_deployment_id:
             warnings.warn(
-                "Parameter `model_deployment_url` and `model_deployment_id` will be removed from ModelDeployment constructor in 3.0.0 and will be ignored now. These two fields will be auto-populated from the service side."
+                "Parameter `model_deployment_url` and `model_deployment_id` were deprecated in 2.8.2 from ModelDeployment constructor and will be removed in 3.0.0. These two fields will be auto-populated from the service side. "
+                "Check: https://accelerated-data-science.readthedocs.io/en/latest/user_guide/model_registration/quick_start.html"
             )
 
         initialize_spec = {}
@@ -701,7 +704,8 @@ class ModelDeployment(Builder):
         """
         if properties:
             warnings.warn(
-                "Parameter `properties` will be removed from ModelDeployment `update()` in 3.0.0. Please use the builder pattern or kwargs to update model deployment instance."
+                "Parameter `properties` is deprecated from ModelDeployment `update()` in 2.8.6 and will be removed in 3.0.0. Please use the builder pattern or kwargs to update model deployment instance. "
+                "Check: https://accelerated-data-science.readthedocs.io/en/latest/user_guide/model_registration/quick_start.html"
             )
 
         updated_properties = properties

--- a/ads/model/deployment/model_deployment.py
+++ b/ads/model/deployment/model_deployment.py
@@ -701,7 +701,7 @@ class ModelDeployment(Builder):
         """
         if properties:
             warnings.warn(
-                "Parameter `properties` will be removed from ModelDeployment update() in 3.0.0. Please use the builder pattern to update model deployment instance."
+                "Parameter `properties` will be removed from ModelDeployment `update()` in 3.0.0. Please use the builder pattern or kwargs to update model deployment instance."
             )
 
         updated_properties = properties

--- a/ads/model/deployment/model_deployment.py
+++ b/ads/model/deployment/model_deployment.py
@@ -70,6 +70,11 @@ MODEL_DEPLOYMENT_INSTANCE_MEMORY_IN_GBS = 16
 MODEL_DEPLOYMENT_INSTANCE_COUNT = 1
 MODEL_DEPLOYMENT_BANDWIDTH_MBPS = 10
 
+MODEL_DEPLOYMENT_RUNTIMES = {
+    ModelDeploymentRuntimeType.CONDA: ModelDeploymentCondaRuntime,
+    ModelDeploymentRuntimeType.CONTAINER: ModelDeploymentContainerRuntime,
+}
+
 
 class ModelDeploymentLogType:
     PREDICT = "predict"
@@ -292,17 +297,17 @@ class ModelDeployment(Builder):
 
         if config:
             warnings.warn(
-                "`config` will be deprecated in 3.0.0 and will be ignored now. Please use `ads.set_auth()` to config the auth information."
+                "Parameter `config` will be removed from ModelDeployment constructor in 3.0.0 and will be ignored now. Please use `ads.set_auth()` to config the auth information."
             )
 
         if properties:
             warnings.warn(
-                "`properties` will be deprecated in 3.0.0. Please use `spec` or the builder pattern to initialize model deployment instance."
+                "Parameter `properties` will be removed from ModelDeployment constructor in 3.0.0. Please use `spec` or the builder pattern to initialize model deployment instance."
             )
 
         if model_deployment_url or model_deployment_id:
             warnings.warn(
-                "`model_deployment_url` and `model_deployment_id` will be deprecated in 3.0.0 and will be ignored now. These two fields will be auto-populated from the service side."
+                "Parameter `model_deployment_url` and `model_deployment_id` will be removed from ModelDeployment constructor in 3.0.0 and will be ignored now. These two fields will be auto-populated from the service side."
             )
 
         initialize_spec = {}
@@ -694,6 +699,11 @@ class ModelDeployment(Builder):
         ModelDeployment
             The instance of ModelDeployment.
         """
+        if properties:
+            warnings.warn(
+                "Parameter `properties` will be removed from ModelDeployment update() in 3.0.0. Please use the builder pattern to update model deployment instance."
+            )
+
         updated_properties = properties
         if not isinstance(properties, ModelDeploymentProperties):
             updated_properties = ModelDeploymentProperties(
@@ -703,7 +713,7 @@ class ModelDeployment(Builder):
         update_model_deployment_details = (
             updated_properties.to_update_deployment()
             if properties or updated_properties.oci_model_deployment or kwargs
-            else self._update_model_deployment_details()
+            else self._update_model_deployment_details(**kwargs)
         )
 
         response = self.dsc_model_deployment.update(
@@ -1487,7 +1497,7 @@ class ModelDeployment(Builder):
             **create_model_deployment_details
         ).to_oci_model(CreateModelDeploymentDetails)
 
-    def _update_model_deployment_details(self) -> UpdateModelDeploymentDetails:
+    def _update_model_deployment_details(self, **kwargs) -> UpdateModelDeploymentDetails:
         """Builds UpdateModelDeploymentDetails from model deployment instance.
 
         Returns
@@ -1499,7 +1509,7 @@ class ModelDeployment(Builder):
             raise ValueError(
                 "Missing parameter runtime or infrastructure. Try reruning it after parameters are fully configured."
             )
-
+        self._update_spec(**kwargs)
         update_model_deployment_details = {
             self.CONST_DISPLAY_NAME: self.display_name,
             self.CONST_DESCRIPTION: self.description,
@@ -1511,6 +1521,65 @@ class ModelDeployment(Builder):
         return OCIDataScienceModelDeployment(
             **update_model_deployment_details
         ).to_oci_model(UpdateModelDeploymentDetails)
+    
+    def _update_spec(self, **kwargs) -> "ModelDeployment":
+        """Updates model deployment specs from kwargs.
+
+        Parameters
+        ----------
+        kwargs:
+            display_name: (str)
+                Model deployment display name
+            description: (str)
+                Model deployment description
+            freeform_tags: (dict)
+                Model deployment freeform tags
+            defined_tags: (dict)
+                Model deployment defined tags
+            
+            Additional kwargs arguments.
+            Can be any attribute that `ads.model.deployment.ModelDeploymentCondaRuntime`, `ads.model.deployment.ModelDeploymentContainerRuntime`
+            and `ads.model.deployment.ModelDeploymentInfrastructure` accepts.
+
+        Returns
+        -------
+        ModelDeployment
+            The instance of ModelDeployment.
+        """
+        if not kwargs:
+            return self
+
+        converted_specs = ads_utils.batch_convert_case(kwargs, "camel")
+        specs = {
+            "self": self._spec,
+            "runtime": self.runtime._spec,
+            "infrastructure": self.infrastructure._spec
+        }
+        sub_set = {
+            self.infrastructure.CONST_ACCESS_LOG,
+            self.infrastructure.CONST_PREDICT_LOG,
+            self.infrastructure.CONST_SHAPE_CONFIG_DETAILS
+        }
+        for spec_value in specs.values():
+            for key in spec_value:
+                if key in converted_specs:
+                    if key in sub_set:
+                        for sub_key in converted_specs[key]:
+                            converted_sub_key = ads_utils.snake_to_camel(sub_key)
+                            spec_value[key][converted_sub_key] = converted_specs[key][sub_key]
+                    else:
+                        spec_value[key] = copy.deepcopy(converted_specs[key])
+        self = (
+            ModelDeployment(spec=specs["self"])
+            .with_runtime(
+                MODEL_DEPLOYMENT_RUNTIMES[self.runtime.type](spec=specs["runtime"])
+            )
+            .with_infrastructure(
+                ModelDeploymentInfrastructure(spec=specs["infrastructure"])
+            )
+        )
+
+        return self
 
     def _build_model_deployment_configuration_details(self) -> Dict:
         """Builds model deployment configuration details from model deployment instance.

--- a/ads/model/deployment/model_deployment_properties.py
+++ b/ads/model/deployment/model_deployment_properties.py
@@ -16,7 +16,7 @@ import warnings
 
 warnings.warn(
     (
-        "The `ads.model.deployment.model_deployment_properties` is deprecated in `oracle-ads 2.8.7` and will be removed in `oracle-ads 3.0`."
+        "The `ads.model.deployment.model_deployment_properties` is deprecated in `oracle-ads 2.8.6` and will be removed in `oracle-ads 3.0`."
         "Use `ModelDeploymentInfrastructure` and `ModelDeploymentRuntime` classes in `ads.model.deployment` module for configuring model deployment. "
         "Check https://accelerated-data-science.readthedocs.io/en/latest/user_guide/model_registration/introduction.html"
     ),

--- a/ads/model/deployment/model_deployment_properties.py
+++ b/ads/model/deployment/model_deployment_properties.py
@@ -12,6 +12,18 @@ from ads.common.oci_datascience import OCIDataScienceMixin
 
 from .common.utils import OCIClientManager
 
+import warnings
+
+warnings.warn(
+    (
+        "The `ads.model.deployment.model_deployment_properties` is deprecated in `oracle-ads 2.8.7` and will be removed in `oracle-ads 3.0`."
+        "Use `ModelDeploymentInfrastructure` and `ModelDeploymentRuntime` classes in `ads.model.deployment` module for configuring model deployment. "
+        "Check https://accelerated-data-science.readthedocs.io/en/latest/user_guide/model_registration/introduction.html"
+    ),
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 class ModelDeploymentProperties(
     OCIDataScienceMixin, data_science_models.ModelDeployment

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -1615,15 +1615,7 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
 
         Examples
         --------
-        >>> # Deprecated way to update access log id, freeform tags and description for the model deployment
-        >>> model.update_deployment(
-        >>>     properties=ModelDeploymentProperties(
-        >>>         access_log_id=<log_ocid>,
-        >>>         description="Description for Custom Model",
-        >>>         freeform_tags={"key": "value"},
-        >>>     )
-        >>> )
-        >>> # New way to update access log id, freeform tags and description for the model deployment
+        >>> # Update access log id, freeform tags and description for the model deployment
         >>> model.update_deployment(
         ...     access_log={
         ...         log_id=<log_ocid>
@@ -1673,8 +1665,10 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         """
         if properties:
             warnings.warn(
-                "Parameter `properties` will be removed from GenericModel `update_deployment()` in 3.0.0. Please use kwargs to update model deployment."
+                "Parameter `properties` is deprecated from GenericModel `update_deployment()` in 2.8.6 and will be removed in 3.0.0. Please use kwargs to update model deployment. "
+                "Check: https://accelerated-data-science.readthedocs.io/en/latest/user_guide/model_registration/introduction.html"
             )
+
         if not inspect.isclass(cls):
             if cls.model_deployment:
                 return cls.model_deployment.update(

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -299,12 +299,12 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
     >>> model.deploy()
     >>> # Update access log id, freeform tags and description for the model deployment
     >>> model.update_deployment(
-    >>>     properties=ModelDeploymentProperties(
-    >>>         access_log_id=<log_ocid>,
-    >>>         description="Description for Custom Model",
-    >>>         freeform_tags={"key": "value"},
-    >>>     )
-    >>> )
+    ...     access_log={
+    ...         log_id=<log_ocid>
+    ...     },
+    ...     description="Description for Custom Model",
+    ...     freeform_tags={"key": "value"},
+    ... )
     >>> model.predict(2)
     >>> # Uncomment the line below to delete the model and the associated model deployment
     >>> # model.delete(delete_associated_model_deployment = True)
@@ -1615,8 +1615,7 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
 
         Examples
         --------
-        >>> # Update access log id, freeform tags and description for the model deployment
-        >>> # Deprecated
+        >>> # Deprecated way to update access log id, freeform tags and description for the model deployment
         >>> model.update_deployment(
         >>>     properties=ModelDeploymentProperties(
         >>>         access_log_id=<log_ocid>,

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -10,6 +10,7 @@ import shutil
 import tempfile
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -44,7 +45,6 @@ from ads.model.datascience_model import DataScienceModel
 from ads.model.deployment import (
     DEFAULT_POLL_INTERVAL,
     DEFAULT_WAIT_TIME,
-    ModelDeployer,
     ModelDeployment,
     ModelDeploymentMode,
     ModelDeploymentProperties,
@@ -1565,9 +1565,7 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
                 "Only SparkPipelineModel framework supports object storage path as `artifact_dir`."
             )
 
-        model_deployment = ModelDeployer(config=auth).get_model_deployment(
-            model_deployment_id=model_deployment_id
-        )
+        model_deployment = ModelDeployment.from_id(model_deployment_id)
 
         current_state = model_deployment.state.name.upper()
         if current_state != ModelDeploymentState.ACTIVE.name:
@@ -1618,6 +1616,7 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         Examples
         --------
         >>> # Update access log id, freeform tags and description for the model deployment
+        >>> # Deprecated
         >>> model.update_deployment(
         >>>     properties=ModelDeploymentProperties(
         >>>         access_log_id=<log_ocid>,
@@ -1625,6 +1624,14 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         >>>         freeform_tags={"key": "value"},
         >>>     )
         >>> )
+        >>> # New way to update access log id, freeform tags and description for the model deployment
+        >>> model.update_deployment(
+        ...     access_log={
+        ...         log_id=<log_ocid>
+        ...     },
+        ...     description="Description for Custom Model",
+        ...     freeform_tags={"key": "value"},
+        ... )
 
         Parameters
         ----------
@@ -1647,12 +1654,28 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
                 If you need to override the default, use the `ads.common.auth.api_keys` or
                 `ads.common.auth.resource_principal` to create appropriate authentication signer
                 and kwargs required to instantiate IdentityClient object.
+            display_name: (str)
+                Model deployment display name
+            description: (str)
+                Model deployment description
+            freeform_tags: (dict)
+                Model deployment freeform tags
+            defined_tags: (dict)
+                Model deployment defined tags
+            
+            Additional kwargs arguments.
+            Can be any attribute that `ads.model.deployment.ModelDeploymentCondaRuntime`, `ads.model.deployment.ModelDeploymentContainerRuntime`
+            and `ads.model.deployment.ModelDeploymentInfrastructure` accepts.
 
         Returns
         -------
         ModelDeployment
             An instance of ModelDeployment class.
         """
+        if properties:
+            warnings.warn(
+                "Parameter `properties` will be removed from GenericModel `update_deployment()` in 3.0.0. Please use kwargs to update model deployment."
+            )
         if not inspect.isclass(cls):
             if cls.model_deployment:
                 return cls.model_deployment.update(
@@ -1666,10 +1689,7 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         if not model_deployment_id:
             raise ValueError("Parameter `model_deployment_id` must be provided.")
 
-        auth = kwargs.pop("auth", authutil.default_signer())
-        model_deployment = ModelDeployer(config=auth).get_model_deployment(
-            model_deployment_id=model_deployment_id
-        )
+        model_deployment = ModelDeployment.from_id(model_deployment_id)
         return model_deployment.update(
             properties=properties,
             wait_for_completion=wait_for_completion,

--- a/ads/model/service/oci_datascience_model.py
+++ b/ads/model/service/oci_datascience_model.py
@@ -17,7 +17,7 @@ from ads.common.oci_datascience import OCIDataScienceMixin
 from ads.common.oci_mixin import OCIWorkRequestMixin
 from ads.common.oci_resource import SEARCH_TYPE, OCIResource
 from ads.common.utils import extract_region
-from ads.model.deployment.model_deployer import ModelDeployer
+from ads.model.deployment import ModelDeployment
 from oci.data_science.models import (
     ArtifactExportDetailsObjectStorage,
     ArtifactImportDetailsObjectStorage,
@@ -469,9 +469,7 @@ class OCIDataScienceModel(
                 logger.info(
                     f"Deleting model deployment `{oci_model_deployment.identifier}`."
                 )
-                ModelDeployer(ds_client=self.client).delete(
-                    model_deployment_id=oci_model_deployment.identifier
-                )
+                ModelDeployment.from_id(oci_model_deployment.identifier).delete()
 
         logger.info(f"Deleting model `{self.id}`.")
         self.client.delete_model(self.id)

--- a/docs/source/user_guide/model_registration/model_deploy.rst
+++ b/docs/source/user_guide/model_registration/model_deploy.rst
@@ -106,10 +106,10 @@ You can update the existing Model Deployment by using ``.update_deployment()`` m
 .. code-block:: python3
 
   lightgbm_model.update_deployment(
-        properties=ModelDeploymentProperties(
-            access_log_id="ocid1.log.oc1.xxx.xxxxx",
-            description="Description for Custom Model",
-            freeform_tags={"key": "value"},
-        )
-        wait_for_completion = True,
-    )
+    wait_for_completion = True,
+    access_log={
+      log_id="ocid1.log.oc1.xxx.xxxxx",
+    },
+    description="Description for Custom Model",
+    freeform_tags={"key": "value"},
+  )

--- a/tests/unitary/default_setup/model/test_oci_datascience_model.py
+++ b/tests/unitary/default_setup/model/test_oci_datascience_model.py
@@ -24,7 +24,6 @@ from ads.common.oci_mixin import OCIModelMixin
 from ads.common.oci_resource import SEARCH_TYPE, OCIResource
 from ads.dataset.progress import TqdmProgressBar
 from ads.model.datascience_model import _MAX_ARTIFACT_SIZE_IN_BYTES
-from ads.model.deployment.model_deployer import ModelDeployer
 from ads.model.service.oci_datascience_model import (
     ModelArtifactNotFoundError,
     ModelProvenanceNotFoundError,
@@ -230,10 +229,10 @@ class TestOCIDataScienceModel:
                 mock_model_deployment.return_value = [
                     MagicMock(lifecycle_state="ACTIVE", identifier="md_id")
                 ]
-                with patch.object(ModelDeployer, "delete") as mock_md_delete:
+                with patch("ads.model.deployment.ModelDeployment.from_id") as mock_from_id:
                     with patch.object(OCIDataScienceModel, "sync") as mock_sync:
                         self.mock_model.delete(delete_associated_model_deployment=True)
-                        mock_md_delete.assert_called_with(model_deployment_id="md_id")
+                        mock_from_id.assert_called_with("md_id")
                         mock_client.delete_model.assert_called_with(self.mock_model.id)
                         mock_sync.assert_called()
 

--- a/tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py
+++ b/tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py
@@ -1389,3 +1389,47 @@ spec:
 
         model_deployment.infrastructure.with_subnet_id("test_id")
         assert model_deployment.infrastructure.subnet_id == "test_id"
+
+    def test_update_spec(self):
+        model_deployment = self.initialize_model_deployment()
+        model_deployment._update_spec(
+            display_name="test_updated_name",
+            freeform_tags={"test_updated_key":"test_updated_value"},
+            access_log={
+                "log_id": "test_updated_access_log_id"
+            },
+            predict_log={
+                "log_group_id": "test_updated_predict_log_group_id"
+            },
+            shape_config_details={
+                "ocpus": 100,
+                "memoryInGBs": 200
+            },
+            replica=20,
+            image="test_updated_image",
+            env={
+                "test_updated_env_key":"test_updated_env_value"
+            }
+        )
+
+        assert model_deployment.display_name == "test_updated_name"
+        assert model_deployment.freeform_tags == {
+            "test_updated_key":"test_updated_value"
+        }
+        assert model_deployment.infrastructure.access_log == {
+            "logId": "test_updated_access_log_id",
+            "logGroupId": "fakeid.loggroup.oc1.iad.xxx"
+        }
+        assert model_deployment.infrastructure.predict_log == {
+            "logId": "fakeid.log.oc1.iad.xxx",
+            "logGroupId": "test_updated_predict_log_group_id"
+        }
+        assert model_deployment.infrastructure.shape_config_details == {
+            "ocpus": 100,
+            "memoryInGBs": 200
+        }
+        assert model_deployment.infrastructure.replica == 20
+        assert model_deployment.runtime.image == "test_updated_image"
+        assert model_deployment.runtime.env == {
+            "test_updated_env_key":"test_updated_env_value"
+        }

--- a/tests/unitary/with_extras/model/test_generic_model.py
+++ b/tests/unitary/with_extras/model/test_generic_model.py
@@ -958,14 +958,14 @@ class TestGenericModel:
         return_value=ModelDeploymentState.ACTIVE,
     )
     @patch.object(GenericModel, "from_model_catalog")
-    @patch.object(ModelDeployer, "get_model_deployment")
+    @patch.object(ModelDeployment, "from_id")
     @patch("ads.common.auth.default_signer")
     @patch("ads.common.oci_client.OCIClientFactory")
     def test_from_model_deployment(
         self,
         mock_client,
         mock_default_signer,
-        mock_get_model_deployment,
+        mock_from_id,
         mock_from_model_catalog,
         mock_model_deployment_state,
         mock_update_status,
@@ -977,7 +977,7 @@ class TestGenericModel:
         test_model_id = "model_ocid"
         md_props = ModelDeploymentProperties(model_id=test_model_id)
         md = ModelDeployment(properties=md_props)
-        mock_get_model_deployment.return_value = md
+        mock_from_id.return_value = md
 
         test_model = MagicMock(model_deployment=md, _summary_status=SummaryStatus())
         mock_from_model_catalog.return_value = test_model
@@ -994,8 +994,8 @@ class TestGenericModel:
             compartment_id="test_compartment_id",
         )
 
-        mock_get_model_deployment.assert_called_with(
-            model_deployment_id=test_model_deployment_id
+        mock_from_id.assert_called_with(
+            test_model_deployment_id
         )
         mock_from_model_catalog.assert_called_with(
             model_id=test_model_id,
@@ -1018,14 +1018,14 @@ class TestGenericModel:
         new_callable=PropertyMock,
         return_value=ModelDeploymentState.FAILED,
     )
-    @patch.object(ModelDeployer, "get_model_deployment")
+    @patch.object(ModelDeployment, "from_id")
     @patch("ads.common.auth.default_signer")
     @patch("ads.common.oci_client.OCIClientFactory")
     def test_from_model_deployment_fail(
         self,
         mock_client,
         mock_default_signer,
-        mock_get_model_deployment,
+        mock_from_id,
         mock_model_deployment_state,
     ):
         """Tests loading model from model deployment."""
@@ -1035,7 +1035,7 @@ class TestGenericModel:
         test_model_id = "model_ocid"
         md_props = ModelDeploymentProperties(model_id=test_model_id)
         md = ModelDeployment(properties=md_props)
-        mock_get_model_deployment.return_value = md
+        mock_from_id.return_value = md
 
         with pytest.raises(NotActiveDeploymentError):
             GenericModel.from_model_deployment(
@@ -1049,21 +1049,21 @@ class TestGenericModel:
                 remove_existing_artifact=True,
                 compartment_id="test_compartment_id",
             )
-            mock_get_model_deployment.assert_called_with(
-                model_deployment_id=test_model_deployment_id
+            mock_from_id.assert_called_with(
+                test_model_deployment_id
             )
 
     @patch.object(ModelDeployment, "update")
-    @patch.object(ModelDeployer, "get_model_deployment")
+    @patch.object(ModelDeployment, "from_id")
     @patch("ads.common.auth.default_signer")
     @patch("ads.common.oci_client.OCIClientFactory")
     def test_update_deployment_class_level(
-        self, mock_client, mock_signer, mock_get_model_deployment, mock_update
+        self, mock_client, mock_signer, mock_from_id, mock_update
     ):
         test_model_deployment_id = "xxxx.datasciencemodeldeployment.xxxx"
         md_props = ModelDeploymentProperties(model_id=test_model_deployment_id)
         md = ModelDeployment(properties=md_props)
-        mock_get_model_deployment.return_value = md
+        mock_from_id.return_value = md
 
         test_model = MagicMock(model_deployment=md, _summary_status=SummaryStatus())
         mock_update.return_value = test_model
@@ -1086,8 +1086,8 @@ class TestGenericModel:
             poll_interval=200,
         )
 
-        mock_get_model_deployment.assert_called_with(
-            model_deployment_id=test_model_deployment_id
+        mock_from_id.assert_called_with(
+            test_model_deployment_id
         )
 
         mock_update.assert_called_with(


### PR DESCRIPTION
### Deprecated ModelDeploymentProperties and ModelDeployer classes

- Deprecated the use of `ModelDeploymentProperties` and `ModelDeployer` classes
- Deprecate `config`, `properties`, `model_deployment_id`, `model_deployment_url` in `ModelDeployment` constructor
- Updated the `update` API in `ModelDeployment`
- Updated the `update_deployment` API in `GenericModel`
- Updated the internal use of `ModelDeployer` and `ModelDeploymentProperties` to `ModelDeployment`
- Updated user guide