### PR TITLE
Replaced print with logger in operator folder

### DIFF
--- a/ads/opctl/__init__.py
+++ b/ads/opctl/__init__.py
@@ -9,7 +9,7 @@ import sys
 
 logger = logging.getLogger(__name__)
 handler = logging.StreamHandler(sys.stdout)
-logger.addHandler(handler)
+# logger.addHandler(handler)
 
 logger.setLevel(logging.INFO)
 

--- a/ads/opctl/operator/cmd.py
+++ b/ads/opctl/operator/cmd.py
@@ -52,7 +52,7 @@ OPERATOR_BASE_DOCKER_GPU_FILE = "Dockerfile.gpu"
 
 def list() -> None:
     """Prints the list of the registered service operators."""
-    print(
+    logger.info(
         tabulate(
             (
                 {
@@ -83,7 +83,7 @@ def info(
     """
     operator_info = {item.name: item for item in _operator_info_list()}.get(name)
     if operator_info:
-        print(operator_info.description)
+        logger.info(operator_info.description)
     else:
         raise OperatorNotFoundError(name)
 
@@ -215,9 +215,9 @@ def init(
                 **{**kwargs, **runtime_kwargs},
             )
 
-    print("#" * 100)
-    print(f"The auto-generated configs location: {output}")
-    print("#" * 100)
+    logger.info("#" * 100)
+    logger.info(f"The auto-generated configs location: {output}")
+    logger.info("#" * 100)
 
 
 @runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)

--- a/ads/opctl/operator/lowcode/forecast/operator.py
+++ b/ads/opctl/operator/lowcode/forecast/operator.py
@@ -9,6 +9,7 @@ from typing import Dict
 from .model.factory import ForecastOperatorModelFactory
 from .operator_config import ForecastOperatorConfig
 
+from ads.opctl import logger
 
 def operate(operator_config: ForecastOperatorConfig) -> None:
     """Runs the forecasting operator."""
@@ -21,5 +22,5 @@ def verify(spec: Dict) -> bool:
     msg_header = (
         f"{'*' * 50} The operator config has been successfully verified {'*' * 50}"
     )
-    print(operator.to_yaml())
-    print("*" * len(msg_header))
+    logger.info(operator.to_yaml())
+    logger.info("*" * len(msg_header))


### PR DESCRIPTION
Replaced print statements with logger in operator folder. Removed handler from ads.opctl as it was leading to printing along with logging.