### PR TITLE
DataType Changes, validation output transpose

### DIFF
--- a/ads/feature_store/common/enums.py
+++ b/ads/feature_store/common/enums.py
@@ -295,6 +295,7 @@ class FeatureType(Enum):
     STRING_BINARY_MAP = "STRING_BINARY_MAP"
     STRING_BOOLEAN_MAP = "STRING_BOOLEAN_MAP"
     UNKNOWN = "UNKNOWN"
+    COMPLEX = "COMPLEX"
 
 
 class EntityType(Enum):

--- a/ads/feature_store/common/spark_session_singleton.py
+++ b/ads/feature_store/common/spark_session_singleton.py
@@ -75,7 +75,8 @@ class SparkSessionSingleton(metaclass=SingletonMeta):
                 "spark.hadoop.oracle.dcat.metastore.id", metastore_id
             ).config(
                 "spark.sql.warehouse.dir", metastore.default_managed_table_location
-            )
+            )\
+                .config("spark.driver.memory", "16G")
 
         if developer_enabled():
             # Configure spark session with delta jars only in developer mode. In other cases,

--- a/ads/feature_store/common/utils/feature_schema_mapper.py
+++ b/ads/feature_store/common/utils/feature_schema_mapper.py
@@ -71,7 +71,7 @@ def map_spark_type_to_feature_type(spark_type):
     if spark_type in spark_type_to_feature_type:
         return spark_type_to_feature_type.get(spark_type)
     else:
-        return FeatureType.UNKNOWN
+        return FeatureType.COMPLEX
 
 
 def map_pandas_type_to_feature_type(feature_name, values):
@@ -180,7 +180,7 @@ def map_feature_type_to_spark_type(feature_type):
     if feature_type_in in spark_types:
         return spark_types.get(feature_type_in)
     else:
-        return "UNKNOWN"
+        return "COMPLEX"
 
 
 def get_raw_data_source_schema(raw_feature_details: List[dict]):
@@ -225,29 +225,21 @@ def map_feature_type_to_pandas(feature_type):
         FeatureType.INTEGER: "int32",
         FeatureType.DECIMAL: "object",
         FeatureType.DATE: "object",
+        FeatureType.STRING_ARRAY: "object",
+        FeatureType.INTEGER_ARRAY: "object",
+        FeatureType.LONG_ARRAY: "object",
+        FeatureType.FLOAT_ARRAY: "object",
+        FeatureType.DOUBLE_ARRAY: "object",
+        FeatureType.TIMESTAMP_ARRAY: "object",
+        FeatureType.BOOLEAN_ARRAY: "object",
+        # FeatureType.DECIMAL_ARRAY: "object",
+        FeatureType.DATE_ARRAY: "object",
     }
     if feature_type_in in supported_feature_type:
         return supported_feature_type.get(feature_type_in)
     else:
         raise TypeError(f"Feature Type {feature_type} is not supported for pandas")
 
-
-def convert_pandas_datatype_with_schema(
-    raw_feature_details: List[dict], input_df: pd.DataFrame
-):
-    feature_detail_map = {}
-    for feature_details in raw_feature_details:
-        feature_detail_map[feature_details.get("name")] = feature_details
-    for column in input_df.columns:
-        if column in feature_detail_map.keys():
-            feature_details = feature_detail_map[column]
-            feature_type = feature_details.get("featureType")
-            pandas_type = map_feature_type_to_pandas(feature_type)
-            input_df[column] = (
-                input_df[column]
-                .astype(pandas_type)
-                .where(pd.notnull(input_df[column]), None)
-            )
 
 
 def map_spark_type_to_stats_data_type(spark_type):

--- a/ads/feature_store/common/utils/utility.py
+++ b/ads/feature_store/common/utils/utility.py
@@ -264,7 +264,7 @@ def largest_matching_subset_of_primary_keys(left_feature_group, right_feature_gr
 
 def convert_pandas_datatype_with_schema(
         raw_feature_details: List[dict], input_df: pd.DataFrame
-):
+) -> pd.DataFrame:
     feature_detail_map = {}
     columns_to_remove = []
     for feature_details in raw_feature_details:
@@ -280,19 +280,21 @@ def convert_pandas_datatype_with_schema(
                 .where(pd.notnull(input_df[column]), None)
             )
         else:
-            logger.warning("column" + column + "doesnt exist in the input feature details")
+            logger.warning("column" + column + "doesn't exist in the input feature details")
             columns_to_remove.append(column)
     return input_df.drop(columns = columns_to_remove)
 
 
-def validate_spark_dataframe_schema(raw_feature_details: List[dict], input_df: DataFrame):
+def convert_spark_dataframe_with_schema(
+        raw_feature_details: List[dict], input_df: DataFrame
+) -> DataFrame:
     feature_detail_map = {}
     columns_to_remove = []
     for feature_details in raw_feature_details:
         feature_detail_map[feature_details.get("name")] = feature_details
     for column in input_df.columns:
         if column not in feature_detail_map.keys():
-            logger.warning("column" + column + "doesnt exist in the input feature details")
+            logger.warning("column" + column + "doesn't exist in the input feature details")
             columns_to_remove.append(column)
 
     return input_df.drop(*columns_to_remove)
@@ -301,4 +303,4 @@ def validate_spark_dataframe_schema(raw_feature_details: List[dict], input_df: D
 def validate_input_feature_details(input_feature_details, data_frame):
     if isinstance(data_frame, pd.DataFrame):
         return convert_pandas_datatype_with_schema(input_feature_details, data_frame)
-    return validate_spark_dataframe_schema(input_feature_details, data_frame)
+    return convert_spark_dataframe_with_schema(input_feature_details, data_frame)

--- a/ads/feature_store/common/utils/utility.py
+++ b/ads/feature_store/common/utils/utility.py
@@ -11,11 +11,12 @@ from great_expectations.core import ExpectationSuite
 from ads.common.decorator.runtime_dependency import OptionalDependency
 from ads.feature_store.common.utils.feature_schema_mapper import (
     map_spark_type_to_feature_type,
-    map_pandas_type_to_feature_type,
+    map_feature_type_to_pandas,
 )
 from ads.feature_store.feature import Feature, DatasetFeature
 from ads.feature_store.feature_group_expectation import Rule, Expectation
 from ads.feature_store.input_feature_detail import FeatureDetail
+from ads.feature_store.common.spark_session_singleton import SparkSessionSingleton
 
 try:
     from pyspark.pandas import DataFrame
@@ -154,18 +155,9 @@ def get_features(
 
 
 def get_schema_from_pandas_df(df: pd.DataFrame):
-    schema_details = []
-
-    for order_number, field in enumerate(df.columns, start=1):
-        details = {
-            "name": field,
-            "feature_type": map_pandas_type_to_feature_type(field, df[field]),
-            "order_number": order_number,
-        }
-
-        schema_details.append(details)
-
-    return schema_details
+    spark = SparkSessionSingleton().get_spark_session()
+    converted_df = spark.createDataFrame(df)
+    return get_schema_from_spark_df(converted_df)
 
 
 def get_schema_from_spark_df(df: DataFrame):
@@ -268,3 +260,45 @@ def largest_matching_subset_of_primary_keys(left_feature_group, right_feature_gr
     common_keys = left_primary_keys.intersection(right_primary_keys)
 
     return common_keys
+
+
+def convert_pandas_datatype_with_schema(
+        raw_feature_details: List[dict], input_df: pd.DataFrame
+):
+    feature_detail_map = {}
+    columns_to_remove = []
+    for feature_details in raw_feature_details:
+        feature_detail_map[feature_details.get("name")] = feature_details
+    for column in input_df.columns:
+        if column in feature_detail_map.keys():
+            feature_details = feature_detail_map[column]
+            feature_type = feature_details.get("featureType")
+            pandas_type = map_feature_type_to_pandas(feature_type)
+            input_df[column] = (
+                input_df[column]
+                .astype(pandas_type)
+                .where(pd.notnull(input_df[column]), None)
+            )
+        else:
+            logger.warning("column" + column + "doesnt exist in the input feature details")
+            columns_to_remove.append(column)
+    return input_df.drop(columns = columns_to_remove)
+
+
+def validate_spark_dataframe_schema(raw_feature_details: List[dict], input_df: DataFrame):
+    feature_detail_map = {}
+    columns_to_remove = []
+    for feature_details in raw_feature_details:
+        feature_detail_map[feature_details.get("name")] = feature_details
+    for column in input_df.columns:
+        if column not in feature_detail_map.keys():
+            logger.warning("column" + column + "doesnt exist in the input feature details")
+            columns_to_remove.append(column)
+
+    return input_df.drop(*columns_to_remove)
+
+
+def validate_input_feature_details(input_feature_details, data_frame):
+    if isinstance(data_frame, pd.DataFrame):
+        return convert_pandas_datatype_with_schema(input_feature_details, data_frame)
+    return validate_spark_dataframe_schema(input_feature_details, data_frame)

--- a/ads/feature_store/docs/source/feature_group.rst
+++ b/ads/feature_store/docs/source/feature_group.rst
@@ -366,7 +366,7 @@ The data will be stored in a data type native to each store. There is an option 
          - DOUBLE_ARRAY
          - List of values
        * - ArrayType(BinaryType())
-         - object (list), object (np.ndarray)
+         - object (list), object (np.ndarray) - not supported
          - BINARY_ARRAY
          - List of values
        * - ArrayType(DateType())

--- a/ads/feature_store/docs/source/feature_group.rst
+++ b/ads/feature_store/docs/source/feature_group.rst
@@ -175,10 +175,6 @@ Statistics Results
 ==================
 You can call the ``get_statistics()`` method of the FeatureGroup instance to fetch validation results for a specific ingestion job.
 
-.. note::
-
-  PyDeequ is a Python API for Deequ, a library built on top of Apache Spark for defining "unit tests for data", which measure data quality in large datasets.
-
 .. code-block:: python3
 
   # Fetch stats results for a feature group job
@@ -196,26 +192,17 @@ With a FeatureGroup instance, we can get the last feature group job details usin
 
   # Fetch validation results for a feature group
   feature_group_job = feature_group.get_last_job()
-  df = feature_group_job.get_validation().to_pandas()
-  df.show()
+  feature_group_job.get_validation_output_df()
 
 Get features
 =============
-You can call the ``get_features_dataframe()`` method of the FeatureGroup instance to fetch features in a feature group
+You can call the ``get_features_df`` method of the FeatureGroup instance to fetch features in a feature group
 
 .. code-block:: python3
 
   # Fetch features for a feature group
-  df = feature_group.get_features_dataframe()
+  df = feature_group.get_features_df()
 
-Get input schema details
-==========================
-You can call the ``get_input_schema_dataframe()`` method of the FeatureGroup instance to fetch input schema details of a feature group
-
-.. code-block:: python3
-
-  # Fetch features for a feature group
-  df = feature_group.get_input_schema_dataframe()
 
 Filter
 ======
@@ -363,31 +350,31 @@ The data will be stored in a data type native to each store. There is an option 
          - STRING
          - Textual data
        * - ArrayType(IntegerType())
-         - object (list), object (np.ndarray) - not supported
+         - object (list), object (np.ndarray)
          - INTEGER_ARRAY
          - List of values
        * - ArrayType(LongType())
-         - object (list), object (np.ndarray) - not supported
+         - object (list), object (np.ndarray)
          - LONG_ARRAY
          - List of values
        * - ArrayType(FloatType())
-         - object (list), object (np.ndarray) - not supported
+         - object (list), object (np.ndarray)
          - FLOAT_ARRAY
          - List of values
        * - ArrayType(DoubleType())
-         - object (list), object (np.ndarray) - not supported
+         - object (list), object (np.ndarray)
          - DOUBLE_ARRAY
          - List of values
        * - ArrayType(BinaryType())
-         - object (list), object (np.ndarray) - not supported
+         - object (list), object (np.ndarray)
          - BINARY_ARRAY
          - List of values
        * - ArrayType(DateType())
-         - object (list), object (np.ndarray) - not supported
+         - object (list), object (np.ndarray)
          - DATE_ARRAY
          - List of values
        * - ArrayType(TimestampType())
-         - object (list), object (np.ndarray) - not supported
+         - object (list), object (np.ndarray)
          - TIMESTAMP_ARRAY
          - List of values
        * - StructType

--- a/ads/feature_store/docs/source/feature_group.rst
+++ b/ads/feature_store/docs/source/feature_group.rst
@@ -152,7 +152,12 @@ Feature store provides an API similar to Pandas to join feature groups together 
 
 Save expectation entity
 =======================
-With a ``FeatureGroup`` instance, we can save the expectation entity using ``save_expectation()``
+With a ``FeatureGroup`` instance, You can save the expectation details using ``with_expectation_suite()`` with parameters
+
+- ``expectation_suite: ExpectationSuite``. ExpectationSuit of great expectation
+- ``expectation_type: ExpectationType``. Type of expectation
+        - ``ExpectationType.STRICT``: Fail the job if expectation not met
+        - ``ExpectationType.LENIENT``: Pass the job even if expectation not met
 
 .. note::
 
@@ -160,16 +165,32 @@ With a ``FeatureGroup`` instance, we can save the expectation entity using ``sav
 
 .. image:: figures/validation.png
 
-The ``.save_expectation()`` method takes the following optional parameter:
-
-- ``expectation: Expectation``. Expectation of great expectation
-- ``expectation_type: ExpectationType``. Type of expectation
-        - ``ExpectationType.STRICT``: Fail the job if expectation not met
-        - ``ExpectationType.LENIENT``: Pass the job even if expectation not met
-
 .. code-block:: python3
 
-  feature_group.save_expectation(expectation_suite, expectation_type="STRICT")
+    expectation_suite = ExpectationSuite(
+        expectation_suite_name="expectation_suite_name"
+    )
+    expectation_suite.add_expectation(
+        ExpectationConfiguration(
+            expectation_type="expect_column_values_to_not_be_null",
+            kwargs={"column": "<column>"},
+        )
+
+    feature_group_resource = (
+        FeatureGroup()
+        .with_feature_store_id(feature_store.id)
+        .with_primary_keys(["<key>"])
+        .with_name("<name>")
+        .with_entity_id(entity.id)
+        .with_compartment_id(<compartment_id>)
+        .with_schema_details_from_dataframe(<datframe>)
+        .with_expectation_suite(
+            expectation_suite=expectation_suite,
+            expectation_type=ExpectationType.STRICT,
+         )
+    )
+
+You can call the ``get_validation_output()`` method of the FeatureGroup instance to fetch validation results for a specific ingestion job.
 
 Statistics Results
 ==================
@@ -192,7 +213,6 @@ With a FeatureGroup instance, we can get the last feature group job details usin
 
   # Fetch validation results for a feature group
   feature_group_job = feature_group.get_last_job()
-  feature_group_job.get_validation_output_df()
 
 Get features
 =============

--- a/ads/feature_store/docs/source/feature_group.rst
+++ b/ads/feature_store/docs/source/feature_group.rst
@@ -173,7 +173,7 @@ The ``.save_expectation()`` method takes the following optional parameter:
 
 Statistics Results
 ==================
-You can call the ``get_statistics()`` method of the FeatureGroup instance to fetch validation results for a specific ingestion job.
+You can call the ``get_statistics()`` method of the FeatureGroup instance to fetch statistics for a specific ingestion job.
 
 .. code-block:: python3
 
@@ -295,7 +295,8 @@ The data will be stored in a data type native to each store. There is an option 
 
     Offline data types
     ###################
-    Please refer to the following mapping when registering a Spark DataFrame, or a Pandas DataFrame.
+    Please refer to the following mapping when registering a Spark DataFrame, or a Pandas DataFrame.For spark dataframes we support
+    all the data types and the ones which are not specified in the following table will be mapped to  Offline Feature Type COMPLEX
 
     .. list-table::
        :widths: 20 25 25 40

--- a/ads/feature_store/docs/source/release_notes.rst
+++ b/ads/feature_store/docs/source/release_notes.rst
@@ -3,7 +3,7 @@
 =============
 Release Notes
 =============
-1.0
+1.1
 ---
 
 .. note::
@@ -24,6 +24,32 @@ Release Notes
         - `link <https://objectstorage.us-ashburn-1.oraclecloud.com/p/vZogtXWwHqbkGLeqyKiqBmVxdbR4MK4nyOBqDsJNVE4sHGUY5KFi4T3mOFGA3FOy/n/idogsu2ylimg/b/oci-feature-store/o/beta/terraform/feature-store-terraform.zip>`__
         - Par link expires Jan 5, 2026
 
+
+Release notes: July 5, 2023
+
+* [FEATURE] Supporting Offline Feature Type COMPLEX
+* [[DOCS] Data Type update for Offline Feature Type COMPLEX
+
+1.0
+---
+
+.. note::
+
+    .. list-table::
+      :header-rows: 1
+
+      * - Package Name
+        - Latest Version
+        - Notes
+      * - Conda pack
+        - `https://objectstorage.us-ashburn-1.oraclecloud.com/n/bigdatadatasciencelarge/b/service-conda-packs-fs/o/service_pack/cpu/PySpark_3.2_and_Feature_Store/1.0/fspyspark32_p38_cpu_v1#conda`
+        -
+      * - SERVICE_VERSION
+        - 0.1.209.master
+        -
+      * - Terraform Stack
+        - `link <https://objectstorage.us-ashburn-1.oraclecloud.com/p/vZogtXWwHqbkGLeqyKiqBmVxdbR4MK4nyOBqDsJNVE4sHGUY5KFi4T3mOFGA3FOy/n/idogsu2ylimg/b/oci-feature-store/o/beta/terraform/feature-store-terraform.zip>`__
+        - Par link expires Jan 5, 2026
 
 Release notes: June 15, 2023
 

--- a/ads/feature_store/docs/source/release_notes.rst
+++ b/ads/feature_store/docs/source/release_notes.rst
@@ -18,7 +18,7 @@ Release Notes
         - `https://objectstorage.us-ashburn-1.oraclecloud.com/n/bigdatadatasciencelarge/b/service-conda-packs-fs/o/service_pack/cpu/PySpark_3.2_and_Feature_Store/1.0/fspyspark32_p38_cpu_v1#conda`
         -
       * - SERVICE_VERSION
-        - 0.1.209.master
+        - 0.1.212.master
         -
       * - Terraform Stack
         - `link <https://objectstorage.us-ashburn-1.oraclecloud.com/p/vZogtXWwHqbkGLeqyKiqBmVxdbR4MK4nyOBqDsJNVE4sHGUY5KFi4T3mOFGA3FOy/n/idogsu2ylimg/b/oci-feature-store/o/beta/terraform/feature-store-terraform.zip>`__

--- a/ads/feature_store/docs/source/terraform.rst
+++ b/ads/feature_store/docs/source/terraform.rst
@@ -30,21 +30,21 @@ Feature Store users need to provide the following access permissions in order to
 
     define tenancy <feature store service tenancy> as <feature store service tenancy ocid>
     endorse group <feature store user group> to read repos in tenancy <feature store service tenancy>
-    allow group <feature store user group> to manage orm-stacks in compartment <compartmentId>
-    allow group <feature store user group> to manage orm-jobs in compartment <compartmentId>
-    allow group <feature store user group> to manage object-family in compartment <compartmentId>
-    allow group <feature store user group> to manage users in compartment <compartmentId>
-    allow group <feature store user group> to manage instance-family in compartment <compartmentId>
-    allow group <feature store user group> to manage tag-namespaces in compartment <compartmentId>
-    allow group <feature store user group> to manage groups in compartment <compartmentId>
-    allow group <feature store user group> to manage policies in compartment <compartmentId>
-    allow group <feature store user group> to manage dynamic-groups in compartment <compartmentId>
-    allow group <feature store user group> to manage virtual-network-family in compartment <compartmentId>
-    allow group <feature store user group> to manage functions-family in compartment <compartmentId>
-    allow group <feature store user group> to inspect compartments in compartment <compartmentId>
-    allow group <feature store user group> to manage cluster-family in compartment <compartmentId>
-    allow group <feature store user group> to manage mysql-family in compartment <compartmentId>
-    allow group <feature store user group> to manage api-gateway-family in compartment <compartmentId>
+    allow group <feature store user group> to manage orm-stacks in compartment <compartmentName>
+    allow group <feature store user group> to manage orm-jobs in compartment <compartmentName>
+    allow group <feature store user group> to manage object-family in compartment <compartmentName>
+    allow group <feature store user group> to manage users in compartment <compartmentName>
+    allow group <feature store user group> to manage instance-family in compartment <compartmentName>
+    allow group <feature store user group> to manage tag-namespaces in compartment <compartmentName>
+    allow group <feature store user group> to manage groups in compartment <compartmentName>
+    allow group <feature store user group> to manage policies in compartment <compartmentName>
+    allow group <feature store user group> to manage dynamic-groups in compartment <compartmentName>
+    allow group <feature store user group> to manage virtual-network-family in compartment <compartmentName>
+    allow group <feature store user group> to manage functions-family in compartment <compartmentName>
+    allow group <feature store user group> to inspect compartments in compartment <compartmentName>
+    allow group <feature store user group> to manage cluster-family in compartment <compartmentName>
+    allow group <feature store user group> to manage mysql-family in compartment <compartmentName>
+    allow group <feature store user group> to manage api-gateway-family in compartment <compartmentName>
 
 Deploy Using Oracle Resource Manager
 ====================================

--- a/ads/feature_store/execution_strategy/spark/spark_execution.py
+++ b/ads/feature_store/execution_strategy/spark/spark_execution.py
@@ -27,9 +27,6 @@ from ads.feature_store.common.enums import (
     EntityType,
 )
 from ads.feature_store.common.spark_session_singleton import SparkSessionSingleton
-from ads.feature_store.common.utils.feature_schema_mapper import (
-    convert_pandas_datatype_with_schema,
-)
 from ads.feature_store.common.utils.transformation_utils import TransformationUtils
 from ads.feature_store.data_validation.great_expectation import ExpectationService
 from ads.feature_store.dataset_job import DatasetJob
@@ -41,6 +38,9 @@ from ads.feature_store.feature_group_job import FeatureGroupJob
 from ads.feature_store.transformation import Transformation
 
 from ads.feature_store.feature_statistics.statistics_service import StatisticsService
+from ads.feature_store.common.utils.utility import (
+    validate_input_feature_details
+)
 
 logger = logging.getLogger(__name__)
 
@@ -177,11 +177,8 @@ class SparkExecutionEngine(Strategy):
             database = feature_group.entity_id
             self.spark_engine.create_database(database)
 
-            if isinstance(data_frame, pd.DataFrame):
-                if not feature_group.is_infer_schema:
-                    convert_pandas_datatype_with_schema(
-                        feature_group.input_feature_details, data_frame
-                    )
+            if not feature_group.is_infer_schema:
+                data_frame = validate_input_feature_details(feature_group.input_feature_details, data_frame)
 
             # TODO: Get event timestamp column and apply filtering basis from and to timestamp
 

--- a/ads/feature_store/feature_group_job.py
+++ b/ads/feature_store/feature_group_job.py
@@ -177,7 +177,7 @@ class FeatureGroupJob(Builder):
         )
 
         # Convert Python object to Pandas DataFrame
-        validation_output_df = pandas.json_normalize(validation_output_json)
+        validation_output_df = pandas.json_normalize(validation_output_json).transpose()
 
         # return the validation output DataFrame
         return validation_output_df

--- a/ads/feature_store/validation_output.py
+++ b/ads/feature_store/validation_output.py
@@ -22,7 +22,7 @@ class ValidationOutput(ResponseBuilder):
             The validation output information as a pandas DataFrame.
         """
         if self.content:
-            profile_result = pd.json_normalize(self.content)
+            profile_result = pd.json_normalize(self.content).transpose()
             return profile_result
 
     @property

--- a/tests/integration/feature_store/test_base.py
+++ b/tests/integration/feature_store/test_base.py
@@ -41,6 +41,9 @@ class FeatureStoreTestCase:
     COMPARTMENT_ID = "ocid1.tenancy.oc1..aaaaaaaa462hfhplpx652b32ix62xrdijppq2c7okwcqjlgrbknhgtj2kofa"
     METASTORE_ID = "ocid1.datacatalogmetastore.oc1.iad.amaaaaaabiudgxyap7tizm4gscwz7amu7dixz7ml3mtesqzzwwg3urvvdgua"
     INPUT_FEATURE_DETAILS = [
+        FeatureDetail("flower")
+        .with_feature_type(FeatureType.STRING)
+        .with_order_number(1),
         FeatureDetail("sepal_length")
         .with_feature_type(FeatureType.DOUBLE)
         .with_order_number(1),

--- a/tests/integration/feature_store/test_dataset_validations.py
+++ b/tests/integration/feature_store/test_dataset_validations.py
@@ -55,7 +55,7 @@ class TestFeatureGroupValidation(FeatureStoreTestCase):
         assert dataset.oci_dataset.id
 
         dataset.materialise()
-        df = dataset.get_validation_output().to_pandas()
+        df = dataset.get_validation_output().to_pandas().T
         assert df is not None
         assert "success" in df.columns
         assert True in df["success"].values

--- a/tests/integration/feature_store/test_datatype_pandas_array.py
+++ b/tests/integration/feature_store/test_datatype_pandas_array.py
@@ -1,4 +1,4 @@
-
+import ads.feature_store.common.exceptions
 from tests.integration.feature_store.test_base import FeatureStoreTestCase
 from ads.feature_store.input_feature_detail import FeatureDetail, FeatureType
 from ads.feature_store.feature_group import FeatureGroup
@@ -8,23 +8,45 @@ import pytest
 
 
 class TestDataTypePandasArray(FeatureStoreTestCase):
-    input_feature_details_string_array = [
-        FeatureDetail("A").with_feature_type(FeatureType.STRING).with_order_number(1),
-        FeatureDetail("B").with_feature_type(FeatureType.STRING_ARRAY).with_order_number(2),
+    input_feature_details_pandas_array = [
+        FeatureDetail("Strings").with_feature_type(FeatureType.STRING_ARRAY).with_order_number(1),
+        FeatureDetail("Int32").with_feature_type(FeatureType.INTEGER_ARRAY).with_order_number(2),
+        FeatureDetail("Int64").with_feature_type(FeatureType.LONG_ARRAY).with_order_number(3),
+        FeatureDetail("Float32").with_feature_type(FeatureType.FLOAT_ARRAY).with_order_number(4),
+        FeatureDetail("Float64").with_feature_type(FeatureType.DOUBLE_ARRAY).with_order_number(5),
+        FeatureDetail("Timestamps").with_feature_type(FeatureType.TIMESTAMP_ARRAY).with_order_number(6),
+        FeatureDetail("Boolean").with_feature_type(FeatureType.BOOLEAN_ARRAY).with_order_number(7),
+        FeatureDetail("Dates").with_feature_type(FeatureType.DATE_ARRAY).with_order_number(8),
     ]
 
     input_feature_details_numpy_array = [
         FeatureDetail("A").with_feature_type(FeatureType.FLOAT_ARRAY).with_order_number(2),
     ]
 
-    a = ["value1", "value2"]
-    b = [['j@a.com', 'x@y.com'], ['x@a.com', 'x@y.com', 'j@k.com']]
-    df_array = pd.DataFrame(
-        {
-            "A": a,
-            "B": b
-        }
-    )
+    strings = [['a', 'b', 'c'], ['d', 'e', 'f'], ['g', 'h', 'i']]
+    int32 = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    int64 = [[92233720368547758072030], [40, 50, 60], [70, 80, 90]]
+    float32 = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]
+    float64 = [[1.1, 2.2, 3.3], [4.4, 5.5, 6.6], [7.7, 8.8, 9.9]]
+    timestamps = [[pd.Timestamp('2023-06-01').timestamp(), pd.Timestamp('2023-06-02').timestamp()],
+                  [pd.Timestamp('2023-06-01').timestamp(), pd.Timestamp('2023-06-02').timestamp()],
+                  [pd.Timestamp('2023-06-03').timestamp(), pd.Timestamp('2023-06-03').timestamp()]]
+    boolean = [[True, False, True], [False, True, False], [True, False, True]]
+    dates = [[pd.Timestamp('2023-06-01').date(), pd.Timestamp('2023-06-02').date()],
+             [pd.Timestamp('2023-06-01').date(), pd.Timestamp('2023-06-03').date()],
+             [pd.Timestamp('2023-06-01').date(), pd.Timestamp('2023-06-03').date()]]
+
+    # Create DataFrame
+    df_array = pd.DataFrame({
+        'Strings': strings,
+        'Int32': int32,
+        'Int64': int64,
+        'Float32': float32,
+        'Float64': float64,
+        'Timestamps': timestamps,
+        'Boolean': boolean,
+        'Dates': dates
+    })
 
     one_d_array = np.array([1.1, 2.2, 3.3], dtype="float32")
     two_d_array = one_d_array * one_d_array[:, np.newaxis]
@@ -36,19 +58,17 @@ class TestDataTypePandasArray(FeatureStoreTestCase):
     def define_feature_group_resource_with_pandas_array_infer_schema(
         self, entity_id, feature_store_id
     ):
-
-        with pytest.raises(TypeError, match="object of type <class 'list'> not supported"):
-            feature_group_pandas_array= (
-                FeatureGroup()
-                .with_description("feature group resource for pandas datatypes")
-                .with_compartment_id(self.COMPARTMENT_ID)
-                .with_name(self.get_name("feature_group_pandas_array"))
-                .with_entity_id(entity_id)
-                .with_feature_store_id(feature_store_id)
-                .with_primary_keys([])
-                .with_schema_details_from_dataframe(self.df_array)
-                .with_statistics_config(False)
-            )
+        feature_group_pandas_array= (
+            FeatureGroup()
+            .with_description("feature group resource for pandas datatypes")
+            .with_compartment_id(self.COMPARTMENT_ID)
+            .with_name(self.get_name("feature_group_pandas_array"))
+            .with_entity_id(entity_id)
+            .with_feature_store_id(feature_store_id)
+            .with_primary_keys([])
+            .with_schema_details_from_dataframe(self.df_array)
+        )
+        return feature_group_pandas_array
 
     def define_feature_group_resource_with_pandas_array_with_schema(
             self, entity_id, feature_store_id
@@ -61,7 +81,7 @@ class TestDataTypePandasArray(FeatureStoreTestCase):
             .with_entity_id(entity_id)
             .with_feature_store_id(feature_store_id)
             .with_primary_keys([])
-            .with_input_feature_details(self.input_feature_details_string_array)
+            .with_input_feature_details(self.input_feature_details_pandas_array)
             .with_statistics_config(False)
         )
         return feature_group_pandas_array
@@ -69,9 +89,7 @@ class TestDataTypePandasArray(FeatureStoreTestCase):
     def define_feature_group_resource_with_numpy_array_infer_schema(
         self, entity_id, feature_store_id
     ):
-
-        with pytest.raises(TypeError, match="object of type <class 'numpy.ndarray'> not supported"):
-            feature_group_numpy_array = (
+        feature_group_numpy_array = (
                 FeatureGroup()
                 .with_description("feature group resource for pandas datatypes")
                 .with_compartment_id(self.COMPARTMENT_ID)
@@ -82,6 +100,7 @@ class TestDataTypePandasArray(FeatureStoreTestCase):
                 .with_schema_details_from_dataframe(self.numpy_array_df)
                 .with_statistics_config(False)
             )
+        return feature_group_numpy_array
 
     def define_feature_group_resource_with_numpy_array_with_schema(
             self, entity_id, feature_store_id
@@ -100,22 +119,28 @@ class TestDataTypePandasArray(FeatureStoreTestCase):
         return feature_group_numpy_array_schema
 
     def test_feature_group_pandas_array_infer_schema(self):
-        """Tests  pandas date time data types"""
+        """Tests  pandas array  types"""
         fs = self.define_feature_store_resource().create()
         assert fs.oci_fs.id
 
         entity = self.create_entity_resource(fs)
         assert entity.oci_fs_entity.id
 
-        self.define_feature_group_resource_with_pandas_array_infer_schema(
+        feature_group = self.define_feature_group_resource_with_pandas_array_infer_schema(
             entity.oci_fs_entity.id, fs.oci_fs.id
         )
+        feature_group.create()
+        feature_group.materialise(self.df_array)
 
+        df = feature_group.select().read()
+        assert df
+
+        self.clean_up_feature_group(feature_group)
         self.clean_up_entity(entity)
         self.clean_up_feature_store(fs)
 
     def test_feature_group_pandas_array_with_schema(self):
-        """Tests  pandas date time data types"""
+        """Tests pandas array with schema"""
         fs = self.define_feature_store_resource().create()
         assert fs.oci_fs.id
 
@@ -128,21 +153,28 @@ class TestDataTypePandasArray(FeatureStoreTestCase):
         feature_group.create()
         feature_group.materialise(self.df_array)
 
+        df = feature_group.select().read()
+        assert df
+
         self.clean_up_feature_group(feature_group)
         self.clean_up_entity(entity)
         self.clean_up_feature_store(fs)
 
     def test_feature_group_numpy_array_infer_schema(self):
-        """Tests  pandas date time data types"""
+        """Tests numpy array infer schema"""
         fs = self.define_feature_store_resource().create()
         assert fs.oci_fs.id
 
         entity = self.create_entity_resource(fs)
         assert entity.oci_fs_entity.id
 
-        self.define_feature_group_resource_with_numpy_array_infer_schema(
-            entity.oci_fs_entity.id, fs.oci_fs.id
-        )
+        try:
+            self.define_feature_group_resource_with_numpy_array_infer_schema(
+                entity.oci_fs_entity.id, fs.oci_fs.id
+            )
+        except TypeError as e:
+            assert e.__str__() == "Unable to infer the type of the field A."
+
         self.clean_up_entity(entity)
         self.clean_up_feature_store(fs)
 
@@ -155,10 +187,14 @@ class TestDataTypePandasArray(FeatureStoreTestCase):
         assert entity.oci_fs_entity.id
 
         feature_group = self.define_feature_group_resource_with_numpy_array_with_schema(
-            entity.oci_fs_entity.id, fs.oci_fs.id
+                entity.oci_fs_entity.id, fs.oci_fs.id
         )
         feature_group.create()
         feature_group.materialise(self.numpy_array_df)
+        try:
+            df = feature_group.select().read()
+        except ads.feature_store.common.exceptions.NotMaterializedError as e:
+            assert e.__str__() == "featureGroup " +feature_group.name + " is not materialized."
 
         self.clean_up_feature_group(feature_group)
         self.clean_up_entity(entity)

--- a/tests/integration/feature_store/test_datatype_pandas_mixed.py
+++ b/tests/integration/feature_store/test_datatype_pandas_mixed.py
@@ -72,16 +72,13 @@ class TestDataTypePandasMixed(FeatureStoreTestCase):
 
         entity = self.create_entity_resource(fs)
         assert entity.oci_fs_entity.id
-
-        feature_group = self.define_feature_group_resource_with_pandas_mixed_infer_schema(
-            entity.oci_fs_entity.id, fs.oci_fs.id
-        )
-        feature_group.create()
-        feature_group.materialise(self.pandas_mixed_df)
-        df = feature_group.select().read()
-        assert df
-
-        self.clean_up_feature_group(feature_group)
+        try:
+            feature_group = self.define_feature_group_resource_with_pandas_mixed_infer_schema(
+                entity.oci_fs_entity.id, fs.oci_fs.id
+            )
+        except TypeError as e:
+            assert e.__str__() == "field MixedColumn: Can not merge type <class 'pyspark.sql.types.StringType'> " \
+                                  "and <class 'pyspark.sql.types.LongType'>"
         self.clean_up_entity(entity)
         self.clean_up_feature_store(fs)
 
@@ -92,14 +89,15 @@ class TestDataTypePandasMixed(FeatureStoreTestCase):
 
         entity = self.create_entity_resource(fs)
         assert entity.oci_fs_entity.id
-        try:
-            feature_group = self.define_feature_group_resource_with_pandas_mixed_infer_schema_nan(
-                entity.oci_fs_entity.id, fs.oci_fs.id
-            )
-        except TypeError as e:
-            assert e.__str__() == "Can not merge type <class 'pyspark.sql.types.StringType'> and <class " \
-                                  "'pyspark.sql.types.LongType'>"
+        feature_group = self.define_feature_group_resource_with_pandas_mixed_infer_schema_nan(
+            entity.oci_fs_entity.id, fs.oci_fs.id
+        )
+        feature_group.create()
+        feature_group.materialise(self.pandas_mixed_df_nan)
+        df = feature_group.select().read()
+        assert df
 
+        self.clean_up_feature_group(feature_group)
         self.clean_up_entity(entity)
         self.clean_up_feature_store(fs)
 

--- a/tests/integration/feature_store/test_datatype_pandas_mixed.py
+++ b/tests/integration/feature_store/test_datatype_pandas_mixed.py
@@ -5,31 +5,49 @@ import pandas as pd
 import numpy as np
 import pytest
 
-flights_df = pd.read_csv("https://objectstorage.us-ashburn-1.oraclecloud.com/p/hh2NOgFJbVSg4amcLM3G3hkTuHyBD-8aE_iCsuZKEvIav1Wlld-3zfCawG4ycQGN/n/ociodscdev/b/oci-feature-store/o/beta/data/flights/flights.csv")
-flights_df_mixed = pd.DataFrame(flights_df["CANCELLATION_REASON"])
-
 
 class TestDataTypePandasMixed(FeatureStoreTestCase):
+    data_mixed = {'MixedColumn': ['John', 25, 'Emma', 30, 'Michael', 35]}
+    data_mixed_nan = {'MixedColumn': ['John', float('nan'), 'Emma', float('nan'), 'Michael', float('nan')]}
+    pandas_mixed_df = pd.DataFrame(data_mixed)
+    pandas_mixed_df_nan = pd.DataFrame(data_mixed_nan)
 
     input_feature_details_mixed = [
-        FeatureDetail("CANCELLATION_REASON").with_feature_type(FeatureType.STRING).with_order_number(1)]
+        FeatureDetail("MixedColumn").with_feature_type(FeatureType.STRING).with_order_number(1)]
 
     def define_feature_group_resource_with_pandas_mixed_infer_schema(
-        self, entity_id, feature_store_id
+            self, entity_id, feature_store_id
     ):
+        feature_group_pandas_mixed = (
+            FeatureGroup()
+            .with_description("feature group resource for pandas datatypes")
+            .with_compartment_id(self.COMPARTMENT_ID)
+            .with_name(self.get_name("feature_group_pandas_mixed"))
+            .with_entity_id(entity_id)
+            .with_feature_store_id(feature_store_id)
+            .with_primary_keys([])
+            .with_schema_details_from_dataframe(self.pandas_mixed_df)
+            .with_statistics_config(False)
+        )
 
-        with pytest.raises(TypeError, match="Input feature 'CANCELLATION_REASON' has mixed types, FeatureType.STRING and FeatureType.FLOAT. That is not allowed. "):
-            feature_group_pandas_mixed = (
-                FeatureGroup()
-                .with_description("feature group resource for pandas datatypes")
-                .with_compartment_id(self.COMPARTMENT_ID)
-                .with_name(self.get_name("feature_group_pandas_mixed"))
-                .with_entity_id(entity_id)
-                .with_feature_store_id(feature_store_id)
-                .with_primary_keys([])
-                .with_schema_details_from_dataframe(flights_df_mixed)
-                .with_statistics_config(False)
-            )
+        return feature_group_pandas_mixed
+
+    def define_feature_group_resource_with_pandas_mixed_infer_schema_nan(
+            self, entity_id, feature_store_id
+    ):
+        feature_group_pandas_mixed_1 = (
+            FeatureGroup()
+            .with_description("feature group resource for pandas datatypes")
+            .with_compartment_id(self.COMPARTMENT_ID)
+            .with_name(self.get_name("feature_group_pandas_mixed_1"))
+            .with_entity_id(entity_id)
+            .with_feature_store_id(feature_store_id)
+            .with_primary_keys([])
+            .with_schema_details_from_dataframe(self.pandas_mixed_df_nan)
+            .with_statistics_config(False)
+        )
+
+        return feature_group_pandas_mixed_1
 
     def define_feature_group_resource_with_pandas_mixed_with_schema(
             self, entity_id, feature_store_id
@@ -48,21 +66,45 @@ class TestDataTypePandasMixed(FeatureStoreTestCase):
         return feature_group_pandas_mixed_schema
 
     def test_feature_group_pandas_mixed_infer_schema(self):
-        """Tests  pandas date time data types"""
+        """Tests  pandas mixed data types"""
         fs = self.define_feature_store_resource().create()
         assert fs.oci_fs.id
 
         entity = self.create_entity_resource(fs)
         assert entity.oci_fs_entity.id
 
-        self.define_feature_group_resource_with_pandas_mixed_infer_schema(
+        feature_group = self.define_feature_group_resource_with_pandas_mixed_infer_schema(
             entity.oci_fs_entity.id, fs.oci_fs.id
         )
+        feature_group.create()
+        feature_group.materialise(self.pandas_mixed_df)
+        df = feature_group.select().read()
+        assert df
+
+        self.clean_up_feature_group(feature_group)
+        self.clean_up_entity(entity)
+        self.clean_up_feature_store(fs)
+
+    def test_feature_group_pandas_mixed_infer_schema_nan(self):
+        """Tests  pandas mixed data types"""
+        fs = self.define_feature_store_resource().create()
+        assert fs.oci_fs.id
+
+        entity = self.create_entity_resource(fs)
+        assert entity.oci_fs_entity.id
+        try:
+            feature_group = self.define_feature_group_resource_with_pandas_mixed_infer_schema_nan(
+                entity.oci_fs_entity.id, fs.oci_fs.id
+            )
+        except TypeError as e:
+            assert e.__str__() == "Can not merge type <class 'pyspark.sql.types.StringType'> and <class " \
+                                  "'pyspark.sql.types.LongType'>"
+
         self.clean_up_entity(entity)
         self.clean_up_feature_store(fs)
 
     def test_feature_group_pandas_mixed_with_schema(self):
-        """Tests  pandas date time data types"""
+        """Tests  pandas mixed data types"""
         fs = self.define_feature_store_resource().create()
         assert fs.oci_fs.id
 
@@ -76,13 +118,10 @@ class TestDataTypePandasMixed(FeatureStoreTestCase):
         feature_group.create()
         assert feature_group.oci_feature_group.id
 
-        feature_group.materialise(flights_df_mixed)
+        feature_group.materialise(self.pandas_mixed_df)
         df = feature_group.select().read()
         assert df
 
         self.clean_up_feature_group(feature_group)
         self.clean_up_entity(entity)
         self.clean_up_feature_store(fs)
-
-
-

--- a/tests/integration/feature_store/test_datatype_pandas_object.py
+++ b/tests/integration/feature_store/test_datatype_pandas_object.py
@@ -68,7 +68,7 @@ class TestDataTypePandasObject(FeatureStoreTestCase):
             FeatureGroup()
             .with_description("feature group resource for pandas datatypes")
             .with_compartment_id(self.COMPARTMENT_ID)
-            .with_name(self.get_name("feature_group_pandas_mixed_schema"))
+            .with_name(self.get_name("feature_group_pandas_string_schema"))
             .with_entity_id(entity_id)
             .with_feature_store_id(feature_store_id)
             .with_primary_keys([])
@@ -84,7 +84,7 @@ class TestDataTypePandasObject(FeatureStoreTestCase):
             FeatureGroup()
             .with_description("feature group resource for pandas datatypes")
             .with_compartment_id(self.COMPARTMENT_ID)
-            .with_name(self.get_name("feature_group_pandas_object_string"))
+            .with_name(self.get_name("feature_group_pandas_object_decimal"))
             .with_entity_id(entity_id)
             .with_feature_store_id(feature_store_id)
             .with_primary_keys([])
@@ -257,7 +257,7 @@ class TestDataTypePandasObject(FeatureStoreTestCase):
         self.clean_up_feature_store(fs)
 
     def test_feature_group_pandas_object_date_with_schema(self):
-        """Tests  pandas object decimal data types"""
+        """Tests  pandas object date data types"""
         fs = self.define_feature_store_resource().create()
         assert fs.oci_fs.id
 

--- a/tests/integration/feature_store/test_datatype_spark_array_map.py
+++ b/tests/integration/feature_store/test_datatype_spark_array_map.py
@@ -42,8 +42,8 @@ class TestDataTypeSparkArrayMap(FeatureStoreTestCase):
         FeatureDetail("timestamp_array_col").with_feature_type(FeatureType.TIMESTAMP_ARRAY).with_order_number(8),
         FeatureDetail("byte_array_col").with_feature_type(FeatureType.BYTE_ARRAY).with_order_number(9),
         FeatureDetail("short_array_col").with_feature_type(FeatureType.INTEGER_ARRAY).with_order_number(10),
-        FeatureDetail("decimal_array_col").with_feature_type(FeatureType.UNKNOWN).with_order_number(11),
-        FeatureDetail("boolean_array_col").with_feature_type(FeatureType.UNKNOWN).with_order_number(12),
+        FeatureDetail("decimal_array_col").with_feature_type(FeatureType.COMPLEX).with_order_number(11),
+        FeatureDetail("boolean_array_col").with_feature_type(FeatureType.COMPLEX).with_order_number(12),
     ]
 
     schema_map = StructType([
@@ -57,7 +57,7 @@ class TestDataTypeSparkArrayMap(FeatureStoreTestCase):
         StructField("string_date_map_col", MapType(StringType(), DateType()), True),
         StructField("string_binary_map_col", MapType(StringType(), BinaryType()), True),
         StructField("string_byte_map_col", MapType(StringType(), ByteType()), True),
-        StructField("string_byte_map_col", MapType(StringType(), DecimalType(10,2)), True),
+        StructField("string_decimal_map_col", MapType(StringType(), DecimalType(10,2)), True),
         StructField("string_boolean_map_col", MapType(StringType(), BooleanType()), True)
     ])
 
@@ -72,8 +72,8 @@ class TestDataTypeSparkArrayMap(FeatureStoreTestCase):
         FeatureDetail("string_date_map_col").with_feature_type(FeatureType.STRING_DATE_MAP).with_order_number(9),
         FeatureDetail("string_binary_map_col").with_feature_type(FeatureType.STRING_BINARY_MAP).with_order_number(8),
         FeatureDetail("string_byte_map_col").with_feature_type(FeatureType.STRING_BYTE_MAP).with_order_number(10),
-        FeatureDetail("string_decimal_map_col").with_feature_type(FeatureType.UNKNOWN).with_order_number(11),
-        FeatureDetail("string_boolean_map_col").with_feature_type(FeatureType.UNKNOWN).with_order_number(12),
+        FeatureDetail("string_decimal_map_col").with_feature_type(FeatureType.COMPLEX).with_order_number(11),
+        FeatureDetail("string_boolean_map_col").with_feature_type(FeatureType.COMPLEX).with_order_number(12),
     ]
 
     # Add data to the DataFrame
@@ -185,7 +185,7 @@ class TestDataTypeSparkArrayMap(FeatureStoreTestCase):
             FeatureGroup()
             .with_description("feature group resource spark map types")
             .with_compartment_id(self.COMPARTMENT_ID)
-            .with_name(self.get_name("feature_group_spark_array"))
+            .with_name(self.get_name("feature_group_spark_map"))
             .with_entity_id(entity_id)
             .with_feature_store_id(feature_store_id)
             .with_primary_keys([])
@@ -211,7 +211,7 @@ class TestDataTypeSparkArrayMap(FeatureStoreTestCase):
         return feature_group_spark_map_schema
 
     def test_feature_group_spark_datatypes_array_infer_schema(self):
-        """Test supported pandas data types"""
+        """Test supported spark array types"""
         fs = self.define_feature_store_resource().create()
         assert fs.oci_fs.id
 
@@ -234,7 +234,7 @@ class TestDataTypeSparkArrayMap(FeatureStoreTestCase):
         self.clean_up_feature_store(fs)
 
     def test_feature_group_spark_datatypes_array_with_schema(self):
-        """Test supported pandas data types"""
+        """Test supported spark array types types with schema"""
         fs = self.define_feature_store_resource().create()
         assert fs.oci_fs.id
 
@@ -257,7 +257,7 @@ class TestDataTypeSparkArrayMap(FeatureStoreTestCase):
         self.clean_up_feature_store(fs)
 
     def test_feature_group_spark_datatypes_map_infer_schema(self):
-        """Test supported pandas data types"""
+        """Test supported spark map types"""
         fs = self.define_feature_store_resource().create()
         assert fs.oci_fs.id
 
@@ -280,7 +280,7 @@ class TestDataTypeSparkArrayMap(FeatureStoreTestCase):
         self.clean_up_feature_store(fs)
 
     def test_feature_group_spark_datatypes_map_with_schema(self):
-        """Test supported pandas data types"""
+        """Test supported spark map types with schema"""
         fs = self.define_feature_store_resource().create()
         assert fs.oci_fs.id
 
@@ -294,7 +294,7 @@ class TestDataTypeSparkArrayMap(FeatureStoreTestCase):
         feature_group.create()
         assert feature_group.oci_feature_group.id
 
-        feature_group.materialise(self.array_df)
+        feature_group.materialise(self.map_df)
         df = feature_group.select().read()
         assert df
 

--- a/tests/integration/feature_store/test_datatype_spark_basic.py
+++ b/tests/integration/feature_store/test_datatype_spark_basic.py
@@ -13,25 +13,6 @@ from ads.feature_store.common.spark_session_singleton import SparkSessionSinglet
 
 
 class TestDataTypeSparkBasic(FeatureStoreTestCase):
-    # TODO: change the creation as it would run on Conda
-
-    # spark_builder = (
-    #     SparkSession.builder.appName("FeatureStore")
-    #     .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-    #     .config(
-    #         "spark.sql.catalog.spark_catalog",
-    #         "org.apache.spark.sql.delta.catalog.DeltaCatalog",
-    #     )
-    #     .config("spark.driver.memory", "16G")
-    #     .enableHiveSupport()
-    # )
-    # spark_builder.config(
-    #     "spark.jars",
-    #     "https://repo1.maven.org/maven2/com/amazon/deequ/deequ/2.0.1-spark-3.2/deequ-2.0.1-spark-3.2.jar",
-    # )
-    # spark = configure_spark_with_delta_pip(
-    #     spark_builder
-    # ).getOrCreate()
 
     schema = StructType([
         StructField("short_col", ShortType(), True),
@@ -52,6 +33,7 @@ class TestDataTypeSparkBasic(FeatureStoreTestCase):
         FeatureDetail("long_col").with_feature_type(FeatureType.LONG).with_order_number(3),
         FeatureDetail("float_col").with_feature_type(FeatureType.FLOAT).with_order_number(4),
         FeatureDetail("double_col").with_feature_type(FeatureType.DOUBLE).with_order_number(5),
+        FeatureDetail("bool_col").with_feature_type(FeatureType.BOOLEAN).with_order_number(5),
         FeatureDetail("string_col").with_feature_type(FeatureType.STRING).with_order_number(6),
         FeatureDetail("byte_col").with_feature_type(FeatureType.BYTE).with_order_number(7),
         FeatureDetail("binary_col").with_feature_type(FeatureType.BINARY).with_order_number(8),
@@ -65,7 +47,7 @@ class TestDataTypeSparkBasic(FeatureStoreTestCase):
     ]
 
     spark = SparkSessionSingleton(FeatureStoreTestCase.METASTORE_ID).get_spark_session()
-    basic_df = spark.createDataFrame(data)
+    basic_df = spark.createDataFrame(data,schema)
 
     def define_feature_group_resource_with_spark_basic_infer_schema(
             self, entity_id, feature_store_id
@@ -79,7 +61,6 @@ class TestDataTypeSparkBasic(FeatureStoreTestCase):
             .with_feature_store_id(feature_store_id)
             .with_primary_keys([])
             .with_schema_details_from_dataframe(self.basic_df)
-            .with_statistics_config(False)
         )
         return feature_group_spark_basic
 
@@ -100,7 +81,7 @@ class TestDataTypeSparkBasic(FeatureStoreTestCase):
         return feature_group_spark_basic_schema
 
     def test_feature_group_spark_datatypes_infer_schema(self):
-        """Test supported pandas data types"""
+        """Test supported spark data types"""
         fs = self.define_feature_store_resource().create()
         assert fs.oci_fs.id
 
@@ -123,7 +104,7 @@ class TestDataTypeSparkBasic(FeatureStoreTestCase):
         self.clean_up_feature_store(fs)
 
     def test_feature_group_spark_datatypes_with_schema(self):
-        """Test supported pandas data types"""
+        """Test supported spark data types"""
         fs = self.define_feature_store_resource().create()
         assert fs.oci_fs.id
 

--- a/tests/integration/feature_store/test_feature_group_validations.py
+++ b/tests/integration/feature_store/test_feature_group_validations.py
@@ -68,7 +68,7 @@ class TestFeatureGroupValidation(FeatureStoreTestCase):
 
         assert fg.oci_feature_group.id
         fg.materialise(self.data)
-        df = fg.get_validation_output().to_pandas()
+        df = fg.get_validation_output().to_pandas().T
         assert df is not None
         assert "success" in df.columns
         assert True in df["success"].values
@@ -110,7 +110,7 @@ class TestFeatureGroupValidation(FeatureStoreTestCase):
 
         assert fg.oci_feature_group.id
         fg.materialise(self.data)
-        df = fg.get_validation_output().to_pandas()
+        df = fg.get_validation_output().to_pandas().T
         assert df is not None
         assert "success" in df.columns
         assert True in df["success"].values

--- a/tests/integration/feature_store/test_input_feature_details.py
+++ b/tests/integration/feature_store/test_input_feature_details.py
@@ -1,0 +1,123 @@
+from pyspark.sql.types import StructType, ShortType, IntegerType, LongType, FloatType, DoubleType, \
+    BooleanType, StringType, StructField, ByteType, BinaryType, DecimalType
+from tests.integration.feature_store.test_base import FeatureStoreTestCase
+from ads.feature_store.input_feature_detail import FeatureDetail, FeatureType
+from ads.feature_store.feature_group import FeatureGroup
+from ads.feature_store.feature_group_job import FeatureGroupJob
+import pandas as pd
+import numpy as np
+import pytest
+from ads.feature_store.common.spark_session_singleton import SparkSessionSingleton
+
+
+class TestInputSchema(FeatureStoreTestCase):
+    input_feature_details = [
+        FeatureDetail("A").with_feature_type(FeatureType.STRING).with_order_number(1),
+        FeatureDetail("B").with_feature_type(FeatureType.INTEGER).with_order_number(2)
+    ]
+
+    a = ["value1", "value2"]
+    b = [25, 60]
+    c = [30, 50]
+    pandas_basic_df = pd.DataFrame(
+        {
+            "A": a,
+            "B": b,
+            "C": c
+        }
+    )
+
+    schema = StructType(
+        [StructField("string_col", StringType(), True),
+         StructField("int_col", IntegerType(), True),
+         StructField("long_col", LongType(), True)]
+    )
+
+    input_feature_details_spark = [
+        FeatureDetail("string_col").with_feature_type(FeatureType.STRING).with_order_number(1),
+        FeatureDetail("int_col").with_feature_type(FeatureType.INTEGER).with_order_number(2),
+        FeatureDetail("C").with_feature_type(FeatureType.INTEGER).with_order_number(2),
+        FeatureDetail("B").with_feature_type(FeatureType.INTEGER).with_order_number(2),
+    ]
+
+    data = [
+        ("value1", 100, 1000),
+        ("value2", 200, 2000)
+    ]
+    spark = SparkSessionSingleton(FeatureStoreTestCase.METASTORE_ID).get_spark_session()
+    basic_df = spark.createDataFrame(data, schema)
+
+    def define_feature_group_resource_with_pandas_schema(
+            self, entity_id, feature_store_id
+    ) -> "FeatureGroup":
+        feature_group_pandas_array = (
+            FeatureGroup()
+            .with_description("feature group resource for pandas array types")
+            .with_compartment_id(self.COMPARTMENT_ID)
+            .with_name(self.get_name("feature_group_pandas_array"))
+            .with_entity_id(entity_id)
+            .with_feature_store_id(feature_store_id)
+            .with_primary_keys([])
+            .with_input_feature_details(self.input_feature_details)
+        )
+        return feature_group_pandas_array
+
+    def define_feature_group_resource_with_spark_schema(
+            self, entity_id, feature_store_id
+    ) -> "FeatureGroup":
+        feature_group_spark_schema = (
+            FeatureGroup()
+            .with_description("feature group resource for pandas array types")
+            .with_compartment_id(self.COMPARTMENT_ID)
+            .with_name(self.get_name("feature_group_spark_schema"))
+            .with_entity_id(entity_id)
+            .with_feature_store_id(feature_store_id)
+            .with_primary_keys([])
+            .with_input_feature_details(self.input_feature_details_spark)
+        )
+        return feature_group_spark_schema
+
+    def test_feature_group_pandas_schema_mismatch(self):
+        """Tests  pandas schema"""
+        fs = self.define_feature_store_resource().create()
+        assert fs.oci_fs.id
+
+        entity = self.create_entity_resource(fs)
+        assert entity.oci_fs_entity.id
+
+        feature_group = self.define_feature_group_resource_with_pandas_schema(
+            entity.oci_fs_entity.id, fs.oci_fs.id
+        )
+        feature_group.create()
+        feature_group.materialise(self.pandas_basic_df)
+
+
+        df = feature_group.select().read()
+        assert len(df.columns) == 2
+
+        self.clean_up_feature_group(feature_group)
+        self.clean_up_entity(entity)
+        self.clean_up_feature_store(fs)
+
+    def test_feature_group_spark_schema_mismatch(self):
+        """Tests  pandas date time data types"""
+        fs = self.define_feature_store_resource().create()
+        assert fs.oci_fs.id
+
+        entity = self.create_entity_resource(fs)
+        assert entity.oci_fs_entity.id
+
+        feature_group = self.define_feature_group_resource_with_spark_schema(
+            entity.oci_fs_entity.id, fs.oci_fs.id
+        )
+        feature_group.create()
+        feature_group.materialise(self.basic_df)
+
+        df = feature_group.select().read()
+        assert len(df.columns) == 2
+
+        self.clean_up_feature_group(feature_group)
+        self.clean_up_entity(entity)
+        self.clean_up_feature_store(fs)
+
+


### PR DESCRIPTION
## Description

- Convert Pandas dataframe  when its passed with with_schema_details….. and use Spark Type to Feature Type mapping
- Validate input feature details, subset
- Change FeatureType.UNKNOWN to ….FeatureType.COMPLEX for not mapped spark types
- validation output transpose

## Unit tests
<img width="1367" alt="Screenshot 2023-07-05 at 11 19 21 AM" src="https://github.com/oracle/accelerated-data-science/assets/42770145/9d26c31d-4421-43cb-a88f-770010a433ff">


## Integration tests
(https://teamcity.oci.oraclecorp.com/buildConfiguration/Odsc_FeatureStore_FeatureStoreAdsIntegrationTests_FeatureStoreAdsIntegrationTestsPython38/40386914?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true)
