### PR TITLE
Loosen pyyaml version, which broken for latest cython.

### DIFF
--- a/ads/pipeline/ads_pipeline.py
+++ b/ads/pipeline/ads_pipeline.py
@@ -1904,7 +1904,7 @@ class Pipeline(Builder):
     #     ) as ml_step_schema_file:
     #         ml_step_schema = json.load(ml_step_schema_file)
 
-    #     yaml_dict = yaml.load(Pipeline._read_from_file(uri=uri))
+    #     yaml_dict = yaml.load(Pipeline._read_from_file(uri=uri), Loader=yaml.FullLoader)
 
     #     pipeline_validator = Validator(pipeline_schema)
     #     if not pipeline_validator.validate(yaml_dict):
@@ -1994,7 +1994,6 @@ class Pipeline(Builder):
             .with_compartment_id(self.compartment_id or "{Provide a compartment OCID}")
             .with_project_id(self.project_id or "{Provide a project OCID}")
         )
-
 
 
 class DataSciencePipeline(OCIDataScienceMixin, oci.data_science.models.Pipeline):

--- a/ads/secrets/secrets.py
+++ b/ads/secrets/secrets.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*--
 
-# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import ads
@@ -273,7 +273,7 @@ class SecretKeeper(Vault, ContextDecorator):
                 if format.lower() == "json":
                     vault_info = json.load(vf)
                 elif format.lower() in ["yaml", "yml"]:
-                    vault_info = yaml.load(vf)
+                    vault_info = yaml.load(vf, Loader=yaml.FullLoader)
                 if not cls._validate_required_vault_attributes(vault_info):
                     logger.error(
                         f"Missing required Attributes in file {uri}: {cls.required_keys}"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     "ocifs>=1.1.3",
     "pandas>1.2.1,<1.6",
     "python_jsonschema_objects>=0.3.13",
-    "PyYAML>=5.4,<6",
+    "PyYAML>=6",  # pyyaml 5.4 is broken with cython 3
     "requests",
     "scikit-learn>=0.23.2,<1.2",
     "tabulate>=0.8.9",

--- a/tests/unitary/default_setup/secret/test_secretkeeper_adw.py
+++ b/tests/unitary/default_setup/secret/test_secretkeeper_adw.py
@@ -121,7 +121,6 @@ def key_encoding_with_wallet(tmpdir):
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_encode(mock_client, mock_signer, key_encoding):
-
     adwsecretkeeper = ADBSecretKeeper(
         *key_encoding[0],
         vault_id="ocid.vault",
@@ -135,7 +134,6 @@ def test_encode(mock_client, mock_signer, key_encoding):
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_adw_save(mock_client, mock_signer, key_encoding, tmpdir):
-
     adwsecretkeeper = ADBSecretKeeper(
         *key_encoding[0],
         vault_id="ocid.vault",
@@ -158,7 +156,7 @@ def test_adw_save(mock_client, mock_signer, key_encoding, tmpdir):
             }
         adwsecretkeeper.export_vault_details(os.path.join(tmpdir, "test.yaml"))
         with open(os.path.join(tmpdir, "test.yaml")) as tf:
-            assert yaml.load(tf) == {
+            assert yaml.load(tf, Loader=yaml.FullLoader) == {
                 "key_id": "ocid.key",
                 "secret_id": "ocid.secret.id",
                 "vault_id": "ocid.vault",
@@ -170,7 +168,6 @@ def test_adw_save(mock_client, mock_signer, key_encoding, tmpdir):
 def test_adw_save_without_explicit_encoding(
     mock_client, mock_signer, key_encoding, tmpdir
 ):
-
     adwsecretkeeper = ADBSecretKeeper(
         *key_encoding[0],
         vault_id="ocid.vault",
@@ -193,7 +190,7 @@ def test_adw_save_without_explicit_encoding(
             }
         adwsecretkeeper.export_vault_details(os.path.join(tmpdir, "test.yaml"))
         with open(os.path.join(tmpdir, "test.yaml")) as tf:
-            assert yaml.load(tf) == {
+            assert yaml.load(tf, Loader=yaml.FullLoader) == {
                 "key_id": "ocid.key",
                 "secret_id": "ocid.secret.id",
                 "vault_id": "ocid.vault",
@@ -203,7 +200,6 @@ def test_adw_save_without_explicit_encoding(
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_adw_context(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -235,7 +231,6 @@ def test_adw_context(mock_client, mock_signer, key_encoding):
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_adw_keeper_no_wallet(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -263,7 +258,6 @@ def test_adw_keeper_with_repository(mock_client, mock_signer, key_encoding, tmpd
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_adw_context_namespace(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -296,7 +290,6 @@ def test_adw_context_namespace(mock_client, mock_signer, key_encoding):
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_adw_context_noexport(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -399,7 +392,6 @@ def test_adw_with_wallet_storage_decode(
     with mock.patch(
         "ads.vault.Vault.get_secret", side_effect=mock_get_secret_id
     ) as mocked_getsecret:
-
         adwsecretkeeper = ADBSecretKeeper(
             vault_id="ocid.vault",
             key_id="ocid.key",
@@ -449,7 +441,6 @@ def test_adw_with_wallet_storage_context_manager(
     with mock.patch(
         "ads.vault.Vault.get_secret", side_effect=mock_get_secret_id
     ) as mocked_getsecret:
-
         with ADBSecretKeeper.load_secret(
             wallet_dir=wallet_dir, source="meta.secret.id", export_env=True
         ) as adwsecretkeeper:
@@ -506,7 +497,6 @@ def test_adw_with_wallet_storage_context_manager_namespace(
     with mock.patch(
         "ads.vault.Vault.get_secret", side_effect=mock_get_secret_id
     ) as mocked_getsecret:
-
         with ADBSecretKeeper.load_secret(
             wallet_dir=wallet_dir,
             source="meta.secret.id",
@@ -566,7 +556,6 @@ def test_adw_with_wallet_storage_context_manager_noexport(
     with mock.patch(
         "ads.vault.Vault.get_secret", side_effect=mock_get_secret_id
     ) as mocked_getsecret:
-
         with ADBSecretKeeper.load_secret(
             wallet_dir=wallet_dir,
             source="meta.secret.id",
@@ -617,7 +606,6 @@ def test_adw_with_wallet_storage_save(
     with mock.patch(
         "ads.vault.Vault.create_secret", side_effect=mock_create_secret
     ) as mocked_getsecret:
-
         adwsecretkeeper = ADBSecretKeeper(
             vault_id="ocid.vault",
             key_id="ocid.key",
@@ -641,7 +629,7 @@ def test_adw_with_wallet_storage_save(
             os.path.join(tmpdir, "info.yaml"), format="yml"
         )
         with open(os.path.join(tmpdir, "info.yaml")) as tf:
-            assert yaml.load(tf) == {
+            assert yaml.load(tf, Loader=yaml.FullLoader) == {
                 "vault_id": "ocid.vault",
                 "key_id": "ocid.key",
                 "secret_id": "meta.secret.id",
@@ -675,7 +663,6 @@ def test_adw_with_wallet_storage_save_without_explicit_encode(
     with mock.patch(
         "ads.vault.Vault.create_secret", side_effect=mock_create_secret
     ) as mocked_getsecret:
-
         adwsecretkeeper = ADBSecretKeeper(
             vault_id="ocid.vault",
             key_id="ocid.key",
@@ -699,7 +686,7 @@ def test_adw_with_wallet_storage_save_without_explicit_encode(
             os.path.join(tmpdir, "info.yaml"), format="yaml"
         )
         with open(os.path.join(tmpdir, "info.yaml")) as tf:
-            assert yaml.load(tf) == {
+            assert yaml.load(tf, Loader=yaml.FullLoader) == {
                 "vault_id": "ocid.vault",
                 "key_id": "ocid.key",
                 "secret_id": "meta.secret.id",
@@ -732,7 +719,6 @@ def test_adw_with_wallet_storage_load_from_file(
         return content_map[id]
 
     with mock.patch("ads.vault.Vault.get_secret", side_effect=mock_get_secret_id) as _:
-
         with ADBSecretKeeper.load_secret(
             source=os.path.join(os.path.join(tmpdir, "info.json")),
             format="json",
@@ -789,7 +775,6 @@ def test_adw_with_wallet_storage_load_from_file(
         return content_map[id]
 
     with mock.patch("ads.vault.Vault.get_secret", side_effect=mock_get_secret_id) as _:
-
         with ADBSecretKeeper.load_secret(
             source=os.path.join(os.path.join(tmpdir, "info.yaml")),
             format="yaml",

--- a/tests/unitary/default_setup/secret/test_secretkeeper_auth_token.py
+++ b/tests/unitary/default_setup/secret/test_secretkeeper_auth_token.py
@@ -24,7 +24,6 @@ def key_encoding():
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_encode(mock_client, mock_signer, key_encoding):
-
     apisecretkeeper = AuthTokenSecretKeeper(
         key_encoding[0],
         vault_id="ocid.vault",
@@ -51,7 +50,6 @@ def test_decode(mock_client, mock_signer, key_encoding):
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_api_context(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -67,7 +65,6 @@ def test_api_context(mock_client, mock_signer, key_encoding):
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_api_context_namespace(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -83,7 +80,6 @@ def test_api_context_namespace(mock_client, mock_signer, key_encoding):
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_api_context_noexport(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -141,7 +137,7 @@ def test_export_vault_details(mock_client, mock_signer, key_encoding, tmpdir):
             os.path.join(tmpdir, "test.yaml"), format="yaml"
         )
         with open(os.path.join(tmpdir, "test.yaml")) as tf:
-            assert yaml.load(tf) == {
+            assert yaml.load(tf, Loader=yaml.FullLoader) == {
                 "key_id": "ocid.key",
                 "secret_id": "ocid.secret.id",
                 "vault_id": "ocid.vault",
@@ -191,5 +187,4 @@ def test_load_from_invalid_file(mock_client, mock_signer, key_encoding, tmpdir):
         with AuthTokenSecretKeeper.load_secret(
             source=os.path.join(tmpdir, "test.yaml"), format="yaml"
         ) as apisecretkeeper:
-
             assert apisecretkeeper == key_encoding[1]

--- a/tests/unitary/default_setup/secret/test_secretkeeper_bds.py
+++ b/tests/unitary/default_setup/secret/test_secretkeeper_bds.py
@@ -56,7 +56,6 @@ def key_encoding():
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_encode(mock_client, mock_signer, key_encoding):
-
     bdssecretkeeper = BDSSecretKeeper(
         *key_encoding[0],
         vault_id="ocid.vault",
@@ -176,7 +175,6 @@ def key_encoding_with_keytab_kerb5(tmpdir):
 def test_encode_with_keytab_kerb5(
     mock_client, mock_signer, key_encoding_with_keytab_kerb5
 ):
-
     bdssecretkeeper = BDSSecretKeeper(
         *key_encoding_with_keytab_kerb5.credentials,
         vault_id="ocid.vault",
@@ -194,7 +192,6 @@ def test_encode_with_keytab_kerb5(
 def test_bds_save_without_explicit_encoding(
     mock_client, mock_signer, key_encoding, tmpdir
 ):
-
     bdssecretkeeper = BDSSecretKeeper(
         *key_encoding[0],
         vault_id="ocid.vault",
@@ -219,7 +216,7 @@ def test_bds_save_without_explicit_encoding(
             }
         bdssecretkeeper.export_vault_details(os.path.join(tmpdir, "test.yaml"))
         with open(os.path.join(tmpdir, "test.yaml")) as tf:
-            assert yaml.load(tf) == {
+            assert yaml.load(tf, Loader=yaml.FullLoader) == {
                 "key_id": "ocid.key",
                 "secret_id": "ocid.secret.id",
                 "vault_id": "ocid.vault",
@@ -229,7 +226,6 @@ def test_bds_save_without_explicit_encoding(
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_bds_save(mock_client, mock_signer, key_encoding_with_keytab_kerb5, tmpdir):
-
     bdssecretkeeper = BDSSecretKeeper(
         *key_encoding_with_keytab_kerb5.credentials,
         vault_id="ocid.vault",
@@ -253,7 +249,7 @@ def test_bds_save(mock_client, mock_signer, key_encoding_with_keytab_kerb5, tmpd
             }
         bdssecretkeeper.export_vault_details(os.path.join(tmpdir, "test.yaml"))
         with open(os.path.join(tmpdir, "test.yaml")) as tf:
-            assert yaml.load(tf) == {
+            assert yaml.load(tf, Loader=yaml.FullLoader) == {
                 "key_id": "ocid.key",
                 "secret_id": "ocid.secret.id",
                 "vault_id": "ocid.vault",
@@ -263,7 +259,6 @@ def test_bds_save(mock_client, mock_signer, key_encoding_with_keytab_kerb5, tmpd
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_bds_context(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -300,7 +295,6 @@ def test_bds_context(mock_client, mock_signer, key_encoding):
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_bds_keeper_no_file(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -315,7 +309,6 @@ def test_bds_keeper_no_file(mock_client, mock_signer, key_encoding):
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_bds_context_namespace(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -356,7 +349,6 @@ def test_bds_context_namespace(mock_client, mock_signer, key_encoding):
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_bds_context_noexport(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -463,7 +455,6 @@ def test_bds_with_keytab_kerb5_decode(
     with mock.patch(
         "ads.vault.Vault.get_secret", side_effect=mock_get_secret_id
     ) as mocked_getsecret:
-
         bdssecretkeeper = BDSSecretKeeper(
             vault_id="ocid.vault",
             key_id="ocid.key",
@@ -546,7 +537,6 @@ def test_bds_with_keytab_krb5_context_manager(
     with mock.patch(
         "ads.vault.Vault.get_secret", side_effect=mock_get_secret_id
     ) as mocked_getsecret:
-
         with BDSSecretKeeper.load_secret(
             source="meta.secret.id", export_env=True
         ) as bdssecretkeeper:
@@ -604,7 +594,6 @@ def test_bds_with_keytab_kerb5_context_manager_namespace(
     with mock.patch(
         "ads.vault.Vault.get_secret", side_effect=mock_get_secret_id
     ) as mocked_getsecret:
-
         with BDSSecretKeeper.load_secret(
             source="meta.secret.id",
             export_prefix="myapp",
@@ -682,7 +671,6 @@ def test_bds_with_keytab_kerb5_context_manager_noexport(
     with mock.patch(
         "ads.vault.Vault.get_secret", side_effect=mock_get_secret_id
     ) as mocked_getsecret:
-
         with BDSSecretKeeper.load_secret(
             source="meta.secret.id",
         ) as bdssecretkeeper:
@@ -726,7 +714,6 @@ def test_bds_with_keytab_kerb5_context_manager_noexport(
 def test_bds_with_keytab_kerb5_load_from_file(
     mock_client, mock_signer, key_encoding_with_keytab_kerb5, tmpdir
 ):
-
     content_map = key_encoding_with_keytab_kerb5[3]
     content_map["meta.secret.id"] = key_encoding_with_keytab_kerb5.encoded
 
@@ -746,7 +733,6 @@ def test_bds_with_keytab_kerb5_load_from_file(
         return content_map[id]
 
     with mock.patch("ads.vault.Vault.get_secret", side_effect=mock_get_secret_id) as _:
-
         with BDSSecretKeeper.load_secret(
             source=os.path.join(os.path.join(tmpdir, "info.json")),
             format="json",
@@ -802,7 +788,6 @@ def test_bds_with_keytab_kerb5_load_from_file(
         return content_map[id]
 
     with mock.patch("ads.vault.Vault.get_secret", side_effect=mock_get_secret_id) as _:
-
         with BDSSecretKeeper.load_secret(
             source=os.path.join(os.path.join(tmpdir, "info.yaml")),
             format="yaml",

--- a/tests/unitary/default_setup/secret/test_secretkeeper_mysqldb.py
+++ b/tests/unitary/default_setup/secret/test_secretkeeper_mysqldb.py
@@ -104,7 +104,6 @@ def key_encoding_with_port():
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_encode(mock_client, mock_signer, key_encoding):
-
     mysqlsecretkeeper = MySQLDBSecretKeeper(
         *key_encoding[0],
         vault_id="ocid1.vault.oc1.<unique_ocid>",
@@ -184,7 +183,6 @@ def test_decode_with_database(mock_client, mock_signer, key_encoding_with_databa
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_mysqldb_context(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -206,7 +204,6 @@ def test_mysqldb_context(mock_client, mock_signer, key_encoding):
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_mysqldb_context_namespace(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -225,7 +222,6 @@ def test_mysqldb_context_namespace(mock_client, mock_signer, key_encoding):
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_mysqldb_context_noexport(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -284,7 +280,7 @@ def test_export_vault_details(mock_client, mock_signer, key_encoding, tmpdir):
             os.path.join(tmpdir, "test.yaml"), format="yaml"
         )
         with open(os.path.join(tmpdir, "test.yaml")) as tf:
-            assert yaml.load(tf) == {
+            assert yaml.load(tf, Loader=yaml.FullLoader) == {
                 "key_id": "ocid.key",
                 "secret_id": "ocid.secret.id",
                 "vault_id": "ocid.vault",
@@ -334,5 +330,4 @@ def test_load_from_invalid_file(mock_client, mock_signer, key_encoding, tmpdir):
         with MySQLDBSecretKeeper.load_secret(
             source=os.path.join(tmpdir, "test.yaml"), format="yaml"
         ) as mysqlsecretkeeper:
-
             assert mysqlsecretkeeper == key_encoding[1]

--- a/tests/unitary/default_setup/secret/test_secretkeeper_oracledb.py
+++ b/tests/unitary/default_setup/secret/test_secretkeeper_oracledb.py
@@ -108,7 +108,6 @@ def key_encoding_with_port():
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_encode(mock_client, mock_signer, key_encoding):
-
     oraclesecretkeeper = OracleDBSecretKeeper(
         *key_encoding[0],
         vault_id="ocid.vault",
@@ -191,7 +190,6 @@ def test_decode_with_sid(mock_client, mock_signer, key_encoding_with_sid):
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_oracledb_context(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -214,7 +212,6 @@ def test_oracledb_context(mock_client, mock_signer, key_encoding):
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_oracledb_context_namespace(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -234,7 +231,6 @@ def test_oracledb_context_namespace(mock_client, mock_signer, key_encoding):
 @patch("ads.common.auth.default_signer")
 @patch("ads.common.oci_client.OCIClientFactory")
 def test_oracledb_context_noexport(mock_client, mock_signer, key_encoding):
-
     with mock.patch(
         "ads.vault.Vault.get_secret", return_value=key_encoding[2]
     ) as mocked_getsecret:
@@ -294,7 +290,7 @@ def test_export_vault_details(mock_client, mock_signer, key_encoding, tmpdir):
             os.path.join(tmpdir, "test.yaml"), format="yaml"
         )
         with open(os.path.join(tmpdir, "test.yaml")) as tf:
-            assert yaml.load(tf) == {
+            assert yaml.load(tf, Loader=yaml.FullLoader) == {
                 "key_id": "ocid.key",
                 "secret_id": "ocid.secret.id",
                 "vault_id": "ocid.vault",
@@ -344,5 +340,4 @@ def test_load_from_invalid_file(mock_client, mock_signer, key_encoding, tmpdir):
         with OracleDBSecretKeeper.load_secret(
             source=os.path.join(tmpdir, "test.yaml"), format="yaml"
         ) as oraclesecretkeeper:
-
             assert oraclesecretkeeper == key_encoding[1]


### PR DESCRIPTION
### Description

Issue described here - https://github.com/oracle/accelerated-data-science/issues/263

### What was done

- loosen pyyaml version to be >=6

### Pre-commit validation
```
check python ast.........................................................Passed
check docstring is first.................................................Passed
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check yaml...........................................(no files to check)Skipped
detect private key.......................................................Passed
fix end of files.........................................................Passed
pretty format json...................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
black....................................................................Passed
rst ``code`` is two backticks........................(no files to check)Skipped
rst ``inline code`` next to normal text..............(no files to check)Skipped
Detect hardcoded secrets.................................................Passed
check-copyright..........................................................Passed
```