### PR TITLE
Fix bugs for PyTorchDistributedRuntime

### DIFF
--- a/ads/jobs/builders/runtimes/pytorch_runtime.py
+++ b/ads/jobs/builders/runtimes/pytorch_runtime.py
@@ -206,7 +206,7 @@ class PyTorchDistributedRuntime(PythonRuntime):
                     envs = {}
                 # Huggingface accelerate requires machine rank
                 envs["RANK"] = str(i)
-                envs["WORLD_SIZE"] = replicas
+                envs["WORLD_SIZE"] = str(replicas)
                 if main_run:
                     envs["MAIN_JOB_RUN_OCID"] = main_run.id
                 name = replica_kwargs.get("display_name")

--- a/tests/unitary/default_setup/jobs/test_jobs_pytorch_ddp.py
+++ b/tests/unitary/default_setup/jobs/test_jobs_pytorch_ddp.py
@@ -137,13 +137,13 @@ class PyTorchRuntimeHandlerTest(unittest.TestCase):
             [
                 {
                     "display_name": "None-0",
-                    "environment_variables": {"RANK": "0", "WORLD_SIZE": 2},
+                    "environment_variables": {"RANK": "0", "WORLD_SIZE": "2"},
                 },
                 {
                     "display_name": "None-1",
                     "environment_variables": {
                         "RANK": "1",
-                        "WORLD_SIZE": 2,
+                        "WORLD_SIZE": "2",
                         "MAIN_JOB_RUN_OCID": test_ocid,
                     },
                 },


### PR DESCRIPTION
Fix two bugs for the PyTorchDistributedRuntime:
- Cast replica to string when setting it as environment variable.
- Set correct prefix for NCCL_SOCKET_IFNAME and GLOO_SOCKET_IFNAME when running DeepSpeed.