### PR TITLE
Added support for security token authentication

### DIFF
--- a/ads/common/auth.py
+++ b/ads/common/auth.py
@@ -22,21 +22,6 @@ from ads.common.extended_enum import ExtendedEnumMeta
 from oci.config import DEFAULT_LOCATION  # "~/.oci/config"
 from oci.config import DEFAULT_PROFILE  # "DEFAULT"
 
-SECURITY_TOKEN_GENERIC_HEADERS = [
-    "date", 
-    "(request-target)", 
-    "host"
-]
-SECURITY_TOKEN_BODY_HEADERS = [
-    "content-length", 
-    "content-type", 
-    "x-content-sha256"
-]
-SECURITY_TOKEN_REQUIRED = [
-    "security_token_file", 
-    "key_file", 
-    "region"
-]
 SECURITY_TOKEN_LEFT_TIME = 600
 
 
@@ -768,6 +753,21 @@ class SecurityToken(AuthSignerGenerator):
     a given user - it requires that user's private key and security token.
     It prepares extra arguments necessary for creating clients for variety of OCI services.
     """
+    SECURITY_TOKEN_GENERIC_HEADERS = [
+        "date",
+        "(request-target)",
+        "host"
+    ]
+    SECURITY_TOKEN_BODY_HEADERS = [
+        "content-length",
+        "content-type",
+        "x-content-sha256"
+    ]
+    SECURITY_TOKEN_REQUIRED = [
+        "security_token_file",
+        "key_file",
+        "region"
+    ]
 
     def __init__(self, args: Optional[Dict] = None):
         """
@@ -823,7 +823,7 @@ class SecurityToken(AuthSignerGenerator):
 
         logger.info(f"Using 'security_token' authentication.")
 
-        for parameter in SECURITY_TOKEN_REQUIRED:
+        for parameter in self.SECURITY_TOKEN_REQUIRED:
             if parameter not in configuration:
                 raise ValueError(
                     f"Parameter `{parameter}` must be provided for using `security_token` authentication."
@@ -838,8 +838,8 @@ class SecurityToken(AuthSignerGenerator):
                 private_key=oci.signer.load_private_key_from_file(
                     configuration.get("key_file"), configuration.get("pass_phrase")
                 ),
-                generic_headers=configuration.get("generic_headers", SECURITY_TOKEN_GENERIC_HEADERS),
-                body_headers=configuration.get("body_headers", SECURITY_TOKEN_BODY_HEADERS)
+                generic_headers=configuration.get("generic_headers", self.SECURITY_TOKEN_GENERIC_HEADERS),
+                body_headers=configuration.get("body_headers", self.SECURITY_TOKEN_BODY_HEADERS)
             ),
             "client_kwargs": self.client_kwargs,
         }
@@ -860,7 +860,7 @@ class SecurityToken(AuthSignerGenerator):
 
         if not security_token_container.valid():
             raise SecurityTokenError(
-                "Security token has expired. Call `oci session authenticate` to generate new session."
+                "Security token is invalid or has expired. Call `oci session authenticate` to generate new session."
             )
         
         time_now = int(time.time())

--- a/ads/common/auth.py
+++ b/ads/common/auth.py
@@ -16,8 +16,7 @@ import requests
 
 import ads.telemetry
 import oci
-from oci_cli import cli_util
-from ads.common import logger
+from ads.common import logger, utils
 from ads.common.decorator.deprecate import deprecated
 from ads.common.extended_enum import ExtendedEnumMeta
 from oci.config import DEFAULT_LOCATION  # "~/.oci/config"
@@ -877,7 +876,7 @@ class SecurityToken(AuthSignerGenerator):
     
     def _refresh_security_token(self, configuration: Dict[str, Any]):
         """Refreshes security token. The logic is mainly taken reference from:
-        https://github.com/oracle/oci-cli/blob/9a0978344950d7b7c24a688892f24968dce20ad3/src/oci_cli/cli_session.py#L152
+        https://github.com/oracle/oci-cli/blob/master/src/oci_cli/cli_session.py#L152
 
         Parameters
         ----------
@@ -919,7 +918,7 @@ class SecurityToken(AuthSignerGenerator):
             refreshed_token = json.loads(response.content.decode('UTF-8'))['token']
             with open(expanded_security_token_location, 'w') as security_token_file:
                 security_token_file.write(refreshed_token)
-            cli_util.apply_user_only_access_permissions(expanded_security_token_location)
+            utils.apply_user_only_access_permissions(expanded_security_token_location)
             logger.info("Successfully refreshed token")
         elif response.status_code == 401:
             raise SecurityTokenError(

--- a/ads/common/auth.py
+++ b/ads/common/auth.py
@@ -6,17 +6,14 @@
 
 import copy
 from datetime import datetime
-import json
 import os
 from dataclasses import dataclass
 import time
 from typing import Any, Callable, Dict, Optional, Union
 
-import requests
-
 import ads.telemetry
 import oci
-from ads.common import logger, utils
+from ads.common import logger
 from ads.common.decorator.deprecate import deprecated
 from ads.common.extended_enum import ExtendedEnumMeta
 from oci.config import DEFAULT_LOCATION  # "~/.oci/config"

--- a/ads/common/auth.py
+++ b/ads/common/auth.py
@@ -862,7 +862,7 @@ class SecurityToken(AuthSignerGenerator):
         
         time_now = int(time.time())
         time_expired = security_token_container.get_jwt()["exp"]
-        if time_now - time_expired < SECURITY_TOKEN_LEFT_TIME:
+        if time_expired - time_now < SECURITY_TOKEN_LEFT_TIME:
             if not self.oci_config_location:
                 logger.warning("Can not auto-refresh token. Specify parameter `oci_config_location` through ads.set_auth() or ads.auth.create_signer().")
             else:

--- a/ads/common/auth.py
+++ b/ads/common/auth.py
@@ -735,6 +735,12 @@ class InstancePrincipal(AuthSignerGenerator):
 
 
 class SecurityToken(AuthSignerGenerator):
+    """
+    Creates security token auth instance. This signer is intended to be used when signing requests for
+    a given user - it requires that user's private key and security token.
+    It prepares extra arguments necessary for creating clients for variety of OCI services.
+    """
+
     def __init__(self, args: Optional[Dict] = None):
         """
         Signer created based on args provided. If not provided current values of according arguments

--- a/ads/common/auth.py
+++ b/ads/common/auth.py
@@ -22,6 +22,7 @@ class AuthType(str, metaclass=ExtendedEnumMeta):
     API_KEY = "api_key"
     RESOURCE_PRINCIPAL = "resource_principal"
     INSTANCE_PRINCIPAL = "instance_principal"
+    SECURITY_TOKEN = "security_token"
 
 
 class SingletonMeta(type):
@@ -139,6 +140,14 @@ def set_auth(
     >>> ads.set_auth("resource_principal")  # Set resource principal authentication
 
     >>> ads.set_auth("instance_principal")  # Set instance principal authentication
+
+    >>> ads.set_auth("security_token")  # Set security token authentication
+
+    >>> config = dict(
+    ...     key_file=~/.oci/sessions/DEFAULT/oci_api_key.pem
+    ...     security_token_file=~/.oci/sessions/DEFAULT/token
+    ... )
+    >>> ads.set_auth("security_token", config=config) # Set security token authentication from provided config
 
     >>> singer = oci.signer.Signer(
     ...     user=ocid1.user.oc1..<unique_ID>,
@@ -274,6 +283,50 @@ def resource_principal(
     return signer_generator(signer_args).create_signer()
 
 
+def security_token(
+    oci_config: Union[str, Dict] = os.path.expanduser(DEFAULT_LOCATION),
+    profile: str = DEFAULT_PROFILE,
+    client_kwargs: Dict = None,
+) -> Dict:
+    """
+    Prepares authentication and extra arguments necessary for creating clients for different OCI services using Security Token.
+
+    Parameters
+    ----------
+    oci_config: Optional[Union[str, Dict]], default is ~/.oci/config
+        OCI authentication config file location or a dictionary with config attributes.
+    profile: Optional[str], is DEFAULT_PROFILE, which is 'DEFAULT'
+        Profile name to select from the config file.
+    client_kwargs: Optional[Dict], default None
+        kwargs that are required to instantiate the Client if we need to override the defaults.
+
+    Returns
+    -------
+    dict
+        Contains keys - config, signer and client_kwargs.
+
+        - The config contains the config loaded from the configuration loaded from `oci_config`.
+        - The signer contains the signer object created from the security token.
+        - client_kwargs contains the `client_kwargs` that was passed in as input parameter.
+
+    Examples
+    --------
+    >>> from ads.common import oci_client as oc
+    >>> auth = ads.auth.security_token(oci_config="/home/datascience/.oci/config", profile="TEST", client_kwargs={"timeout": 6000})
+    >>> oc.OCIClientFactory(**auth).object_storage # Creates Object storage client with timeout set to 6000 using Security Token authentication
+    """
+    signer_args = dict(
+        oci_config=oci_config if isinstance(oci_config, Dict) else {},
+        oci_config_location=oci_config
+        if isinstance(oci_config, str)
+        else os.path.expanduser(DEFAULT_LOCATION),
+        oci_key_profile=profile,
+        client_kwargs=client_kwargs,
+    )
+    signer_generator = AuthFactory().signerGenerator(AuthType.SECURITY_TOKEN)
+    return signer_generator(signer_args).create_signer()
+
+
 def create_signer(
     auth_type: Optional[str] = AuthType.API_KEY,
     oci_config_location: Optional[str] = DEFAULT_LOCATION,
@@ -346,6 +399,11 @@ def create_signer(
     >>> signer_callable = oci.auth.signers.InstancePrincipalsSecurityTokenSigner
     >>> signer_kwargs = dict(log_requests=True) # will log the request url and response data when retrieving
     >>> auth = ads.auth.create_signer(signer_callable=signer_callable, signer_kwargs=signer_kwargs) # instance principals authentication dictionary created based on callable with kwargs parameters
+    >>> config = dict(
+    ...     key_file=~/.oci/sessions/DEFAULT/oci_api_key.pem
+    ...     security_token_file=~/.oci/sessions/DEFAULT/token
+    ... )
+    >>> auth = ads.auth.create_signer(auth_type="security_token", config=config) # security token authentication created based on provided config
     """
     if signer or signer_callable:
         configuration = ads.telemetry.update_oci_client_config()
@@ -365,8 +423,6 @@ def create_signer(
             oci_config=config,
             client_kwargs=client_kwargs,
         )
-        if config:
-            auth_type = AuthType.API_KEY
 
         signer_generator = AuthFactory().signerGenerator(auth_type)
 
@@ -678,6 +734,102 @@ class InstancePrincipal(AuthSignerGenerator):
         return signer_dict
 
 
+class SecurityToken(AuthSignerGenerator):
+    def __init__(self, args: Optional[Dict] = None):
+        """
+        Signer created based on args provided. If not provided current values of according arguments
+        will be used from current global state from AuthState class.
+
+        Parameters
+        ----------
+        args: dict
+            args that are required to create Security Token signer. Contains keys: oci_config,
+            oci_config_location, oci_key_profile, client_kwargs.
+
+            - oci_config is a configuration dict that can be used to create clients
+            - oci_config_location - path to config file
+            - oci_key_profile - the profile to load from config file
+            - client_kwargs - optional parameters for OCI client creation in next steps
+        """
+        self.oci_config = args.get("oci_config")
+        self.oci_config_location = args.get("oci_config_location")
+        self.oci_key_profile = args.get("oci_key_profile")
+        self.client_kwargs = args.get("client_kwargs")
+
+    def create_signer(self) -> Dict:
+        """
+        Creates security token configuration and signer with extra arguments necessary for creating clients.
+        Signer constructed from the `oci_config` provided. If not 'oci_config', configuration will be
+        constructed from 'oci_config_location' and 'oci_key_profile' in place.
+
+        Returns
+        -------
+        dict
+            Contains keys - config, signer and client_kwargs.
+
+            - config contains the configuration information
+            - signer contains the signer object created. It is instantiated from signer_callable, or
+            signer provided in args used, or instantiated in place
+            - client_kwargs contains the `client_kwargs` that was passed in as input parameter
+
+        Examples
+        --------
+        >>> signer_args = dict(
+        ...     client_kwargs=client_kwargs
+        ... )
+        >>> signer_generator = AuthFactory().signerGenerator(AuthType.SECURITY_TOKEN)
+        >>> signer_generator(signer_args).create_signer()
+        """
+        if self.oci_config:
+            configuration = ads.telemetry.update_oci_client_config(self.oci_config)
+        else:
+            configuration = ads.telemetry.update_oci_client_config(
+                oci.config.from_file(self.oci_config_location, self.oci_key_profile)
+            )
+
+        logger.info(f"Using 'security_token' authentication.")
+
+        if "security_token_file" not in configuration and "security_token_content" not in configuration:
+            raise ValueError(
+                "Parameter `security_token_file` or `security_token_content` must be provided for using `security_token` authentication."
+            )
+
+        if "key_file" not in configuration and "key_content" not in configuration:
+            raise ValueError(
+                "Parameter `key_file` or `key_content` must be provided for using `security_token` authentication."
+            )
+        
+        if "security_token_content" not in configuration and not self.oci_config:
+            os.system(f'oci session refresh --profile {self.oci_key_profile or DEFAULT_PROFILE}')
+
+        return {
+            "config": configuration,
+            "signer": oci.auth.signers.SecurityTokenSigner(
+                token=(
+                    configuration.get("security_token_content", None)
+                    or self._read_security_token_file(configuration.get("security_token_file"))
+                ),
+                private_key=(
+                    oci.signer.load_private_key(configuration.get("key_content"))
+                    if configuration.get("key_content")
+                    else oci.signer.load_private_key_from_file(configuration.get("key_file"))
+                ),
+                generic_headers=configuration.get("generic_headers"),
+                body_headers=configuration.get("body_headers")
+            ),
+            "client_kwargs": self.client_kwargs,
+        }
+    
+    def _read_security_token_file(self, security_token_file: str) -> str:
+        try:
+            token = None
+            with open(security_token_file, 'r') as f:
+                token = f.read()
+            return token
+        except:
+            raise
+
+
 class AuthFactory:
     """
     AuthFactory class which contains list of registered signers and alllows to register new signers.
@@ -687,12 +839,14 @@ class AuthFactory:
         * APIKey
         * ResourcePrincipal
         * InstancePrincipal
+        * SecurityToken
     """
 
     classes = {
         AuthType.API_KEY: APIKey,
         AuthType.RESOURCE_PRINCIPAL: ResourcePrincipal,
         AuthType.INSTANCE_PRINCIPAL: InstancePrincipal,
+        AuthType.SECURITY_TOKEN: SecurityToken,
     }
 
     @classmethod
@@ -726,7 +880,7 @@ class AuthFactory:
 
         Returns
         -------
-        :class:`APIKey` or :class:`ResourcePrincipal` or :class:`InstancePrincipal`
+        :class:`APIKey` or :class:`ResourcePrincipal` or :class:`InstancePrincipal` or :class:`SecurityToken`
             returns one of classes, which implements creation of signer of specified type
 
         Raises

--- a/ads/common/utils.py
+++ b/ads/common/utils.py
@@ -17,7 +17,9 @@ import os
 import random
 import re
 import shutil
+import stat
 import string
+import subprocess
 import sys
 import tempfile
 from datetime import datetime
@@ -1599,3 +1601,58 @@ def is_path_exists(uri: str, auth: Optional[Dict] = None) -> bool:
     if fsspec.filesystem(path_scheme, **storage_options).exists(uri):
         return True
     return False
+
+def apply_user_only_access_permissions(path: str):
+    """Applies user-only access permission to path. The logic is mainly taken reference from:
+    https://github.com/oracle/oci-cli/blob/master/src/oci_cli/cli_util.py#L2555
+
+    Parameters
+    ----------
+    path: str
+        Path to the file or folder
+    """
+    if not os.path.exists(path):
+        raise RuntimeError("Failed attempting to set permissions on path that does not exist: {}".format(path))
+
+    if is_windows():
+        # General permissions strategy is:
+        #   - if we create a new folder (e.g. C:\Users\opc\.oci), set access to allow full control for current user and no access for anyone else
+        #   - if we create a new file, set access to allow full control for current user and no access for anyone else
+        #   - thus if the user elects to place a new file (config or key) in an existing directory, we will not change the
+        #     permissions of that directory but will explicitly set the permissions on that file
+        username = os.environ['USERNAME']
+        userdomain = os.environ['UserDomain']
+        userWithDomain = os.environ['USERNAME']
+        if userdomain:
+            userWithDomain = userdomain + "\\" + username
+        admin_grp = '*S-1-5-32-544'
+        system_usr = '*S-1-5-18'
+        try:
+            if os.path.isfile(path):
+                subprocess.check_output('icacls "{path}" /reset'.format(path=path), stderr=subprocess.STDOUT)
+                try:
+                    subprocess.check_output('icacls "{path}" /inheritance:r /grant:r "{username}:F" /grant {admin_grp}:F /grant {system_usr}:F'.format(path=path, username=userWithDomain, admin_grp=admin_grp, system_usr=system_usr), stderr=subprocess.STDOUT)
+                except subprocess.CalledProcessError:
+                    subprocess.check_output('icacls "{path}" /inheritance:r /grant:r "{username}:F" /grant {admin_grp}:F /grant {system_usr}:F'.format(path=path, username=username, admin_grp=admin_grp, system_usr=system_usr), stderr=subprocess.STDOUT)
+            else:
+                if os.listdir(path):
+                    # safety check to make sure we aren't changing permissions of existing files
+                    raise RuntimeError("Failed attempting to set permissions on existing folder that is not empty.")
+                subprocess.check_output('icacls "{path}" /reset'.format(path=path), stderr=subprocess.STDOUT)
+                try:
+                    subprocess.check_output('icacls "{path}" /inheritance:r /grant:r "{username}:(OI)(CI)F"  /grant:r {admin_grp}:(OI)(CI)F /grant:r {system_usr}:(OI)(CI)F'.format(path=path, username=userWithDomain, admin_grp=admin_grp, system_usr=system_usr), stderr=subprocess.STDOUT)
+                except subprocess.CalledProcessError:
+                    subprocess.check_output('icacls "{path}" /inheritance:r /grant:r "{username}:(OI)(CI)F"  /grant:r {admin_grp}:(OI)(CI)F /grant:r {system_usr}:(OI)(CI)F'.format(path=path, username=username, admin_grp=admin_grp, system_usr=system_usr), stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as exc_info:
+            print("Error occurred while attempting to set permissions for {path}: {exception}".format(path=path, exception=str(exc_info)))
+            sys.exit(exc_info.returncode)
+    else:
+        if os.path.isfile(path):
+            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+        else:
+            # For directories, we need to apply S_IXUSER otherwise it looks like on Linux/Unix/macOS if we create the directory then
+            # it won't behave like a directory and let files be put into it
+            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+
+def is_windows():
+    return sys.platform == 'win32' or sys.platform == 'cygwin'

--- a/ads/opctl/cli.py
+++ b/ads/opctl/cli.py
@@ -230,7 +230,7 @@ _options = [
         "--auth",
         "-a",
         help="authentication method",
-        type=click.Choice(["api_key", "resource_principal"]),
+        type=click.Choice(["api_key", "resource_principal", "security_token"]),
         default=None,
     ),
     click.option(

--- a/ads/opctl/config/merger.py
+++ b/ads/opctl/config/merger.py
@@ -115,7 +115,7 @@ class ConfigMerger(ConfigProcessor):
             else:
                 self.config["execution"]["auth"] = AuthType.API_KEY
         # determine profile
-        if self.config["execution"]["auth"] != AuthType.API_KEY:
+        if self.config["execution"]["auth"] == AuthType.RESOURCE_PRINCIPAL:
             profile = self.config["execution"]["auth"].upper()
             exec_config.pop("oci_profile", None)
             self.config["execution"]["oci_profile"] = None

--- a/docs/source/user_guide/cli/authentication.rst
+++ b/docs/source/user_guide/cli/authentication.rst
@@ -62,13 +62,28 @@ You can choose to use the instance principal to authenticate while using the Acc
   mc = ModelCatalog(compartment_id="<compartment_id>")
   mc.list_models()
 
+4. Authenticating Using Security Token
+--------------------------------------
 
-4. Overriding Defaults
+**Prerequisite**
+
+* You have setup security token as per the instruction `here <https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm>`_
+
+You can choose to use the security token to authenticate while using the Accelerated Data Science (ADS) SDK by running ``ads.set_auth(auth='security_token')``. For example:
+
+.. code-block:: python
+
+  import ads
+  ads.set_auth(auth='security_token')
+  mc = ModelCatalog(compartment_id="<compartment_id>")
+  mc.list_models()
+
+5. Overriding Defaults
 ----------------------
 
 The default authentication that is used by ADS is set with the ``set_auth()`` method. However, each relevant ADS method has an optional parameter to specify the authentication method to use. The most common use case for this is when you have different permissions in different API keys or there are differences between the permissions granted in the resource principals and your API keys.
 
-By default, ADS uses API keys to sign requests to OCI resources. The ``set_auth()`` method is used to explicitly set a default signing method. This method accepts one of three strings ``"api_key"``, ``"resource_principal"``, or ``instance_principal``.
+By default, ADS uses API keys to sign requests to OCI resources. The ``set_auth()`` method is used to explicitly set a default signing method. This method accepts one of four strings ``"api_key"``, ``"resource_principal"``, ``instance_principal`` or ``security_token``.
 
 The ``~/.oci/config`` configuration allow for multiple configurations to be stored in the same file. The ``set_auth()`` method takes is ``oci_config_location`` parameter that specifies the location of the configuration, and the default is ``"~/.oci/config"``. Each configuration is called a profile, and the default profile is ``DEFAULT``. The ``set_auth()`` method takes in a parameter ``profile``. It specifies which profile in the ``~/.oci/config`` configuration file to use. In this context, the ``profile`` parameter is only used when API keys are being used. If no value for ``profile`` is specified, then the ``DEFAULT`` profile section is used.
 
@@ -97,6 +112,7 @@ The ``~/.oci/config`` configuration allow for multiple configurations to be stor
   
   ads.set_auth("resource_principal")  # default signer is set to resource principal authentication
   ads.set_auth("instance_principal")  # default signer is set to instance principal authentication
+  ads.set_auth("security_token")  # default signer is set to security token authentication
 
   singer = oci.auth.signers.ResourcePrincipalsFederationSigner()
   ads.set_auth(config={}, singer=signer) # default signer is set to ResourcePrincipalsFederationSigner
@@ -122,9 +138,12 @@ Additional signers may be provided by running ``set_auth()`` with ``signer`` or 
   oc.OCIClientFactory(**auth).object_storage
 
   # Example 3: Create Object Storage client with timeout set to 6000 using API Key authentication.
-  auth = authutil.api_keys(oci_config="/home/datascience/.oci/config", profile="TEST", kwargs={"timeout": 6000})
+  auth = authutil.api_keys(oci_config="/home/datascience/.oci/config", profile="TEST", client_kwargs={"timeout": 6000})
   oc.OCIClientFactory(**auth).object_storage
 
+  # Example 4: Create Object Storage client with timeout set to 6000 using security token authentication.
+  auth = authutil.security_token(oci_config="/home/datascience/.oci/config", profile="test_session", client_kwargs={"timeout": 6000})
+  oc.OCIClientFactory(**auth).object_storage
 
 In the this example, the default authentication uses API keys specified with the ``set_auth`` method. However, since the ``os_auth`` is specified to use resource principals, the notebook session uses the resource principal to access OCI Object Store.
 
@@ -144,11 +163,14 @@ More signers can be created using the ``create_signer()`` method. With the ``aut
   # Example 1. Create signer that uses instance principals
   auth = ads.auth.create_signer("instance_principal")
 
-  # Example 2. Provide a ResourcePrincipalsFederationSigner object
+  # Example 2. Create signer that uses security token
+  auth = ads.auth.create_signer("security_token", profile="test_session")
+
+  # Example 3. Provide a ResourcePrincipalsFederationSigner object
   singer = oci.auth.signers.ResourcePrincipalsFederationSigner()
   auth = ads.auth.create_signer(config={}, singer=signer)
 
-  # Example 3. Create signer that uses instance principals with log requests enabled
+  # Example 4. Create signer that uses instance principals with log requests enabled
   signer_callable = oci.auth.signers.InstancePrincipalsSecurityTokenSigner
   signer_kwargs = dict(log_requests=True) # will log the request url and response data when retrieving
   auth = ads.auth.create_signer(signer_callable=signer_callable, signer_kwargs=signer_kwargs)

--- a/tests/unitary/default_setup/auth/test_auth.py
+++ b/tests/unitary/default_setup/auth/test_auth.py
@@ -638,7 +638,7 @@ class TestSecurityToken(TestCase):
         mock_get_jwt.assert_called()
         mock_refresh_security_token.assert_called_with(configuration)
 
-    @mock.patch("oci_cli.cli_util.apply_user_only_access_permissions")
+    @mock.patch("ads.common.utils.apply_user_only_access_permissions")
     @mock.patch("json.loads")
     @mock.patch("requests.post")
     @mock.patch("json.dumps")


### PR DESCRIPTION
### Added support for security token authentication

- Added new authenticate way `security_token`
- Updated ADS SDK and OPCTL
- Updated user guide

### Example
```
import ads
ads.set_auth("security_token") # using ~/.oci/config and DEFAULT profile
ads.set_auth("security_token", profile="test_session") # using ~/.oci/config and test_session profile
ads.set_auth("security_token", oci_config_location="test_config_location", profile="test_session") # using test_config_location config and test_session profile

# use config dict
config = {
    "region": "us-ashburn-1",
    "key_file": "~/.oci/sessions/test_session/oci_api_key.pem",
    "security_token_file": "~/.oci/sessions/test_session/token",
}
ads.set_auth("security_token", config=config)

# use AuthContext 
with AuthContext(auth='security_token', profile="test_session"):
    DataScienceJob.from_id("<job_ocid>")

# create security token signer
singer = ads.auth.security_token()
singer = ads.auth.create_signer(auth_type="security_token")

# opctl
!ads opctl run --ocid <job_ocid> --auth security_token
!ads opctl run --ocid <job_ocid> --auth security_token --oci-profile test_session
```