### PR TITLE
Replace printing with logging

### DIFF
--- a/ads/opctl/__init__.py
+++ b/ads/opctl/__init__.py
@@ -9,7 +9,7 @@ import sys
 
 logger = logging.getLogger(__name__)
 handler = logging.StreamHandler(sys.stdout)
-logger.addHandler(handler)
+# logger.addHandler(handler)
 
 logger.setLevel(logging.INFO)
 

--- a/ads/opctl/operator/cmd.py
+++ b/ads/opctl/operator/cmd.py
@@ -52,7 +52,7 @@ OPERATOR_BASE_DOCKER_GPU_FILE = "Dockerfile.gpu"
 
 def list() -> None:
     """Prints the list of the registered service operators."""
-    print(
+    logger.info(
         tabulate(
             (
                 {
@@ -83,7 +83,7 @@ def info(
     """
     operator_info = {item.name: item for item in _operator_info_list()}.get(name)
     if operator_info:
-        print(operator_info.description)
+        logger.info(operator_info.description)
     else:
         raise OperatorNotFoundError(name)
 
@@ -215,9 +215,9 @@ def init(
                 **{**kwargs, **runtime_kwargs},
             )
 
-    print("#" * 100)
-    print(f"The auto-generated configs location: {output}")
-    print("#" * 100)
+    logger.info("#" * 100)
+    logger.info(f"The auto-generated configs location: {output}")
+    logger.info("#" * 100)
 
 
 @runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)

--- a/ads/opctl/operator/lowcode/forecast/model/factory.py
+++ b/ads/opctl/operator/lowcode/forecast/model/factory.py
@@ -11,6 +11,7 @@ from .automlx import AutoMLXOperatorModel
 from .base_model import ForecastOperatorBaseModel
 from .neuralprophet import NeuralProphetOperatorModel
 from .prophet import ProphetOperatorModel
+from ..utils import select_auto_model
 
 
 class UnSupportedModelError(Exception):
@@ -56,6 +57,8 @@ class ForecastOperatorModelFactory:
             In case of not supported model.
         """
         model_type = operator_config.spec.model
+        if model_type == "auto":
+            model_type = select_auto_model(operator_config.spec.historical_data.columns)
         if model_type not in cls._MAP:
             raise UnSupportedModelError(model_type)
         return cls._MAP[model_type](config=operator_config)

--- a/ads/opctl/operator/lowcode/forecast/operator.py
+++ b/ads/opctl/operator/lowcode/forecast/operator.py
@@ -9,6 +9,7 @@ from typing import Dict
 from .model.factory import ForecastOperatorModelFactory
 from .operator_config import ForecastOperatorConfig
 
+from ads.opctl import logger
 
 def operate(operator_config: ForecastOperatorConfig) -> None:
     """Runs the forecasting operator."""
@@ -21,5 +22,5 @@ def verify(spec: Dict) -> bool:
     msg_header = (
         f"{'*' * 50} The operator config has been successfully verified {'*' * 50}"
     )
-    print(operator.to_yaml())
-    print("*" * len(msg_header))
+    logger.info(operator.to_yaml())
+    logger.info("*" * len(msg_header))

--- a/ads/opctl/operator/lowcode/forecast/schema.yaml
+++ b/ads/opctl/operator/lowcode/forecast/schema.yaml
@@ -248,6 +248,7 @@ spec:
         - arima
         - neuralprophet
         - automlx
+        - auto
 
     model_kwargs:
       type: dict

--- a/ads/opctl/operator/lowcode/forecast/utils.py
+++ b/ads/opctl/operator/lowcode/forecast/utils.py
@@ -294,6 +294,6 @@ def human_time_friendly(seconds):
     return ", ".join(accumulator)
 
 def select_auto_model(columns):
-    if len(columns) > 15:
+    if columns!=None and len(columns) > 15:
         return SupportedModels.Arima
     return SupportedModels.AutoMLX

--- a/ads/opctl/operator/lowcode/forecast/utils.py
+++ b/ads/opctl/operator/lowcode/forecast/utils.py
@@ -21,6 +21,7 @@ from sklearn.metrics import (
 )
 
 from ads.dataset.label_encoder import DataFrameLabelEncoder
+from ads.opctl.operator.lowcode.forecast.const import SupportedModels
 
 
 def _label_encode_dataframe(df, no_encode=set()):
@@ -291,3 +292,8 @@ def human_time_friendly(seconds):
             )
     accumulator.append("{} secs".format(round(seconds, 2)))
     return ", ".join(accumulator)
+
+def select_auto_model(columns):
+    if len(columns) > 15:
+        return SupportedModels.Arima
+    return SupportedModels.AutoMLX


### PR DESCRIPTION
Replaced all prints with logger.info. Removed handler in ads.opctl as it was leading to double printing.