### PR TITLE
Fixed opctl commands.

### DIFF
--- a/ads/opctl/cli.py
+++ b/ads/opctl/cli.py
@@ -452,6 +452,25 @@ def init_operator(**kwargs):
 @commands.command()
 @click.argument("ocid", nargs=1)
 @add_options(_model_deployment_options)
+@click.option(
+    "--conda-pack-folder",
+    required=False,
+    default=None,
+    help="folder where conda packs are saved",
+)
+@click.option(
+    "--auth",
+    "-a",
+    help="authentication method",
+    type=click.Choice(AuthType.values()),
+    default=None,
+)
+@click.option(
+    "--oci-profile",
+    help="oci profile",
+    default=None,
+)
+@click.option("--debug", "-d", help="set debug mode", is_flag=True, default=False)
 def delete(**kwargs):
     suppress_traceback(kwargs["debug"])(delete_cmd)(**kwargs)
 
@@ -459,6 +478,25 @@ def delete(**kwargs):
 @commands.command()
 @click.argument("ocid", nargs=1)
 @add_options(_model_deployment_options)
+@click.option(
+    "--conda-pack-folder",
+    required=False,
+    default=None,
+    help="folder where conda packs are saved",
+)
+@click.option(
+    "--auth",
+    "-a",
+    help="authentication method",
+    type=click.Choice(AuthType.values()),
+    default=None,
+)
+@click.option(
+    "--oci-profile",
+    help="oci profile",
+    default=None,
+)
+@click.option("--debug", "-d", help="set debug mode", is_flag=True, default=False)
 def cancel(**kwargs):
     suppress_traceback(kwargs["debug"])(cancel_cmd)(**kwargs)
 
@@ -491,6 +529,25 @@ def cancel(**kwargs):
     required=False,
     default=90
 )
+@click.option(
+    "--conda-pack-folder",
+    required=False,
+    default=None,
+    help="folder where conda packs are saved",
+)
+@click.option(
+    "--auth",
+    "-a",
+    help="authentication method",
+    type=click.Choice(AuthType.values()),
+    default=None,
+)
+@click.option(
+    "--oci-profile",
+    help="oci profile",
+    default=None,
+)
+@click.option("--debug", "-d", help="set debug mode", is_flag=True, default=False)
 def watch(**kwargs):
     """
     ``tail`` logs form a job run, dataflow run or pipeline run.
@@ -502,6 +559,25 @@ def watch(**kwargs):
 @commands.command()
 @click.argument("ocid", nargs=1)
 @add_options(_model_deployment_options)
+@click.option(
+    "--conda-pack-folder",
+    required=False,
+    default=None,
+    help="folder where conda packs are saved",
+)
+@click.option(
+    "--auth",
+    "-a",
+    help="authentication method",
+    type=click.Choice(AuthType.values()),
+    default=None,
+)
+@click.option(
+    "--oci-profile",
+    help="oci profile",
+    default=None,
+)
+@click.option("--debug", "-d", help="set debug mode", is_flag=True, default=False)
 def activate(**kwargs):
     """
     Activates a data science service.
@@ -512,6 +588,25 @@ def activate(**kwargs):
 @commands.command()
 @click.argument("ocid", nargs=1)
 @add_options(_model_deployment_options)
+@click.option(
+    "--conda-pack-folder",
+    required=False,
+    default=None,
+    help="folder where conda packs are saved",
+)
+@click.option(
+    "--auth",
+    "-a",
+    help="authentication method",
+    type=click.Choice(AuthType.values()),
+    default=None,
+)
+@click.option(
+    "--oci-profile",
+    help="oci profile",
+    default=None,
+)
+@click.option("--debug", "-d", help="set debug mode", is_flag=True, default=False)
 def deactivate(**kwargs):
     """
     Deactivates a data science service.


### PR DESCRIPTION
### Fixed opctl commands

- Added the necessary command options for `delete\cancel\watch\activate\deactivate`:
  - `--conda-pack-folder`
  - `--auth`
  - `--oci-profile`
  - `--debug`

## Notebook
<img width="1114" alt="Screenshot 2023-07-25 at 12 07 11 AM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/d680e3f3-9b5d-43db-904a-c8c188e7c2d9">
<img width="1114" alt="Screenshot 2023-07-25 at 12 07 20 AM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/d13e2ee9-ad6f-4306-9553-659f4b874057">
