### PR TITLE
Fixed job run opctl.

### DIFF
--- a/ads/opctl/cli.py
+++ b/ads/opctl/cli.py
@@ -17,6 +17,7 @@ import ads.opctl.model.cli
 import ads.opctl.spark.cli
 from ads.common import auth as authutil
 from ads.common.auth import AuthType
+from ads.opctl.cmds import apply as apply_cmd
 from ads.opctl.cmds import activate as activate_cmd
 from ads.opctl.cmds import cancel as cancel_cmd
 from ads.opctl.cmds import configure as configure_cmd
@@ -400,6 +401,12 @@ def run(file, **kwargs):
                 config = suppress_traceback(debug)(yaml.safe_load)(f.read())
         else:
             raise FileNotFoundError(f"{file} is not found")
+
+        if (
+            "kind" in config
+            and config["execution"].get("backend", None) != BACKEND_NAME.LOCAL.value
+        ):
+            return suppress_traceback(debug)(apply_cmd)(config, **kwargs)
     else:
         # If no yaml is provided, we assume there's cmdline args to define a job.
         config = {"kind": "job"}

--- a/ads/opctl/cli.py
+++ b/ads/opctl/cli.py
@@ -17,7 +17,6 @@ import ads.opctl.model.cli
 import ads.opctl.spark.cli
 from ads.common import auth as authutil
 from ads.common.auth import AuthType
-from ads.opctl.cmds import apply as apply_cmd
 from ads.opctl.cmds import activate as activate_cmd
 from ads.opctl.cmds import cancel as cancel_cmd
 from ads.opctl.cmds import configure as configure_cmd
@@ -389,6 +388,7 @@ def run(file, **kwargs):
     Jobs
     """
     debug = kwargs["debug"]
+    config = {}
     if file:
         if os.path.exists(file):
             auth = {}
@@ -402,14 +402,6 @@ def run(file, **kwargs):
         else:
             raise FileNotFoundError(f"{file} is not found")
 
-        if (
-            "kind" in config
-            and config["execution"].get("backend", None) != BACKEND_NAME.LOCAL.value
-        ):
-            return suppress_traceback(debug)(apply_cmd)(config, **kwargs)
-    else:
-        # If no yaml is provided, we assume there's cmdline args to define a job.
-        config = {"kind": "job"}
     suppress_traceback(debug)(run_cmd)(config, **kwargs)
 
 

--- a/ads/opctl/cmds.py
+++ b/ads/opctl/cmds.py
@@ -170,8 +170,8 @@ def run(config: Dict, **kwargs) -> Dict:
     Dict
         dictionary of job id and run id in case of ML Job run, else empty if running locally
     """
-    p = ConfigProcessor(config).step(ConfigMerger, **kwargs)
     if config:
+        p = ConfigProcessor(config).step(ConfigMerger, **kwargs)
         if p.config["kind"] != BACKEND_NAME.LOCAL.value and p.config["kind"] != "distributed":
             p.config["execution"]["backend"] = p.config["kind"]
             return _BackendFactory(p.config).backend.apply()

--- a/ads/opctl/cmds.py
+++ b/ads/opctl/cmds.py
@@ -178,7 +178,7 @@ def run(config: Dict, **kwargs) -> Dict:
     else:
         # If no yaml is provided and config is empty, we assume there's cmdline args to define a job.
         config = {"kind": "job"}
-        p.config["kind"] = config["kind"]
+        p = ConfigProcessor(config).step(ConfigMerger, **kwargs)
     if config.get("kind") == "distributed":  # TODO: add kind factory
         print(
             "......................... Initializing the process ..................................."


### PR DESCRIPTION
### Fixed job run opctl

- Fixed job run opctl command to call `run` instead of `apply` when commands like `ads opctl run --backend job ...` is passed in 

## Notebook
- Create and run job from YAML
<img width="1115" alt="Screenshot 2023-07-25 at 4 44 42 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/a78ff0d8-d5b0-46bb-978c-b033b05ed6a3">

- Create and run job from command parameters
<img width="1107" alt="Screenshot 2023-07-25 at 5 01 28 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/6bec8e79-63b9-4915-81e5-875a6f0574fe">
