### PR TITLE
Fixed generic model multiple deploy.

### DIFF
--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -2151,7 +2151,7 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
                 "log_id", None
             )
             or self.properties.deployment_predict_log_id,
-            deployment_image = existing_runtime.image
+            deployment_image = getattr(existing_runtime, "image", None)
             or self.properties.deployment_image,
             deployment_instance_subnet_id = existing_infrastructure.subnet_id
             or self.properties.deployment_instance_subnet_id
@@ -2229,16 +2229,24 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         runtime = None
         if self.properties.deployment_image:
             image_digest = (
-                kwargs.pop("image_digest", None) or existing_runtime.image_digest
+                kwargs.pop("image_digest", None) 
+                or getattr(existing_runtime, "image_digest", None)
             )
-            cmd = kwargs.pop("cmd", []) or existing_runtime.cmd
-            entrypoint = kwargs.pop("entrypoint", []) or existing_runtime.entrypoint
+            cmd = (
+                kwargs.pop("cmd", []) 
+                or getattr(existing_runtime, "cmd", [])
+            )
+            entrypoint = (
+                kwargs.pop("entrypoint", [])
+                or getattr(existing_runtime, "entrypoint", [])
+            )
             server_port = (
-                kwargs.pop("server_port", None) or existing_runtime.server_port
+                kwargs.pop("server_port", None) 
+                or getattr(existing_runtime, "server_port", None)
             )
             health_check_port = (
                 kwargs.pop("health_check_port", None)
-                or existing_runtime.health_check_port
+                or getattr(existing_runtime, "health_check_port", None)
             )
             runtime = (
                 ModelDeploymentContainerRuntime()


### PR DESCRIPTION
### Fixed generic model multiple deploy issue

- The `model_deployment` property of generic model is a place holder for properties. The default runtime of it is container. After user deploys a conda runtime model and call `deploy` again, the `model_deployment` property will be updated to conda runtime, and property error happens. Though this use case is rare, but we need to cover it.
- Need to cover the following unique properties that are only available for container runtime:
-- `image`
-- `cmd`
-- `entrypoint`
-- `image_digest`
-- `server_port`
-- `health_check_port`