### PR TITLE
Odsc 41744/move incorrect opctl information

### DIFF
--- a/ads/opctl/backend/ads_dataflow.py
+++ b/ads/opctl/backend/ads_dataflow.py
@@ -189,7 +189,7 @@ class DataFlowBackend(Backend):
         Watch DataFlow Run from OCID.
         """
         run_id = self.config["execution"]["run_id"]
-        interval = self.config["execution"]["interval"]
+        interval = self.config["execution"].get("interval")
         with AuthContext(auth=self.auth_type, profile=self.profile):
             run = DataFlowRun.from_ocid(run_id)
             run.watch(interval=interval)

--- a/ads/opctl/backend/ads_dataflow.py
+++ b/ads/opctl/backend/ads_dataflow.py
@@ -189,9 +189,10 @@ class DataFlowBackend(Backend):
         Watch DataFlow Run from OCID.
         """
         run_id = self.config["execution"]["run_id"]
+        interval = self.config["execution"]["interval"]
         with AuthContext(auth=self.auth_type, profile=self.profile):
             run = DataFlowRun.from_ocid(run_id)
-            run.watch()
+            run.watch(interval=interval)
 
 
 class DataFlowRuntimeFactory(RuntimeFactory):

--- a/ads/opctl/backend/ads_ml_job.py
+++ b/ads/opctl/backend/ads_ml_job.py
@@ -227,10 +227,11 @@ class MLJobBackend(Backend):
         Watch Job Run from OCID.
         """
         run_id = self.config["execution"]["run_id"]
-
+        interval = self.config["execution"]["interval"]
+        wait = self.config["execution"]["wait"]
         with AuthContext(auth=self.auth_type, profile=self.profile):
             run = DataScienceJobRun.from_ocid(run_id)
-            run.watch()
+            run.watch(interval=interval, wait=wait)
 
     def _jinja_write(self, operator_slug, operator_folder):
         # TODO AH: fill in templates with relevant details

--- a/ads/opctl/backend/ads_ml_job.py
+++ b/ads/opctl/backend/ads_ml_job.py
@@ -227,8 +227,8 @@ class MLJobBackend(Backend):
         Watch Job Run from OCID.
         """
         run_id = self.config["execution"]["run_id"]
-        interval = self.config["execution"]["interval"]
-        wait = self.config["execution"]["wait"]
+        interval = self.config["execution"].get("interval")
+        wait = self.config["execution"].get("wait")
         with AuthContext(auth=self.auth_type, profile=self.profile):
             run = DataScienceJobRun.from_ocid(run_id)
             run.watch(interval=interval, wait=wait)

--- a/ads/opctl/backend/ads_ml_pipeline.py
+++ b/ads/opctl/backend/ads_ml_pipeline.py
@@ -90,8 +90,8 @@ class PipelineBackend(Backend):
         Watch Pipeline Run from OCID.
         """
         run_id = self.config["execution"]["run_id"]
-        log_type = self.config["execution"]["log_type"]
-        interval = self.config["execution"]["interval"]
+        log_type = self.config["execution"].get("log_type")
+        interval = self.config["execution"].get("interval")
         with AuthContext(auth=self.auth_type, profile=self.profile):
             PipelineRun.from_ocid(run_id).watch(
                 interval=interval,

--- a/ads/opctl/backend/ads_ml_pipeline.py
+++ b/ads/opctl/backend/ads_ml_pipeline.py
@@ -90,9 +90,13 @@ class PipelineBackend(Backend):
         Watch Pipeline Run from OCID.
         """
         run_id = self.config["execution"]["run_id"]
-        log_type = self.config["execution"].get("log_type")
+        log_type = self.config["execution"]["log_type"]
+        interval = self.config["execution"]["interval"]
         with AuthContext(auth=self.auth_type, profile=self.profile):
-            PipelineRun.from_ocid(run_id).watch(log_type=log_type)
+            PipelineRun.from_ocid(run_id).watch(
+                interval=interval,
+                log_type=log_type
+            )
 
     def init(
         self,

--- a/ads/opctl/cli.py
+++ b/ads/opctl/cli.py
@@ -480,14 +480,14 @@ def cancel(**kwargs):
 @click.option(
     "--interval",
     help="log interval in seconds",
-    type=[click.INT, click.FLOAT],
+    type=int,
     required=False,
     default=3,
 )
 @click.option(
     "--wait",
     help="time in seconds to keep updating the logs after the job run finished for job.",
-    type=[click.INT, click.FLOAT],
+    type=int,
     required=False,
     default=90
 )

--- a/ads/opctl/cli.py
+++ b/ads/opctl/cli.py
@@ -233,41 +233,28 @@ _options = [
         type=click.Choice(["api_key", "resource_principal"]),
         default=None,
     ),
+]
+
+_model_deployment_options = [
     click.option(
         "--wait-for-completion",
-        help="either to wait for process to complete or not",
+        help="either to wait for process to complete or not for model deployment",
         is_flag=True,
         required=False,
     ),
     click.option(
         "--max-wait-time",
-        help="maximum wait time in seconds for progress to complete",
+        help="maximum wait time in seconds for progress to complete for model deployment",
         type=int,
         required=False,
         default=1200,
     ),
     click.option(
         "--poll-interval",
-        help="poll interval in seconds",
+        help="poll interval in seconds for model deployment",
         type=int,
         required=False,
         default=10,
-    ),
-    click.option(
-        "--log-type", help="the type of logging.", required=False, default=None
-    ),
-    click.option(
-        "--log-filter",
-        help="expression for filtering the logs.",
-        required=False,
-        default=None,
-    ),
-    click.option(
-        "--interval",
-        help="log interval in seconds",
-        type=int,
-        required=False,
-        default=3,
     ),
 ]
 
@@ -464,21 +451,46 @@ def init_operator(**kwargs):
 
 @commands.command()
 @click.argument("ocid", nargs=1)
-@add_options(_options)
+@add_options(_model_deployment_options)
 def delete(**kwargs):
     suppress_traceback(kwargs["debug"])(delete_cmd)(**kwargs)
 
 
 @commands.command()
 @click.argument("ocid", nargs=1)
-@add_options(_options)
+@add_options(_model_deployment_options)
 def cancel(**kwargs):
     suppress_traceback(kwargs["debug"])(cancel_cmd)(**kwargs)
 
 
 @commands.command()
 @click.argument("ocid", nargs=1)
-@add_options(_options)
+@click.option(
+    "--log-type", 
+    help="the type of logging. Allowed value: `custom_log` and `service_log` for pipeline, `access` and `predict` for model deployment.", 
+    required=False, 
+    default=None
+)
+@click.option(
+    "--log-filter",
+    help="expression for filtering the logs for model deployment.",
+    required=False,
+    default=None,
+)
+@click.option(
+    "--interval",
+    help="log interval in seconds",
+    type=int,
+    required=False,
+    default=3,
+)
+@click.option(
+    "--wait",
+    help="time in seconds to keep updating the logs after the job run finished for job.",
+    type=int,
+    required=False,
+    default=90
+)
 def watch(**kwargs):
     """
     ``tail`` logs form a job run, dataflow run or pipeline run.
@@ -489,7 +501,7 @@ def watch(**kwargs):
 
 @commands.command()
 @click.argument("ocid", nargs=1)
-@add_options(_options)
+@add_options(_model_deployment_options)
 def activate(**kwargs):
     """
     Activates a data science service.
@@ -499,7 +511,7 @@ def activate(**kwargs):
 
 @commands.command()
 @click.argument("ocid", nargs=1)
-@add_options(_options)
+@add_options(_model_deployment_options)
 def deactivate(**kwargs):
     """
     Deactivates a data science service.

--- a/ads/opctl/cli.py
+++ b/ads/opctl/cli.py
@@ -480,14 +480,14 @@ def cancel(**kwargs):
 @click.option(
     "--interval",
     help="log interval in seconds",
-    type=int,
+    type=[click.INT, click.FLOAT],
     required=False,
     default=3,
 )
 @click.option(
     "--wait",
     help="time in seconds to keep updating the logs after the job run finished for job.",
-    type=int,
+    type=[click.INT, click.FLOAT],
     required=False,
     default=90
 )

--- a/tests/unitary/with_extras/opctl/test_opctl_dataflow_backend.py
+++ b/tests/unitary/with_extras/opctl/test_opctl_dataflow_backend.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from ads.jobs.builders.infrastructure.dataflow import DataFlowRun
 
 from ads.opctl.backend.ads_dataflow import DataFlowBackend
 
@@ -86,6 +87,23 @@ class TestDataFlowBackend:
                 "oci://<bucket_name>@<namespace>/<prefix>",
                 False,
             )
+
+    @patch(
+        "ads.opctl.backend.ads_dataflow.DataFlowRun.watch",
+        return_value=DataFlowRun(),
+    )
+    @patch(
+        "ads.opctl.backend.ads_dataflow.DataFlowRun.from_ocid",
+        return_value=DataFlowRun(),
+    )
+    def test_watch(self, mock_from_ocid, mock_watch):
+        config = self.config
+        config["execution"]["run_id"] = "test_dataflow_run_id"
+        config["execution"]["interval"] = 10
+        backend = DataFlowBackend(config)
+        backend.watch()
+        mock_from_ocid.assert_called_with("test_dataflow_run_id")
+        mock_watch.assert_called_with(interval=10)
 
     @pytest.mark.parametrize(
         "runtime_type",

--- a/tests/unitary/with_extras/opctl/test_opctl_ml_job_backend.py
+++ b/tests/unitary/with_extras/opctl/test_opctl_ml_job_backend.py
@@ -109,6 +109,24 @@ class TestMLJobBackend:
         job_create.assert_called()
         job_run.assert_called()
 
+    @patch(
+        "ads.opctl.backend.ads_ml_job.DataScienceJobRun.watch",
+        return_value=DataScienceJobRun(),
+    )
+    @patch(
+        "ads.opctl.backend.ads_ml_job.DataScienceJobRun.from_ocid",
+        return_value=DataScienceJobRun(),
+    )
+    def test_watch(self, mock_from_ocid, mock_watch):
+        config = self.config
+        config["execution"]["run_id"] = "test_job_run_id"
+        config["execution"]["interval"] = 10
+        config["execution"]["wait"] = 15
+        backend = MLJobBackend(config)
+        backend.watch()
+        mock_from_ocid.assert_called_with("test_job_run_id")
+        mock_watch.assert_called_with(interval=10, wait=15)
+
     @pytest.mark.parametrize(
         "runtime_type",
         ["container", "script", "python", "notebook", "gitPython"],

--- a/tests/unitary/with_extras/opctl/test_opctl_ml_pipeline_backend.py
+++ b/tests/unitary/with_extras/opctl/test_opctl_ml_pipeline_backend.py
@@ -129,10 +129,11 @@ class TestMLPipelineBackend:
         config = self.config
         config["execution"]["run_id"] = "test_pipeline_run_id"
         config["execution"]["log_type"] = "custom_log"
+        config["execution"]["interval"] = 10
         backend = PipelineBackend(config)
         backend.watch()
         mock_from_ocid.assert_called_with("test_pipeline_run_id")
-        mock_watch.assert_called_with(log_type="custom_log")
+        mock_watch.assert_called_with(interval=10, log_type="custom_log")
 
     @pytest.mark.parametrize(
         "runtime_type",


### PR DESCRIPTION
### Fixed incorrect opctl command help information.

- Fixed the incorrect help information for `delete/cancel/activate/deactivate` commands
- Fixed the help information for `watch` command. 
- Added SDK supported parameters for opctl `watch` for job/data flow/pipeline

### Notebook
<img width="636" alt="Screenshot 2023-06-21 at 4 37 33 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/0d452c0d-77f9-4984-891c-03e8deedf309">
<img width="623" alt="Screenshot 2023-06-21 at 4 38 05 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/98810dbf-7e20-4f1e-96fc-98102fed311d">
<img width="632" alt="Screenshot 2023-06-21 at 4 38 35 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/e6a9dc46-8c76-4b81-858c-a9c467376a20">
<img width="654" alt="Screenshot 2023-06-21 at 4 38 57 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/47431b4c-94a5-4672-a406-59f5f3b4f89d">
<img width="665" alt="Screenshot 2023-06-21 at 4 39 17 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/d256de15-4ffb-46d7-970f-3deb7a7744b9">
