### PR TITLE
ODSC-44980: Prepare workflows for feature store merge

### DIFF
--- a/.github/workflows/run-unittests-default_setup.yml
+++ b/.github/workflows/run-unittests-default_setup.yml
@@ -1,6 +1,7 @@
 name: tests/unitary/default_setup/**
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/run-unittests.yml
+++ b/.github/workflows/run-unittests.yml
@@ -1,6 +1,7 @@
 name: tests/unitary/**
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -41,7 +42,7 @@ jobs:
         test-path: ["tests/unitary", "tests/unitary/with_extras/model"]
         include:
           - test-path: "tests/unitary"
-            ignore-path: "tests/unitary/with_extras/model"
+            ignore-path: "--ignore tests/unitary/with_extras/model --ignore tests/unitary/with_extras/feature_store"
             name: "unitary"
           - test-path: "tests/unitary/with_extras/model"
             name: "model"
@@ -115,8 +116,7 @@ jobs:
           # Run tests
           python -m pytest -v -p no:warnings --durations=5 \
           -n auto --dist loadfile ${{ matrix.cov-reports }} \
-          ${{ matrix.test-path }} \
-          --ignore "${{ matrix.ignore-path }}"
+          ${{ matrix.test-path }} ${{ matrix.ignore-path }}
 
       - name: "Save coverage files"
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Description
This PR takes care of excluding feature store unitary tests when running with maximum dependencies as feature store requires dependencies which are only present inside the feature store conda pack. It allso adds support to trigger github workflows without creating a PR. 
Jira: https://jira.oci.oraclecorp.com/browse/ODSC-44980

## What was done
- Added new triggers for worflows: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
- Add new ignore paths in preparation for feature store merge