### PR TITLE
Add pre-commit hooks for ocids, copyright and secrets

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,40 @@
+title = "Gitleaks Config"
+
+# Gitleaks feature, extending the existing base config from:
+# https://github.com/zricethezav/gitleaks/blob/master/config/gitleaks.toml
+[extend]
+useDefault = true
+
+# Allowlist's 'stopwords' and 'regexes' excludes any secrets or mathching patterns from the current repository.
+# Paths listed in allowlist will not be scanned.
+[allowlist]
+    description = "Global allow list"
+    stopwords = ["test_password", "sample_key"]
+    regexes = [
+        '''example-password''',
+        '''this-is-not-the-secret''',
+        '''<redacted>'''
+    ]
+    paths = [
+        '''tests/integration/tests_configs.yaml'''
+    ]
+
+# Describe rule to search real ocids
+[[rules]]
+    description = "Real ocids"
+    id = "ocid"
+    regex = '''ocid[123]\.[a-z1-9A-Z]*\.oc\d\.[a-z1-9A-Z]*\.[a-z1-9A-Z]+'''
+    keywords = [
+        "ocid"
+    ]
+
+# Describe rule to search generic secrets
+[[rules]]
+    description = "Generic secret"
+    id = "generic-secret"
+    regex = '''(?i)((key|api|token|secret|passwd|password|psw|pass|pswd)[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([0-9a-zA-Z!@#$%^&*<>\\\-_.=]{3,100})['\"]'''
+    entropy = 0
+    secretGroup = 4
+    keywords = [
+        "key","api","token","secret","passwd","password", "psw", "pass", "pswd"
+    ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,12 @@
 repos:
+# Standard hooks
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
     -   id: check-ast
+        exclude: ^docs/
     -   id: check-docstring-first
-        exclude: ^tests/
+        exclude: ^(docs/|tests/)
     -   id: check-json
     -   id: check-merge-conflict
     -   id: check-yaml
@@ -14,14 +16,34 @@ repos:
     -   id: pretty-format-json
         args: ['--autofix']
     -   id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+        exclude: ^docs/
+# Black, the code formatter, natively supports pre-commit
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.3.0
     hooks:
     -   id: black
+        exclude: ^docs/
+# Regex based rst files common mistakes detector
 -   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
     -   id: rst-backticks
+        files: ^docs/
     -   id: rst-inline-touching-normal
-
-exclude: ^(docs/)
+        files: ^docs/
+# Hardcoded secrets and ocids detector
+-   repo: https://github.com/gitleaks/gitleaks
+    rev: v8.17.0
+    hooks:
+    -   id: gitleaks
+# Oracle copyright checker
+-   repo: https://github.com/oracle-samples/oci-data-science-ai-samples/
+    rev: cbe0136
+    hooks:
+    -   id: check-copyright
+        name: check-copyright
+        entry: .pre-commit-scripts/check-copyright.py
+        language: script
+        types_or: ['python', 'shell', 'bash']
+        exclude: ^docs/


### PR DESCRIPTION
### Description

Added 3 pre-commit hooks:

1. copyright check - this was moved from bitbucket repository and trimmed to be "script" type instead of "python". This check is taken from samples repo now (created by this PR https://github.com/oracle-samples/oci-data-science-ai-samples/pull/323)
2. secrets - used gitleaks, but expanded with custom solution for generic secret
3. ocids - used gitleaks, special rule added with regex, which recognize real ocids

Jira: https://jira.oci.oraclecorp.com/browse/ODSC-42791 (more details about chosen solution in comments in this ticket)

- updated .pre-commit-config.yaml. **Important:** it had top level excluded `docs/` folder, which is incorrect, because we have hooks which check `rst` files, that hooks will never be implemented. I added `exclude` or `files` into each hook id, depending on task of hook. 
- added .gitleaks.toml

### Validation 

Created virtual environment is project folder, installed `pre-commit`, made changes in 3 different files - docs, ads and tests folder - added password, ocid and wrong Copyright. Output (expected, now it is also complaining on rst files, with proper exclude/files setting rst-related hook checked file from docs folder):
```
(venv) (base) lrudenka@lrudenka-mac accelerated-data-science % git add . && git commit -m tests
check python ast.........................................................Passed
check docstring is first.................................................Failed
- hook id: check-docstring-first
- exit code: 1

ads/jobs/serializer.py:15: Module docstring appears after code (code seen on line 6).

check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check yaml...............................................................Passed
detect private key.......................................................Passed
fix end of files.........................................................Passed
pretty format json...................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
black....................................................................Passed
rst ``code`` is two backticks............................................Failed
- hook id: rst-backticks
- exit code: 1

docs/source/release_notes.rst:391:* Fix the version of the `jsonschema` package.
docs/source/release_notes.rst:392:* Update `numpy` deps to >= 1.19.2 for compatibility with `TensorFlow 2.6`.
docs/source/release_notes.rst:456:* Improvement to the model provenance metadata, including a reference to the model training resource (notebook sessions) by passing in the `training_id` to the `.save()` method.
docs/source/release_notes.rst:573:* Changed `set_documentation_mode` to false by default.
docs/source/release_notes.rst:575:* Fixed the `_check_object_exists` to handle situations where the object storage bucket has more than 1000 objects.
docs/source/release_notes.rst:576:* Added option `overwrite_script` in the `create_app()` method to allow a user to override a pre-existing file.

rst ``inline code`` next to normal text..................................Passed
Detect hardcoded secrets.................................................Failed
- hook id: gitleaks
- exit code: 1

○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

Finding:     REDACTEDD
Secret:      REDACTED
RuleID:      ocid
Entropy:     4.651618
File:        ads/jobs/ads_job.py
Line:        24
Fingerprint: ads/jobs/ads_job.py:ocid:24

Finding:     password="REDACTED""
Secret:      REDACTED
RuleID:      generic-secret
Entropy:     3.277613
File:        docs/source/release_notes.rst
Line:        4
Fingerprint: docs/source/release_notes.rst:generic-secret:4

Finding:     password = "REDACTED""
Secret:      REDACTED
RuleID:      generic-secret
Entropy:     3.277613
File:        ads/jobs/ads_job.py
Line:        26
Fingerprint: ads/jobs/ads_job.py:generic-secret:26

Finding:     REDACTEDD
Secret:      REDACTED
RuleID:      ocid
Entropy:     4.651618
File:        docs/source/release_notes.rst
Line:        6
Fingerprint: docs/source/release_notes.rst:ocid:6

Finding:     REDACTEDD
Secret:      REDACTED
RuleID:      ocid
Entropy:     4.651618
File:        tests/integration/pipeline/test_base.py
Line:        9
Fingerprint: tests/integration/pipeline/test_base.py:ocid:9

2:49PM INF 1 commits scanned.
2:49PM INF scan completed in 74ms
2:49PM WRN leaks found: 5

check-copyright..........................................................Failed
- hook id: check-copyright
- exit code: 1

ads/jobs/ads_job.py: Year published or year last edited not correct.
my_test.py: Year published or year last edited not correct.

```
 