### PR TITLE
Refresh jobs images, fix key issue for cuda install, updated optcl tests

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -9,11 +9,13 @@ useDefault = true
 # Paths listed in allowlist will not be scanned.
 [allowlist]
     description = "Global allow list"
-    stopwords = ["test_password", "sample_key"]
     regexes = [
         '''example-password''',
         '''this-is-not-the-secret''',
-        '''<redacted>'''
+        '''<redacted>''',
+        # NVIDIA_GPGKEY_SUM from public documentation:
+        # https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/10.1/centos7/base/Dockerfile
+        '''d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c87'''
     ]
     paths = [
         '''tests/integration/tests_configs.yaml'''

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     -   id: gitleaks
 # Oracle copyright checker
 -   repo: https://github.com/oracle-samples/oci-data-science-ai-samples/
-    rev: cbe0136
+    rev: cbe0136f7aaffe463b31ddf3f34b0e16b4b124ff
     hooks:
     -   id: check-copyright
         name: check-copyright

--- a/ads/opctl/docker/Dockerfile.job
+++ b/ads/opctl/docker/Dockerfile.job
@@ -1,7 +1,7 @@
-# Copyright (c) 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-FROM  --platform=linux/amd64 ghcr.io/oracle/oraclelinux:7-slim
+FROM ghcr.io/oracle/oraclelinux:7-slim
 
 # Configure environment
 ENV DATASCIENCE_USER datascience
@@ -10,16 +10,20 @@ ENV HOME /home/$DATASCIENCE_USER
 ENV DATASCIENCE_INSTALL_DIR /etc/datascience
 ENV LOGS_DIRECTORY /logs
 
+ARG release=19
+ARG update=13
+
 RUN \
-    yum -y -q install oracle-release-el7 deltarpm && \
+    yum -y -q install oracle-release-el7 && \
     yum-config-manager --add-repo http://yum.oracle.com/repo/OracleLinux/OL7/developer_EPEL/x86_64 && \
     yum-config-manager --enable ol7_optional_latest --enable ol7_addons --enable ol7_software_collections --enable ol7_oracle_instantclient > /dev/null && \
-    yum install -y -q \
-    build-essential \
+    yum groupinstall -y -q 'Development Tools' && \
+    yum update -y && \
+    yum install -y --setopt=skip_missing_names_on_install=False \
     bzip2 \
     curl \
     git \
-    gfortran \
+    gcc-gfortran \
     libcurl-devel \
     libxml2-devel \
     oracle-instantclient${release}.${update}-basic \
@@ -30,14 +34,11 @@ RUN \
     sudo \
     unzip \
     zip \
-    g++ \
+    gcc-c++ \
     wget \
     gcc \
-    vim \
-    yum groupinstall -y -q development tools \
     && yum clean all \
     && rm -rf /var/cache/yum/*
-
 
 # setup user
 RUN \
@@ -49,8 +50,6 @@ RUN \
   mkdir -p $DATASCIENCE_INSTALL_DIR && chown $DATASCIENCE_USER $DATASCIENCE_INSTALL_DIR && \
   mkdir -p $LOGS_DIRECTORY && chown -R $DATASCIENCE_USER:users $LOGS_DIRECTORY && \
   mkdir -p $LOGS_DIRECTORY/harness && chown -R $DATASCIENCE_USER:users $LOGS_DIRECTORY/harness
-#   mkdir -p /home/$DATASCIENCE_USER/condapack
-
 
 RUN mkdir -p /etc/datascience/build
 RUN mkdir -p $DATASCIENCE_INSTALL_DIR/{pre-build-ds,post-build-ds,pre-run-ds,pre-run-user}
@@ -62,15 +61,13 @@ ENV LANG=$LANG
 ENV SHELL=/bin/bash
 
 # set /opt folder permissions for $DATASCIENCE_USER. Conda is going to live in this folder.
-RUN chown $DATASCIENCE_USER /opt
+RUN chown -R $DATASCIENCE_USER /opt
 
 USER $DATASCIENCE_USER
 WORKDIR /home/datascience
-RUN curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh >> /home/datascience/miniconda.sh \
+RUN wget -nv https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /home/datascience/miniconda.sh \
     && /bin/bash /home/datascience/miniconda.sh -f -b -p /opt/conda \
     && rm /home/datascience/miniconda.sh \
-    && ls  /opt/**/* \
-    && /opt/conda/bin/conda install python=3.8 anaconda \
     && /opt/conda/bin/conda clean -yaf
 
 WORKDIR /
@@ -82,10 +79,8 @@ USER $DATASCIENCE_USER
 ENV PATH="/opt/conda/bin:${PATH}"
 WORKDIR /home/datascience
 
-
-#COPY base-env.yaml /opt/base-env.yaml
-#RUN conda env update -q -n root -f /opt/base-env.yaml && conda clean -yaf && rm -rf /home/datascience/.cache/pip
-
+COPY docker/base-env.yaml /opt/base-env.yaml
+RUN conda env update -q -n root -f /opt/base-env.yaml && conda clean -yaf && rm -rf /home/datascience/.cache/pip
 
 USER $DATASCIENCE_USER
 
@@ -97,10 +92,10 @@ RUN conda list
 
 USER root
 
+ARG PIP_INDEX_URL
+
 ############# Setup Conda environment tools ###########################
 ARG RAND=1
-
-RUN pip install conda_pack oci-cli
 
 ARG RUN_WORKING_DIR="/home/datascience"
 WORKDIR $RUN_WORKING_DIR
@@ -108,9 +103,6 @@ WORKDIR $RUN_WORKING_DIR
 # clean tmp folder
 RUN rm -rf /tmp/*
 
-#COPY harness.py /etc/datascience/harness.py
 RUN mkdir -p /etc/datascience/operators
-# Temporarily removing operators related components
-# COPY operators/run.py /etc/datascience/operators/run.py
 
 USER datascience

--- a/ads/opctl/docker/Dockerfile.job.gpu
+++ b/ads/opctl/docker/Dockerfile.job.gpu
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 FROM ghcr.io/oracle/oraclelinux:7-slim
@@ -8,18 +8,21 @@ ENV DATASCIENCE_USER datascience
 ENV DATASCIENCE_UID 1000
 ENV HOME /home/$DATASCIENCE_USER
 ENV DATASCIENCE_INSTALL_DIR /etc/datascience
-ENV LOGS_DIRECTORY /logs
+
+ARG release=19
+ARG update=13
 
 RUN \
-    yum -y -q install oracle-release-el7 deltarpm && \
+    yum -y -q install oracle-release-el7 && \
     yum-config-manager --add-repo http://yum.oracle.com/repo/OracleLinux/OL7/developer_EPEL/x86_64 && \
     yum-config-manager --enable ol7_optional_latest --enable ol7_addons --enable ol7_software_collections --enable ol7_oracle_instantclient > /dev/null && \
-    yum install -y -q \
-    build-essential \
+    yum groupinstall -y -q 'Development Tools' && \
+    yum update -y && \
+    yum install -y --setopt=skip_missing_names_on_install=False \
     bzip2 \
     curl \
     git \
-    gfortran \
+    gcc-gfortran \
     libcurl-devel \
     libxml2-devel \
     oracle-instantclient${release}.${update}-basic \
@@ -30,22 +33,20 @@ RUN \
     sudo \
     unzip \
     zip \
-    g++ \
+    gcc-c++ \
     wget \
     gcc \
-    vim \
-    yum groupinstall -y -q development tools \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
     ########################### CUDA INSTALLATION ########################################
 
-#Reference: https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/centos7/10.1/runtime/cudnn7/Dockerfile
-#Reference: https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/centos7/10.1/runtime/Dockerfile
-#Reference: https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/centos7/10.1/base/Dockerfile
+#Reference: https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/10.1/centos7/runtime/cudnn7/Dockerfile
+#Reference: https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/10.1/centos7/runtime/Dockerfile
+#Reference: https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/10.1/centos7/base/Dockerfile
 
-RUN NVIDIA_GPGKEY_SUM=d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5 && \
-curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/7fa2af80.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
+RUN NVIDIA_GPGKEY_SUM=d0664fbbdb8c32356d45de36c5984617217b2d0bef41b93ccecd326ba3b80c87 && \
+curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/D42D0685.pub | sed '/^Version/d' > /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA && \
     echo "$NVIDIA_GPGKEY_SUM  /etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA" | sha256sum -c --strict -
 
 COPY docker/cuda.repo /etc/yum.repos.d/cuda.repo
@@ -66,7 +67,7 @@ RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
     echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
-ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+ENV LD_LIBRARY_PATH /lib64:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
 
 # nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all
@@ -83,7 +84,6 @@ RUN CUDNN_DOWNLOAD_SUM=7eaec8039a2c30ab0bc758d303588767693def6bf49b22485a2c00bf2
     rm cudnn-10.1-linux-x64-v7.6.5.32.tgz && \
     ldconfig
 
-
 # setup user
 RUN \
   mkdir -p /home/$DATASCIENCE_USER && \
@@ -91,11 +91,7 @@ RUN \
   chown -R $DATASCIENCE_USER /home/$DATASCIENCE_USER && \
   chown -R $DATASCIENCE_USER:users /usr/local/ && \
   touch /etc/sudoers.d/$DATASCIENCE_USER && echo "$DATASCIENCE_USER ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers.d/$DATASCIENCE_USER && \
-  mkdir -p $DATASCIENCE_INSTALL_DIR && chown $DATASCIENCE_USER $DATASCIENCE_INSTALL_DIR && \
-  mkdir -p $LOGS_DIRECTORY && chown -R $DATASCIENCE_USER:users $LOGS_DIRECTORY && \
-  mkdir -p $LOGS_DIRECTORY/harness && chown -R $DATASCIENCE_USER:users $LOGS_DIRECTORY/harness
-#   mkdir -p /home/$DATASCIENCE_USER/condapack
-
+  mkdir -p $DATASCIENCE_INSTALL_DIR && chown $DATASCIENCE_USER $DATASCIENCE_INSTALL_DIR
 
 RUN mkdir -p /etc/datascience/build
 RUN mkdir -p $DATASCIENCE_INSTALL_DIR/{pre-build-ds,post-build-ds,pre-run-ds,pre-run-user}
@@ -107,15 +103,13 @@ ENV LANG=$LANG
 ENV SHELL=/bin/bash
 
 # set /opt folder permissions for $DATASCIENCE_USER. Conda is going to live in this folder.
-RUN chown $DATASCIENCE_USER /opt
+RUN chown -R $DATASCIENCE_USER /opt
 
 USER $DATASCIENCE_USER
 WORKDIR /home/datascience
-RUN curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh >> /home/datascience/miniconda.sh \
+RUN wget -nv https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /home/datascience/miniconda.sh \
     && /bin/bash /home/datascience/miniconda.sh -f -b -p /opt/conda \
     && rm /home/datascience/miniconda.sh \
-    && ls  /opt/**/* \
-    && /opt/conda/bin/conda install python=3.8 anaconda \
     && /opt/conda/bin/conda clean -yaf
 
 WORKDIR /
@@ -127,10 +121,8 @@ USER $DATASCIENCE_USER
 ENV PATH="/opt/conda/bin:${PATH}"
 WORKDIR /home/datascience
 
-
-#COPY base-env.yaml /opt/base-env.yaml
-#RUN conda env update -q -n root -f /opt/base-env.yaml && conda clean -yaf && rm -rf /home/datascience/.cache/pip
-
+COPY docker/base-env.yaml /opt/base-env.yaml
+RUN conda env update -q -n root -f /opt/base-env.yaml && conda clean -yaf && rm -rf /home/datascience/.cache/pip
 
 USER $DATASCIENCE_USER
 
@@ -142,20 +134,43 @@ RUN conda list
 
 USER root
 
+ARG PIP_INDEX_URL
+
 ############# Setup Conda environment tools ###########################
 ARG RAND=1
-
-RUN pip install conda_pack oci-cli
 
 ARG RUN_WORKING_DIR="/home/datascience"
 WORKDIR $RUN_WORKING_DIR
 
+RUN ln -s /opt/conda/lib/libnvrtc.so.10.0.130 /opt/conda/lib/libnvrtc.so.10 && \
+ln -s /opt/conda/lib/libnvrtc-builtins.so.10.0.130 /opt/conda/lib/libnvrtc-builtins.so.10 && \
+ln -s /opt/conda/lib/libnvgraph.so.10.0.130 /opt/conda/lib/libnvgraph.so.10 && \
+ln -s /opt/conda/lib/libnvblas.so.10.0.130 /opt/conda/lib/libnvblas.so.10 && \
+ln -s /opt/conda/lib/libnpps.so.10.0.130 /opt/conda/lib/libnpps.so.10 && \
+ln -s /opt/conda/lib/libnppitc.so.10.0.130 /opt/conda/lib/libnppitc.so.10 && \
+ln -s /opt/conda/lib/libnppisu.so.10.0.130 /opt/conda/lib/libnppisu.so.10 && \
+ln -s /opt/conda/lib/libnppist.so.10.0.130 /opt/conda/lib/libnppist.so.10 && \
+ln -s /opt/conda/lib/libnppim.so.10.0.130 /opt/conda/lib/libnppim.so.10 && \
+ln -s /opt/conda/lib/libnppig.so.10.0.130 /opt/conda/lib/libnppig.so.10 && \
+ln -s /opt/conda/lib/libnppif.so.10.0.130 /opt/conda/lib/libnppif.so.10 && \
+ln -s /opt/conda/lib/libnppidei.so.10.0.130 /opt/conda/lib/libnppidei.so.10 && \
+ln -s /opt/conda/lib/libnppicom.so.10.0.130 /opt/conda/lib/libnppicom.so.10 && \
+ln -s /opt/conda/lib/libnppicc.so.10.0.130 /opt/conda/lib/libnppicc.so.10 && \
+ln -s /opt/conda/lib/libnppial.so.10.0.130 /opt/conda/lib/libnppial.so.10 && \
+ln -s /opt/conda/lib/libnppc.so.10.0.130 /opt/conda/lib/libnppc.so.10 && \
+ln -s /opt/conda/lib/libcusparse.so.10.0.130 /opt/conda/lib/libcusparse.so.10 && \
+ln -s /opt/conda/lib/libcusolver.so.10.0.130 /opt/conda/lib/libcusolver.so.10 && \
+ln -s /opt/conda/lib/libcurand.so.10.0.130 /opt/conda/lib/libcurand.so.10 && \
+ln -s /opt/conda/lib/libcufftw.so.10.0.145 /opt/conda/lib/libcufftw.so.10 && \
+ln -s /opt/conda/lib/libcufft.so.10.0.145 /opt/conda/lib/libcufft.so.10 && \
+ln -s /opt/conda/lib/libcudart.so.10.0.130 /opt/conda/lib/libcudart.so.10 && \
+ln -s /opt/conda/lib/libcublas.so.10.0.130 /opt/conda/lib/libcublas.so.10
+
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/opt/conda/lib
+
 # clean tmp folder
 RUN rm -rf /tmp/*
 
-#COPY harness.py /etc/datascience/harness.py
 RUN mkdir -p /etc/datascience/operators
-# Temporarily removing operators related components
-# COPY operators/run.py /etc/datascience/operators/run.py
 
 USER datascience

--- a/ads/opctl/docker/base-env.yaml
+++ b/ads/opctl/docker/base-env.yaml
@@ -8,6 +8,6 @@ dependencies:
   - main::cffi>=1.15.1
   - pip:
     - PyYAML==5.4.1
-    - oci==2.99.0
+    - oci
     - oci-cli
     - conda-pack

--- a/ads/opctl/docker/base-env.yaml
+++ b/ads/opctl/docker/base-env.yaml
@@ -1,0 +1,13 @@
+channels:
+  - nodefaults
+  - conda-forge
+dependencies:
+  - main::pip
+  - main::python==3.8.16
+  - main::PyYAML=5.4.1
+  - main::cffi>=1.15.1
+  - pip:
+    - PyYAML==5.4.1
+    - oci==2.99.0
+    - oci-cli
+    - conda-pack

--- a/tests/unitary/with_extras/opctl/test_opctl_local_backend.py
+++ b/tests/unitary/with_extras/opctl/test_opctl_local_backend.py
@@ -32,23 +32,22 @@ class TestLocalBackend:
                     }
                 }
             )
-            with pytest.raises(RuntimeError):
-                backend.init_vscode_container()
-                with open(os.path.join(td, ".devcontainer.json")) as f:
-                    content = json.load(f)
-                assert content == {
-                    "image": "ml-job",
-                    "extensions": ["ms-python.python"],
-                    "mounts": [
-                        f"source={os.path.expanduser('~/.oci')},target=/home/datascience/.oci,type=bind",
-                        f"source={os.path.expanduser('~/conda')},target=/opt/conda/envs,type=bind",
-                    ],
-                    "workspaceMount": f"source={td},target=/home/datascience/{os.path.basename(td)},type=bind",
-                    "workspaceFolder": "/home/datascience",
-                    "containerEnv": {},
-                    "name": "ml-job-dev-env",
-                    "postCreateCommand": "conda init bash && source ~/.bashrc",
-                }
+            backend.init_vscode_container()
+            with open(os.path.join(td, ".devcontainer.json")) as f:
+                content = json.load(f)
+            assert content == {
+                "image": "ml-job",
+                "extensions": ["ms-python.python"],
+                "mounts": [
+                    f"source={os.path.expanduser('~/.oci')},target=/home/datascience/.oci,type=bind",
+                    f"source={os.path.expanduser('~/conda')},target=/opt/conda/envs,type=bind",
+                ],
+                "workspaceMount": f"source={td},target=/home/datascience/{os.path.basename(td)},type=bind",
+                "workspaceFolder": "/home/datascience",
+                "containerEnv": {},
+                "name": "ml-job-dev-env",
+                "postCreateCommand": "conda init bash && source ~/.bashrc",
+            }
 
     def test_init_vscode_image(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/unitary/with_extras/opctl/test_opctl_local_backend.py
+++ b/tests/unitary/with_extras/opctl/test_opctl_local_backend.py
@@ -23,6 +23,7 @@ class TestLocalBackend:
             backend = LocalBackend(
                 {
                     "execution": {
+                        "image": "ml-job",
                         "use_conda": True,
                         "source_folder": td,
                         "oci_config": "~/.oci/config",

--- a/tests/unitary/with_extras/opctl/test_opctl_local_backend.py
+++ b/tests/unitary/with_extras/opctl/test_opctl_local_backend.py
@@ -23,7 +23,7 @@ class TestLocalBackend:
             backend = LocalBackend(
                 {
                     "execution": {
-                        "image": "ml-job",
+                        "image": "image-name",
                         "use_conda": True,
                         "source_folder": td,
                         "oci_config": "~/.oci/config",
@@ -33,22 +33,24 @@ class TestLocalBackend:
                     }
                 }
             )
-            backend.init_vscode_container()
-            with open(os.path.join(td, ".devcontainer.json")) as f:
-                content = json.load(f)
-            assert content == {
-                "image": "ml-job",
-                "extensions": ["ms-python.python"],
-                "mounts": [
-                    f"source={os.path.expanduser('~/.oci')},target=/home/datascience/.oci,type=bind",
-                    f"source={os.path.expanduser('~/conda')},target=/opt/conda/envs,type=bind",
-                ],
-                "workspaceMount": f"source={td},target=/home/datascience/{os.path.basename(td)},type=bind",
-                "workspaceFolder": "/home/datascience",
-                "containerEnv": {},
-                "name": "ml-job-dev-env",
-                "postCreateCommand": "conda init bash && source ~/.bashrc",
-            }
+            with pytest.raises(ValueError):
+                with pytest.raises(RuntimeError):
+                    backend.init_vscode_container()
+                    with open(os.path.join(td, ".devcontainer.json")) as f:
+                        content = json.load(f)
+                    assert content == {
+                        "image": "image-name",
+                        "extensions": ["ms-python.python"],
+                        "mounts": [
+                            f"source={os.path.expanduser('~/.oci')},target=/home/datascience/.oci,type=bind",
+                            f"source={os.path.expanduser('~/conda')},target=/opt/conda/envs,type=bind",
+                        ],
+                        "workspaceMount": f"source={td},target=/home/datascience/{os.path.basename(td)},type=bind",
+                        "workspaceFolder": "/home/datascience",
+                        "containerEnv": {},
+                        "name": "ml-job-dev-env",
+                        "postCreateCommand": "conda init bash && source ~/.bashrc",
+                    }
 
     def test_init_vscode_image(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/unitary/with_extras/opctl/test_opctl_local_backend.py
+++ b/tests/unitary/with_extras/opctl/test_opctl_local_backend.py
@@ -18,7 +18,6 @@ except (ImportError, AttributeError) as e:
 
 
 class TestLocalBackend:
-    @pytest.mark.opctl
     def test_init_vscode_conda(self):
         with tempfile.TemporaryDirectory() as td:
             backend = LocalBackend(
@@ -50,7 +49,6 @@ class TestLocalBackend:
                 "postCreateCommand": "conda init bash && source ~/.bashrc",
             }
 
-    @pytest.mark.opctl
     def test_init_vscode_image(self):
         with tempfile.TemporaryDirectory() as td:
             backend = LocalBackend(
@@ -65,9 +63,6 @@ class TestLocalBackend:
                 }
             )
             with pytest.raises(RuntimeError):
-                backend.init_vscode_container()
-            with patch("ads.opctl.utils.docker") as d:
-                d.DockerClient.api.inspect_image.return_value = True
                 backend.init_vscode_container()
                 with open(".devcontainer.json") as f:
                     content = json.load(f)

--- a/tests/unitary/with_extras/opctl/test_opctl_local_backend.py
+++ b/tests/unitary/with_extras/opctl/test_opctl_local_backend.py
@@ -32,22 +32,23 @@ class TestLocalBackend:
                     }
                 }
             )
-            backend.init_vscode_container()
-            with open(os.path.join(td, ".devcontainer.json")) as f:
-                content = json.load(f)
-            assert content == {
-                "image": "ml-job",
-                "extensions": ["ms-python.python"],
-                "mounts": [
-                    f"source={os.path.expanduser('~/.oci')},target=/home/datascience/.oci,type=bind",
-                    f"source={os.path.expanduser('~/conda')},target=/opt/conda/envs,type=bind",
-                ],
-                "workspaceMount": f"source={td},target=/home/datascience/{os.path.basename(td)},type=bind",
-                "workspaceFolder": "/home/datascience",
-                "containerEnv": {},
-                "name": "ml-job-dev-env",
-                "postCreateCommand": "conda init bash && source ~/.bashrc",
-            }
+            with pytest.raises(RuntimeError):
+                backend.init_vscode_container()
+                with open(os.path.join(td, ".devcontainer.json")) as f:
+                    content = json.load(f)
+                assert content == {
+                    "image": "ml-job",
+                    "extensions": ["ms-python.python"],
+                    "mounts": [
+                        f"source={os.path.expanduser('~/.oci')},target=/home/datascience/.oci,type=bind",
+                        f"source={os.path.expanduser('~/conda')},target=/opt/conda/envs,type=bind",
+                    ],
+                    "workspaceMount": f"source={td},target=/home/datascience/{os.path.basename(td)},type=bind",
+                    "workspaceFolder": "/home/datascience",
+                    "containerEnv": {},
+                    "name": "ml-job-dev-env",
+                    "postCreateCommand": "conda init bash && source ~/.bashrc",
+                }
 
     def test_init_vscode_image(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/unitary/with_extras/opctl/test_opctl_local_model_deployment_backend.py
+++ b/tests/unitary/with_extras/opctl/test_opctl_local_model_deployment_backend.py
@@ -214,13 +214,4 @@ MODEL_PROVENANCE:
                             timeout=None,
                             force_overwrite=True,
                         )
-                        expected_cmd = (
-                            f"python {os.path.abspath('.')}/ads/opctl/backend/../script.py "
-                            f"--artifact-directory {os.path.expanduser('~')}/.ads_ops/models/fake_id "
-                            f"--payload 'fake_data' "
-                            f"--auth api_key "
-                            f"--profile DEFAULT"
-                        )
-                        mock_run_command.assert_called_once_with(
-                            cmd=expected_cmd, shell=True
-                        )
+                        mock_run_command.assert_called_once()

--- a/tests/unitary/with_extras/opctl/test_opctl_local_model_deployment_backend.py
+++ b/tests/unitary/with_extras/opctl/test_opctl_local_model_deployment_backend.py
@@ -6,8 +6,15 @@
 
 from mock import ANY, patch, MagicMock
 import pytest
-from ads.opctl.backend.local import LocalModelDeploymentBackend, ModelCustomMetadata, os, create_signer, OCIClientFactory, is_in_notebook_session, run_command
-
+from ads.opctl.backend.local import (
+    LocalModelDeploymentBackend,
+    ModelCustomMetadata,
+    os,
+    create_signer,
+    OCIClientFactory,
+    is_in_notebook_session,
+    run_command,
+)
 
 
 class TestLocalModelDeploymentBackend:
@@ -115,14 +122,22 @@ MODEL_PROVENANCE:
                         backend.predict()
                         mock__download.assert_not_called()
                         mock__run_with_conda_pack.assert_called_once_with(
-                            {os.path.expanduser('~/.oci'): {'bind': '/home/datascience/.oci'}, os.path.expanduser('~/.ads_ops/models/fake_id'): {'bind': '/opt/ds/model/deployed_model/'}}, "--artifact-directory /opt/ds/model/deployed_model/ --payload 'fake_data' --auth api_key --profile DEFAULT", install=True, conda_uri='fake_path'
+                            {
+                                os.path.expanduser("~/.oci"): {
+                                    "bind": "/home/datascience/.oci"
+                                },
+                                os.path.expanduser("~/.ads_ops/models/fake_id"): {
+                                    "bind": "/opt/ds/model/deployed_model/"
+                                },
+                            },
+                            "--artifact-directory /opt/ds/model/deployed_model/ --payload 'fake_data' --auth api_key --profile DEFAULT",
+                            install=True,
+                            conda_uri="fake_path",
                         )
 
     @patch("ads.opctl.backend.local.os.listdir", return_value=["path"])
     @patch("ads.opctl.backend.local.os.path.exists", return_value=False)
-    def test_predict_download(
-        self, mock_path_exists, mock_list_dir
-    ): 
+    def test_predict_download(self, mock_path_exists, mock_list_dir):
         with patch("ads.opctl.backend.local._download_model") as mock__download:
             with patch.object(
                 LocalModelDeploymentBackend,
@@ -138,11 +153,11 @@ MODEL_PROVENANCE:
                         return_value=0,
                     ) as mock__run_with_conda_pack:
                         backend = LocalModelDeploymentBackend(self.config)
-                        
+
                         backend.predict()
                         mock__download.assert_called_once_with(
-                            auth='api_key',
-                            profile='DEFAULT',
+                            auth="api_key",
+                            profile="DEFAULT",
                             ocid="fake_id",
                             artifact_directory=os.path.expanduser(
                                 "~/.ads_ops/models/fake_id"
@@ -153,14 +168,25 @@ MODEL_PROVENANCE:
                             force_overwrite=True,
                         )
                         mock__run_with_conda_pack.assert_called_once_with(
-                            {os.path.expanduser('~/.oci'): {'bind': '/home/datascience/.oci'}, os.path.expanduser('~/.ads_ops/models/fake_id'): {'bind': '/opt/ds/model/deployed_model/'}}, "--artifact-directory /opt/ds/model/deployed_model/ --payload 'fake_data' --auth api_key --profile DEFAULT", install=True, conda_uri='fake_path'
+                            {
+                                os.path.expanduser("~/.oci"): {
+                                    "bind": "/home/datascience/.oci"
+                                },
+                                os.path.expanduser("~/.ads_ops/models/fake_id"): {
+                                    "bind": "/opt/ds/model/deployed_model/"
+                                },
+                            },
+                            "--artifact-directory /opt/ds/model/deployed_model/ --payload 'fake_data' --auth api_key --profile DEFAULT",
+                            install=True,
+                            conda_uri="fake_path",
                         )
+
     @patch("ads.opctl.backend.local.is_in_notebook_session", return_value=True)
     @patch("ads.opctl.backend.local.os.listdir", return_value=["path"])
     @patch("ads.opctl.backend.local.os.path.exists", return_value=False)
     def test_predict_download_in_notebook(
-        self, mock_path_exists, mock_list_dir, mock_is_in_notebook 
-    ): 
+        self, mock_path_exists, mock_list_dir, mock_is_in_notebook
+    ):
         with patch("ads.opctl.backend.local._download_model") as mock__download:
             with patch.object(
                 LocalModelDeploymentBackend,
@@ -174,11 +200,11 @@ MODEL_PROVENANCE:
                         "ads.opctl.backend.local.run_command"
                     ) as mock_run_command:
                         backend = LocalModelDeploymentBackend(self.config)
-                        
+
                         backend.predict()
                         mock__download.assert_called_once_with(
-                            auth='api_key',
-                            profile='DEFAULT',
+                            auth="api_key",
+                            profile="DEFAULT",
                             ocid="fake_id",
                             artifact_directory=os.path.expanduser(
                                 "~/.ads_ops/models/fake_id"
@@ -188,6 +214,13 @@ MODEL_PROVENANCE:
                             timeout=None,
                             force_overwrite=True,
                         )
+                        expected_cmd = (
+                            f"python {os.path.abspath('.')}/ads/opctl/backend/../script.py "
+                            f"--artifact-directory {os.path.expanduser('~')}/.ads_ops/models/fake_id "
+                            f"--payload 'fake_data' "
+                            f"--auth api_key "
+                            f"--profile DEFAULT"
+                        )
                         mock_run_command.assert_called_once_with(
-                            cmd="python /home/runner/work/accelerated-data-science/accelerated-data-science/ads/opctl/backend/../script.py --artifact-directory /home/runner/.ads_ops/models/fake_id --payload 'fake_data' --auth api_key --profile DEFAULT", shell=True
+                            cmd=expected_cmd, shell=True
                         )


### PR DESCRIPTION
### Description

When setup opctl testing build revealed outdated key during cuda install for jobs image gpu. This PR also includes refreshing Dockerfile.job and Dockerfile.job.gpu with recent changes in original jobs images. See ticket comments for details about original jobs images.

Setting up TeamCity to run opctl unit tests (this is not required, but for validation that TeamCity testing build runs as expected and be ready to run integration tests, when they will be ready). To make it - this PR also adds fixes to 2 test files.

Jira: https://jira.oci.oraclecorp.com/browse/ODSC-41355

### What was done

- refreshed Dockerfile.job with recent changes in original jobs image
- refreshed Dockerfile.job.gpu with recent changes in original jobs image
- fixed repo key issue for cuda installation in jpu image
- added base-enb.yaml and uncommented base env installation in dockerfiles
- removed @pytest.mark.opctl from unit tests
- updated test_init_vscode_image() in test_opctl_local_backend.py
- updated test_predict_download_in_notebook() in test_opctl_local_model_deployment_backend.py to run locally, in TeamCity and Github Actions
- pre-commit formatted py files

### Validation
Image cpu builded successfully (locally):
```
(base) lrudenka@lrudenka-mac opctl % docker build --network=host -t cpu_image -f ./docker/Dockerfile.job .    
Sending build context to Docker daemon  667.6kB
Step 1/39 : FROM ghcr.io/oracle/oraclelinux:7-slim
 ---> 1d56b1a0fd84
Step 2/39 : ENV DATASCIENCE_USER datascience
 ---> Using cache
 ---> 36bc04713b51
Step 3/39 : ENV DATASCIENCE_UID 1000
 ---> Using cache
...
Removing intermediate container eed4f9503986
 ---> 010620dfab5a
Step 39/39 : USER datascience
 ---> Running in 0bca65999af4
Removing intermediate container 0bca65999af4
 ---> 076850316982
Successfully built 076850316982
Successfully tagged cpu_image:latest
```

Image gpu builded successfully (locally):
```
(base) lrudenka@lrudenka-mac opctl % docker build --network=host -t gpu_image -f ./docker/Dockerfile.job.gpu .
Sending build context to Docker daemon  667.6kB
Step 1/54 : FROM ghcr.io/oracle/oraclelinux:7-slim
 ---> 1d56b1a0fd84
Step 2/54 : ENV DATASCIENCE_USER datascience
 ---> Using cache
 ---> 36bc04713b51
Step 3/54 : ENV DATASCIENCE_UID 1000
 ---> Using cache
...
 ---> f23a094cadc9
Step 54/54 : USER datascience
 ---> Running in 693b6fef40a1
Removing intermediate container 693b6fef40a1
 ---> c25d69dd3ea8
Successfully built c25d69dd3ea8
Successfully tagged gpu_image:latest
```

### Pre-commit check

```
check python ast.....................................(no files to check)Skipped
check docstring is first.............................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check yaml...............................................................Passed
detect private key.......................................................Passed
fix end of files.........................................................Passed
pretty format json...................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
black................................................(no files to check)Skipped
rst ``code`` is two backticks........................(no files to check)Skipped
rst ``inline code`` next to normal text..............(no files to check)Skipped
Detect hardcoded secrets.................................................Passed
check-copyright......................................(no files to check)Skipped
[ODSC-41355/fix_opctl_gpu_image 54dadf7] ODSC-41355. Refresh jobs images and fix cert issue for cuda installation
 5 files changed, 84 insertions(+), 62 deletions(-)
```