### PR TITLE
ODSC-44202. Adds Data Flow + Local backends for the Forecasting operator.

### DIFF
--- a/ads/common/utils.py
+++ b/ads/common/utils.py
@@ -1282,6 +1282,7 @@ def copy_file(
     auth: Optional[Dict] = None,
     chunk_size: Optional[int] = DEFAULT_BUFFER_SIZE,
     progressbar_description: Optional[str] = "Copying `{uri_src}` to `{uri_dst}`",
+    ignore_if_src_not_exists: Optional[bool] = False,
 ) -> str:
     """
     Copies file from `uri_src` to `uri_dst`.
@@ -1301,9 +1302,9 @@ def copy_file(
         The default authentication is set using `ads.set_auth` API. If you need to override the
         default, use the `ads.common.auth.api_keys` or `ads.common.auth.resource_principal` to create appropriate
         authentication signer and kwargs required to instantiate IdentityClient object.
-    chunk_size: (int, optinal). Defaults to `DEFAULT_BUFFER_SIZE`
+    chunk_size: (int, optional). Defaults to `DEFAULT_BUFFER_SIZE`
         How much data can be copied in one iteration.
-    progressbar_description: (str, optinal). Defaults to `"Copying `{uri_src}` to `{uri_dst}`"`.
+    progressbar_description: (str, optional). Defaults to `"Copying `{uri_src}` to `{uri_dst}`"`.
         Prefix for the progressbar.
 
     Returns
@@ -1323,8 +1324,13 @@ def copy_file(
         uri_dst = os.path.join(uri_dst, os.path.basename(uri_src))
     src_path_scheme = urlparse(uri_src).scheme or "file"
     src_file_system = fsspec.filesystem(src_path_scheme, **auth)
-    file_size = src_file_system.info(uri_src)["size"]
 
+    if not fsspec.filesystem(src_path_scheme, **auth).exists(uri_src):
+        if ignore_if_src_not_exists:
+            return uri_dst
+        raise FileNotFoundError(f"The `{uri_src}` not exists.")
+
+    file_size = src_file_system.info(uri_src)["size"]
     if not force_overwrite:
         dst_path_scheme = urlparse(uri_dst).scheme or "file"
         if fsspec.filesystem(dst_path_scheme, **auth).exists(uri_dst):

--- a/ads/jobs/builders/runtimes/base.py
+++ b/ads/jobs/builders/runtimes/base.py
@@ -11,10 +11,6 @@ from ads.jobs import env_var_parser
 
 
 Self = TypeVar("Self", bound="Runtime")
-"""Special type to represent the current enclosed class.
-
-This type is used by factory class method or when a method returns ``self``.
-"""
 
 
 class Runtime(Builder):
@@ -31,6 +27,7 @@ class Runtime(Builder):
         CONST_FREEFORM_TAGS: "freeform_tags",
         CONST_DEFINED_TAGS: "defined_tags",
         CONST_ENV_VAR: CONST_ENV_VAR,
+        CONST_ARGS: CONST_ARGS,
     }
 
     def __init__(self, spec: Dict = None, **kwargs) -> None:
@@ -248,7 +245,11 @@ class Runtime(Builder):
             This method returns self to support chaining methods.
         """
         return (
-            self.with_environment_variable(env_name="env_value")
-            .with_freeform_tag(tag_name="tag_value")
-            .with_argument(key1="val1")
+            self.with_environment_variable(
+                **kwargs.get(self.attribute_map[self.CONST_ENV_VAR], {})
+            )
+            .with_freeform_tag(
+                **kwargs.get(self.attribute_map[self.CONST_FREEFORM_TAGS], {})
+            )
+            .with_argument(**kwargs.get(self.attribute_map[self.CONST_ARGS], {}))
         )

--- a/ads/jobs/builders/runtimes/python_runtime.py
+++ b/ads/jobs/builders/runtimes/python_runtime.py
@@ -262,7 +262,7 @@ class ScriptRuntime(CondaRuntime):
             .with_script(
                 "{Path to the script. For MLflow and Operator will be auto generated}"
             )
-            .with_argument(key1="val1")
+            .with_argument(**kwargs.get("args", {}))
         )
 
 
@@ -978,8 +978,11 @@ class DataFlowRuntime(CondaRuntime):
                 "{Path to the executable script. For MLflow and Operator will auto generated}"
             )
             .with_script_bucket(
-                "{The object storage bucket to save a script. "
-                "Example: oci://<bucket_name>@<tenancy>/<prefix>}"
+                kwargs.get(
+                    "script_bucket",
+                    "{The object storage bucket to save a script. "
+                    "Example: oci://<bucket_name>@<tenancy>/<prefix>}",
+                )
             )
             .with_overwrite(True)
             .with_configuration({"spark.driverEnv.env_key": "env_value"})

--- a/ads/opctl/backend/ads_dataflow.py
+++ b/ads/opctl/backend/ads_dataflow.py
@@ -5,28 +5,27 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 
-import os
 import json
+import os
 import shlex
+import tempfile
+import time
 from typing import Dict, Union
 
-from ads.opctl.backend.base import Backend
-from ads.opctl.decorator.common import print_watch_command
-from ads.common.auth import create_signer, AuthContext
+from ads.common.auth import AuthContext, create_signer, AuthType
 from ads.common.oci_client import OCIClientFactory
-
-from ads.opctl.backend.base import (
-    Backend,
-    RuntimeFactory,
-)
-
 from ads.jobs import (
-    Job,
     DataFlow,
-    DataFlowRuntime,
     DataFlowNotebookRuntime,
     DataFlowRun,
+    DataFlowRuntime,
+    Job,
 )
+from ads.opctl import logger
+from ads.opctl.backend.base import Backend, RuntimeFactory
+from ads.opctl.constants import OPERATOR_MODULE_PATH
+from ads.opctl.decorator.common import print_watch_command
+from ads.opctl.operator.common.const import ENV_OPERATOR_ARGS
 
 REQUIRED_FIELDS = [
     "compartment_id",
@@ -83,6 +82,15 @@ class DataFlowBackend(Backend):
             The YAML specification for the given resource if `uri` was not provided.
             `None` otherwise.
         """
+        RUNTIME_KWARGS_MAP = {
+            DataFlowRuntime().type: {
+                "conda_slug": (
+                    f"{self.config['execution'].get('conda_pack_os_prefix','oci://bucket@namespace/conda_environments').rstrip('/')}"
+                    f"/{kwargs.get('conda_slug', 'conda_slug') }"
+                ),
+                "script_bucket": f"{self.config['infrastructure'].get('script_bucket','').rstrip('/')}",
+            },
+        }
 
         with AuthContext(auth=self.auth_type, profile=self.profile):
             # define an job
@@ -95,7 +103,7 @@ class DataFlowBackend(Backend):
                 .with_runtime(
                     DataFlowRuntimeFactory.get_runtime(
                         key=runtime_type or DataFlowRuntime().type
-                    ).init()
+                    ).init(**{**kwargs, **RUNTIME_KWARGS_MAP[runtime_type]})
                 )
             )
 
@@ -109,7 +117,7 @@ class DataFlowBackend(Backend):
                 uri=uri,
                 overwrite=overwrite,
                 note=note,
-                filter_by_attribute_map=True,
+                filter_by_attribute_map=False,
                 **kwargs,
             )
 
@@ -191,6 +199,103 @@ class DataFlowBackend(Backend):
         with AuthContext(auth=self.auth_type, profile=self.profile):
             run = DataFlowRun.from_ocid(run_id)
             run.watch(interval=interval)
+
+
+class DataFlowOperatorBackend(DataFlowBackend):
+    """Backend class to run operator on Data Flow Applications."""
+
+    def __init__(self, config: Dict) -> None:
+        super().__init__(config=config)
+
+        self.job = None
+
+        self.runtime_config = self.config.get("runtime", {})
+        self.operator_config = {
+            **{
+                key: value
+                for key, value in self.config.items()
+                if key not in ("runtime", "infrastructure", "execution")
+            }
+        }
+        self.operator_type = self.operator_config.get("type", "unknown")
+        self.operator_version = self.operator_config.get("version", "unknown")
+
+    def _adjust_common_information(self):
+        """Adjusts common information of the application."""
+
+        if self.job.name.lower().startswith("{job"):
+            self.job.with_name(
+                f"job_{self.operator_type.lower()}" f"_{self.operator_version.lower()}"
+            )
+        self.job.runtime.with_maximum_runtime_in_minutes(
+            self.config["execution"].get("max_wait_time", 1200)
+        )
+
+        temp_dir = tempfile.mkdtemp()
+
+        # prepare run.py file to run the operator
+        script_file = os.path.join(
+            temp_dir, f"{self.operator_type}_{int(time.time())}_run.py"
+        )
+
+        operator_module = f"{OPERATOR_MODULE_PATH}.{self.operator_type}"
+        with open(script_file, "w") as fp:
+            fp.writelines(
+                [
+                    "import runpy",
+                    f"runpy.run_module('{operator_module}', run_name='__main__')",
+                ]
+            )
+        self.job.runtime.with_script_uri(script_file)
+
+        # propagate environment variables to the runtime config
+        env_vars = {
+            "OCI_IAM_TYPE": AuthType.RESOURCE_PRINCIPAL,
+            "OCIFS_IAM_TYPE": AuthType.RESOURCE_PRINCIPAL,
+            ENV_OPERATOR_ARGS: json.dumps(self.operator_config),
+            **(self.job.runtime.envs or {}),
+        }
+
+        runtime_config = self.job.runtime.configuration or dict()
+
+        existing_env_keys = {
+            key.upper()
+            .replace("SPARK.EXECUTORENV.", "")
+            .replace("SPARK.DRIVERENV.", "")
+            for key in runtime_config
+            if "SPARK.EXECUTORENV" in key.upper() or "SPARK.DRIVERENV" in key.upper()
+        }
+
+        for env_key, env_value in (env_vars or {}).items():
+            if env_key.upper() not in existing_env_keys:
+                runtime_config[f"spark.driverEnv.{env_key}"] = env_value
+
+        self.job.runtime.with_configuration(runtime_config)
+
+    @print_watch_command
+    def run(self, **kwargs: Dict) -> Union[Dict, None]:
+        """
+        Runs the operator on the Data Flow service.
+        """
+        self.job = Job.from_dict(self.runtime_config).build()
+
+        # adjust job's common information
+        self._adjust_common_information()
+
+        # run the job if only it is not a dry run mode
+        if not self.config["execution"].get("dry_run"):
+            job = self.job.create()
+            logger.info(f"{'*' * 50} DataFlow Application {'*' * 50}")
+            logger.info(job)
+
+            job_run = job.run()
+            logger.info(f"{'*' * 50} DataFlow Application Run {'*' * 50}")
+            logger.info(job_run)
+
+            return {"job_id": job.id, "run_id": job_run.id}
+        else:
+            logger.info(f"{'*' * 50} DataFlow Application (Dry Run Mode) {'*' * 50}")
+            logger.info(self.job)
 
 
 class DataFlowRuntimeFactory(RuntimeFactory):

--- a/ads/opctl/backend/ads_dataflow.py
+++ b/ads/opctl/backend/ads_dataflow.py
@@ -241,10 +241,12 @@ class DataFlowOperatorBackend(DataFlowBackend):
         operator_module = f"{OPERATOR_MODULE_PATH}.{self.operator_type}"
         with open(script_file, "w") as fp:
             fp.writelines(
-                [
-                    "import runpy",
-                    f"runpy.run_module('{operator_module}', run_name='__main__')",
-                ]
+                "\n".join(
+                    [
+                        "import runpy",
+                        f"runpy.run_module('{operator_module}', run_name='__main__')",
+                    ]
+                )
             )
         self.job.runtime.with_script_uri(script_file)
 
@@ -285,7 +287,7 @@ class DataFlowOperatorBackend(DataFlowBackend):
         # run the job if only it is not a dry run mode
         if not self.config["execution"].get("dry_run"):
             job = self.job.create()
-            logger.info(f"{'*' * 50} DataFlow Application {'*' * 50}")
+            logger.info(f"{'*' * 50} Data Flow Application {'*' * 50}")
             logger.info(job)
 
             job_run = job.run()

--- a/ads/opctl/backend/ads_ml_job.py
+++ b/ads/opctl/backend/ads_ml_job.py
@@ -685,17 +685,17 @@ class MLJobOperatorBackend(MLJobBackend):
         # run the job if only it is not a dry run mode
         if not self.config["execution"].get("dry_run"):
             job = self.job.create()
-            print(f"{'*' * 50}Job{'*' * 50}")
-            print(job)
+            logger.info(f"{'*' * 50}Job{'*' * 50}")
+            logger.info(job)
 
             job_run = job.run()
-            print(f"{'*' * 50}JobRun{'*' * 50}")
-            print(job_run)
+            logger.info(f"{'*' * 50}JobRun{'*' * 50}")
+            logger.info(job_run)
 
             return {"job_id": job.id, "run_id": job_run.id}
         else:
-            print(f"{'*' * 50} Job (Dry Run Mode) {'*' * 50}")
-            print(self.job)
+            logger.info(f"{'*' * 50} Job (Dry Run Mode) {'*' * 50}")
+            logger.info(self.job)
 
 
 class JobRuntimeFactory(RuntimeFactory):

--- a/ads/opctl/backend/local.py
+++ b/ads/opctl/backend/local.py
@@ -7,10 +7,12 @@
 import copy
 import json
 import os
+import runpy
+import sys
 import tempfile
 from concurrent.futures import Future, ThreadPoolExecutor
 from time import sleep
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from oci.data_science.models import PipelineStepRun
 
@@ -37,15 +39,15 @@ from ads.opctl.constants import (
     DEFAULT_NOTEBOOK_SESSION_SPARK_CONF_DIR,
     ML_JOB_GPU_IMAGE,
     ML_JOB_IMAGE,
+    OPERATOR_MODULE_PATH,
 )
 from ads.opctl.distributed.cmds import load_ini, local_run
 from ads.opctl.model.cmds import _download_model
 from ads.opctl.operator import __operators__
 from ads.opctl.operator.common.const import ENV_OPERATOR_ARGS
 from ads.opctl.operator.common.errors import OperatorNotFoundError
-from ads.opctl.operator.runtime import runtime as operator_runtime
 from ads.opctl.operator.runtime import const as operator_runtime_const
-
+from ads.opctl.operator.runtime import runtime as operator_runtime
 from ads.opctl.spark.cmds import (
     generate_core_site_properties,
     generate_core_site_properties_str,
@@ -830,8 +832,8 @@ class LocalModelDeploymentBackend(LocalBackend):
 class LocalOperatorBackend(Backend):
     """Class representing local operator backend."""
 
-    def __init__(self, config: Dict) -> None:
-        super().__init__(config=config)
+    def __init__(self, config: Optional[Dict]) -> None:
+        super().__init__(config=config or {})
 
         self.runtime_config = self.config.get("runtime", {})
         self.operator_config = {
@@ -844,11 +846,47 @@ class LocalOperatorBackend(Backend):
         self.operator_type = self.operator_config.get("type")
 
         self._RUNTIME_RUN_MAP = {
-            operator_runtime.ContainerRuntime.type: self._run_with_container
+            operator_runtime.ContainerRuntime.type: self._run_with_container,
+            operator_runtime.PythonRuntime.type: self._run_with_python,
         }
 
+    def _run_with_python(self) -> int:
+        """Runs the operator within a local python environment.
+
+        Returns
+        -------
+        int
+            The operator's run exit code.
+        """
+
+        # build runtime object
+        runtime = operator_runtime.PythonRuntime.from_dict(
+            self.runtime_config, ignore_unknown=True
+        )
+
+        # run operator
+        operator_module = f"{OPERATOR_MODULE_PATH}.{self.operator_type}"
+        operator_spec = json.dumps(self.operator_config)
+        sys.argv = [operator_module, "--spec", operator_spec]
+
+        print(f"{'*' * 50} Runtime Config {'*' * 50}")
+        print(runtime.to_yaml())
+
+        try:
+            runpy.run_module(operator_module, run_name="__main__")
+        except SystemExit as exception:
+            return exception.code
+        else:
+            return 0
+
     def _run_with_container(self) -> int:
-        """Runs the operator within a container."""
+        """Runs the operator within a container.
+
+        Returns
+        -------
+        int
+            The operator's run exit code.
+        """
 
         # build runtime object
         runtime: operator_runtime.ContainerRuntime = (
@@ -870,6 +908,9 @@ class LocalOperatorBackend(Backend):
                 "bind": container_path.lstrip().rstrip()
             }
 
+        logger.info(f"{'*' * 50} Runtime Config {'*' * 50}")
+        logger.info(runtime.to_yaml())
+
         return run_container(
             image=runtime.spec.image,
             bind_volumes=bind_volumes,
@@ -878,10 +919,12 @@ class LocalOperatorBackend(Backend):
         )
 
     def run(self, **kwargs: Dict) -> Dict:
-        """Runs the operator code."""
+        """Runs the operator."""
 
         # extract runtime
-        runtime_type = self.runtime_config.get("type", "unknown")
+        runtime_type = self.runtime_config.get(
+            "type", operator_runtime.OPERATOR_LOCAL_RUNTIME_TYPE.PYTHON
+        )
         if runtime_type not in self._RUNTIME_RUN_MAP:
             raise RuntimeError(
                 f"Not supported runtime - {runtime_type} for local backend. "
@@ -898,7 +941,7 @@ class LocalOperatorBackend(Backend):
         if exit_code != 0:
             raise RuntimeError(
                 f"Operation did not complete successfully. Exit code: {exit_code}. "
-                f"Run with the --debug argument to view container logs."
+                f"Run with the --debug argument to view logs."
             )
 
     def init(
@@ -944,14 +987,22 @@ class LocalOperatorBackend(Backend):
                     + ":"
                     + "/root/.oci"
                 ],
-                "env": [{"name": "test_env_key", "value": "test_env_val"}],
-            }
+                "env": [
+                    {
+                        "name": "operator",
+                        "value": f"{self.operator_config['type']}:{self.operator_config['version']}",
+                    }
+                ],
+            },
+            operator_runtime.PythonRuntime.type: {},
         }
 
         with AuthContext(auth=self.auth_type, profile=self.profile):
             note = (
-                "# This YAML specification was auto generated by the `ads opctl operator init` command.\n"
-                "# The more details about the jobs YAML specification can be found in the ADS documentation:\n"
+                "# This YAML specification was auto generated by the "
+                "`ads opctl operator init` command.\n"
+                "# The more details about the operator's runtime YAML "
+                "specification can be found in the ADS documentation:\n"
                 "# https://accelerated-data-science.readthedocs.io/en/latest \n\n"
             )
 

--- a/ads/opctl/cmds.py
+++ b/ads/opctl/cmds.py
@@ -16,7 +16,8 @@ import ads
 from ads.common.auth import AuthContext, AuthType
 from ads.common.extended_enum import ExtendedEnumMeta
 from ads.common.oci_datascience import DSCNotebookSession
-from ads.opctl.backend.ads_dataflow import DataFlowBackend
+from ads.opctl import logger
+from ads.opctl.backend.ads_dataflow import DataFlowBackend, DataFlowOperatorBackend
 from ads.opctl.backend.ads_ml_job import (
     MLJobBackend,
     MLJobDistributedBackend,
@@ -28,8 +29,8 @@ from ads.opctl.backend.local import (
     LocalBackend,
     LocalBackendDistributed,
     LocalModelDeploymentBackend,
-    LocalPipelineBackend,
     LocalOperatorBackend,
+    LocalPipelineBackend,
 )
 from ads.opctl.config.base import ConfigProcessor
 from ads.opctl.config.merger import ConfigMerger
@@ -50,6 +51,7 @@ from ads.opctl.constants import (
     DEFAULT_OCI_CONFIG_FILE,
     DEFAULT_PROFILE,
     RESOURCE_TYPE,
+    RUNTIME_TYPE,
 )
 from ads.opctl.distributed.cmds import (
     docker_build_cmd,
@@ -60,7 +62,6 @@ from ads.opctl.distributed.cmds import (
     verify_and_publish_image,
 )
 from ads.opctl.utils import get_service_pack_prefix, is_in_notebook_session
-import subprocess
 
 
 class DataScienceResource(str, metaclass=ExtendedEnumMeta):
@@ -867,26 +868,30 @@ def init(
         print(output)
 
 
-def apply(config: Dict, backend_config: Dict = None, **kwargs) -> None:
+def apply(config: Dict, backend: Union[Dict, str] = None, **kwargs) -> None:
     """
     Runs the operator with the given specification on the targeted backend.
 
     Parameters
     ----------
-    config: dict
-        dictionary of configurations
-    kwargs: dict
-        keyword arguments, stores configuration from command line args
+    config: Dict
+        The operator's config.
+    backend: (Union[Dict, str], optional)
+        The backend config or backend name to run the operator.
+    kwargs: (Dict, optional)
+        Optional key value arguments to run the operator.
     """
-    backend_config = backend_config or {}
-    p_backend = ConfigProcessor(backend_config).step(ConfigMerger, **kwargs)
     p = ConfigProcessor(config).step(ConfigMerger, **kwargs)
-    p.config["runtime"] = backend_config
-    p.config["infrastructure"] = p_backend.config["infrastructure"]
-    p.config["execution"] = p_backend.config["execution"]
 
     if p.config.get("kind", "").lower() == "operator":
-        from ads.opctl.operator import __operators__, OperatorNotFoundError
+        from ads.opctl.operator import OperatorNotFoundError, __operators__
+        from ads.opctl.operator import cmd as operator_cmd
+        from ads.opctl.operator.common.utils import OperatorInfo, _operator_info
+
+        operator_type = p.config.get("type", "").lower()
+
+        if not (operator_type and operator_type in __operators__):
+            raise OperatorNotFoundError(operator_type or "unknown")
 
         supported_backends = (
             BACKEND_NAME.JOB.value,
@@ -894,33 +899,87 @@ def apply(config: Dict, backend_config: Dict = None, **kwargs) -> None:
             BACKEND_NAME.OPERATOR_LOCAL.value,
         )
 
-        operator_type = p.config.get("type", "").lower()
+        backend_runtime_map = {
+            BACKEND_NAME.JOB.value.lower(): (
+                BACKEND_NAME.JOB.value.lower(),
+                RUNTIME_TYPE.PYTHON.value.lower(),
+            ),
+            BACKEND_NAME.DATAFLOW.value.lower(): (
+                BACKEND_NAME.DATAFLOW.value.lower(),
+                RUNTIME_TYPE.DATAFLOW.value.lower(),
+            ),
+            BACKEND_NAME.OPERATOR_LOCAL.value.lower(): (
+                BACKEND_NAME.OPERATOR_LOCAL.value.lower(),
+                RUNTIME_TYPE.PYTHON.value.lower(),
+            ),
+        }
 
-        if not (operator_type and operator_type in __operators__):
-            raise OperatorNotFoundError(operator_type or "unknown")
-
-        if not (p.config["runtime"] and p.config["runtime"].get("kind")):
-            raise ValueError(
-                "To run an operator the backend config needs to be provided."
+        if not backend:
+            logger.info(
+                f"Backend config is not provided, the {BACKEND_NAME.OPERATOR_LOCAL.value} "
+                "will be used by default. "
             )
+            backend = {"kind": BACKEND_NAME.OPERATOR_LOCAL.value}
 
-        backend_kind = p.config["runtime"].get("kind").lower()
+        if isinstance(backend, str):
+            backend = {"kind": backend}
+
+        backend_kind = backend.get("kind").lower() or "unknown"
+
+        # If backend kind is Job, then it is necessary to check the infrastructure kind.
+        # This is necessary, because Jobs and DataFlow have similar kind,
+        # The only difference would be in the infrastructure kind.
+        # This is a temporary solution, the logic needs to be placed in the ConfigMerger instead.
+        if backend_kind == BACKEND_NAME.JOB.value:
+            if (
+                backend.get("spec", {})
+                .get("infrastructure", {})
+                .get("type", "")
+                .lower()
+                == BACKEND_NAME.DATAFLOW.value
+            ):
+                backend_kind = BACKEND_NAME.DATAFLOW.value
 
         if backend_kind not in supported_backends:
             raise RuntimeError(
                 f"Not supported backend - {backend_kind}. Supported backends: {supported_backends}"
             )
 
-        if backend_kind == BACKEND_NAME.OPERATOR_LOCAL.value:
+        # generate backend specification in case if it is not provided
+        if not backend.get("spec"):
+            # get operator physical location
+            operator_path = os.path.join(
+                os.path.dirname(__file__), "operator", "lowcode", operator_type
+            )
+            # load operator info
+            operator_info: OperatorInfo = _operator_info(operator_path)
+
+            backends = operator_cmd._init_backend_config(
+                operator_info=operator_info, **kwargs
+            )
+            backend = backends[backend_runtime_map[backend_kind]]
+
+        p_backend = ConfigProcessor(
+            {**backend, **{"execution": {"backend": backend_kind}}}
+        ).step(ConfigMerger, **kwargs)
+
+        p.config["runtime"] = backend
+        p.config["infrastructure"] = p_backend.config["infrastructure"]
+        p.config["execution"] = p_backend.config["execution"]
+
+        if (
+            p_backend.config["execution"]["backend"]
+            == BACKEND_NAME.OPERATOR_LOCAL.value
+        ):
             if kwargs.get("dry_run"):
-                print(
+                logger.info(
                     "The dry run option is not supported for "
                     "the local backend and will be ignored."
                 )
             LocalOperatorBackend(config=p.config).run()
-        elif backend_kind == BACKEND_NAME.JOB.value:
+        elif p_backend.config["execution"]["backend"] == BACKEND_NAME.JOB.value:
             MLJobOperatorBackend(config=p.config).run()
-        elif backend_kind == BACKEND_NAME.DATAFLOW.value:
-            raise NotImplementedError("The Data Flow backend is not supported yet.")
+        elif p_backend.config["execution"]["backend"] == BACKEND_NAME.DATAFLOW.value:
+            DataFlowOperatorBackend(config=p.config).run()
     else:
         raise RuntimeError("Not supported operator.")

--- a/ads/opctl/operator/common/utils.py
+++ b/ads/opctl/operator/common/utils.py
@@ -8,7 +8,6 @@ import argparse
 import importlib
 import inspect
 import os
-import re
 from dataclasses import dataclass
 from string import Template
 from typing import Any, Dict, List, Optional, Tuple
@@ -49,6 +48,8 @@ class OperatorInfo:
         The version of the operator.
     conda: str
         The conda environment that have to be used to run the operator.
+    path: str
+        The operator location.
     """
 
     name: str
@@ -57,17 +58,27 @@ class OperatorInfo:
     description: str
     version: str
     conda: str
+    path: str
 
     @classmethod
     def from_init(*args: List, **kwargs: Dict) -> "OperatorInfo":
         """Instantiates the class from the initial operator details config."""
+
+        path = kwargs.get("__operator_path__")
+        if path:
+            readme_file_path = os.path.join(path, "readme.md")
+            if os.path.exists(readme_file_path):
+                with open(readme_file_path, "r") as readme_file:
+                    operator_readme = readme_file.read()
+
         return OperatorInfo(
             name=kwargs.get("__type__"),
             gpu=kwargs.get("__gpu__", "").lower() == "yes",
-            description=kwargs.get("__description__"),
+            description=operator_readme or kwargs.get("__short_description__"),
             short_description=kwargs.get("__short_description__"),
             version=kwargs.get("__version__"),
             conda=kwargs.get("__conda__"),
+            path=path,
         )
 
 

--- a/ads/opctl/operator/lowcode/forecast/README.md
+++ b/ads/opctl/operator/lowcode/forecast/README.md
@@ -23,8 +23,10 @@ ads opctl operator init -n forecast --overwrite --output /dst/configs/
 The most important files expected to be generated are:
 
 - `forecast.yaml`: Contains forecast-related configuration.
+- `backend_operator_local_python_config.yaml`: Contains a local backend configuration to run forecasting in a local conda environment.
 - `backend_operator_local_container_config.yaml`: Contains a local backend configuration to run forecasting in a local container.
-- `backend_job_container_config.yaml`: Contains Data Science job-related config to run forecasting in a Data Science job.
+- `backend_job_container_config.yaml`: Contains Data Science job-related config to run forecasting in a Data Science job within a container runtime.
+- `backend_job_python_config.yaml`: Contains Data Science job-related config to run forecasting in a Data Science job within a conda runtime.
 
 ## 3. Running forecasting on the local conda environment
 
@@ -44,7 +46,7 @@ To run forecasting locally, create and activate a new conda environment (`ads-fo
 - oracle_ads-2.8.7b0-py3-none-any.whl
 ```
 
-Check the previously generated `forecast.yaml` and adjust the input and output file locations.
+Check the previously generated within `init` command the `forecast.yaml` and adjust the input and output file locations.
 
 Use the command below to verify the forecasting config.
 
@@ -55,8 +57,15 @@ ads opctl operator verify -f /dst/configs/forecast.yaml
 Use the following command to run the forecasting within the `ads-forecasting` conda environment.
 
 ```bash
-python -m ads.opctl.operator.lowcode.forecast -f /dst/configs/forecast.yaml
+ads opctl apply -f /dst/configs/forecast.yaml -b local.operator
 ```
+
+Alternatively the `backend_operator_local_python_config.yaml` config can be used.
+```bash
+ads opctl apply -f /dst/configs/forecast.yaml -b /dst/configs/backend_operator_local_python_config.yaml
+```
+
+The operator will be used in your local environment without any additional adjustments.
 
 ## 4. Running forecasting on the local container
 
@@ -93,7 +102,7 @@ Run the forecasting within a container using the command below:
 ads opctl apply -f /dst/configs/forecast.yaml --backend-config /dst/configs/backend_operator_local_container_config.yaml
 ```
 
-## 5. Running forecasting in the Data Science job
+## 5. Running forecasting in the Data Science job within container runtime
 
 To run the forecasting operator within a Data Science job, follow these steps:
 
@@ -130,3 +139,7 @@ ads opctl apply -f /dst/configs/forecast.yaml --backend-config /dst/configs/back
 ```
 
 The logs can be monitored using the `ads opctl watch` command.
+
+```bash
+ads opctl watch <OCID>
+```

--- a/ads/opctl/operator/lowcode/forecast/README.md
+++ b/ads/opctl/operator/lowcode/forecast/README.md
@@ -17,16 +17,18 @@ Follow the [CLI Configuration](https://accelerated-data-science.readthedocs.io/e
 To generate starter configs, run the command below. This will create a list of YAML configs and place them in the `output` folder.
 
 ```bash
-ads opctl operator init -n forecast --overwrite --output /dst/configs/
+ads opctl operator init -n forecast --overwrite --output ~/forecast/
 ```
 
 The most important files expected to be generated are:
 
 - `forecast.yaml`: Contains forecast-related configuration.
-- `backend_operator_local_python_config.yaml`: Contains a local backend configuration to run forecasting in a local conda environment.
-- `backend_operator_local_container_config.yaml`: Contains a local backend configuration to run forecasting in a local container.
-- `backend_job_container_config.yaml`: Contains Data Science job-related config to run forecasting in a Data Science job within a container runtime.
-- `backend_job_python_config.yaml`: Contains Data Science job-related config to run forecasting in a Data Science job within a conda runtime.
+- `backend_operator_local_python_config.yaml`: This includes a local backend configuration for running forecasting in a local environment. The environment should be set up manually before running the operator.
+- `backend_operator_local_container_config.yaml`: This includes a local backend configuration for running forecasting within a local container. The container should be built before running the operator. Please refer to the instructions below for details on how to accomplish this.
+- `backend_job_container_config.yaml`: Contains Data Science job-related config to run forecasting in a Data Science job within a container (BYOC) runtime. The container should be built and published before running the operator. Please refer to the instructions below for details on how to accomplish this.
+- `backend_job_python_config.yaml`: Contains Data Science job-related config to run forecasting in a Data Science job within a conda runtime. The conda should be built and published before running the operator.
+
+All generated configurations should be ready to use without the need for any additional adjustments. However, they are provided as starter kit configurations that can be customized as needed.
 
 ## 3. Running forecasting on the local conda environment
 
@@ -46,26 +48,21 @@ To run forecasting locally, create and activate a new conda environment (`ads-fo
 - oracle_ads-2.8.7b0-py3-none-any.whl
 ```
 
-Check the previously generated within `init` command the `forecast.yaml` and adjust the input and output file locations.
+Please review the previously generated `forecast.yaml` file using the `init` command, and make any necessary adjustments to the input and output file locations. By default, it assumes that the files should be located in the same folder from which the `init` command was executed.
 
 Use the command below to verify the forecasting config.
 
 ```bash
-ads opctl operator verify -f /dst/configs/forecast.yaml
+ads opctl operator verify -f ~/forecast/forecast.yaml
 ```
 
 Use the following command to run the forecasting within the `ads-forecasting` conda environment.
 
 ```bash
-ads opctl apply -f /dst/configs/forecast.yaml -b local.operator
+ads opctl apply -f ~/forecast/forecast.yaml -b local.operator
 ```
 
-Alternatively the `backend_operator_local_python_config.yaml` config can be used.
-```bash
-ads opctl apply -f /dst/configs/forecast.yaml -b /dst/configs/backend_operator_local_python_config.yaml
-```
-
-The operator will be used in your local environment without any additional adjustments.
+The operator will run in your local environment without requiring any additional modifications.
 
 ## 4. Running forecasting on the local container
 
@@ -77,46 +74,55 @@ Use the command below to build the forecast container.
 ads opctl operator build-image -n forecast
 ```
 
-This will create a new `forecast:v1` image, and `/etc/operator` will be used as the working directory in the container.
+This will create a new `forecast:v1` image, with `/etc/operator` as the designated working directory within the container.
 
 
-Check the `backend_operator_local_container_config.yaml` config. By default, it should have a `volume` section with the `.oci` configs folder mounted.
+Check the `backend_operator_local_container_config.yaml` config file. By default, it should have a `volume` section with the `.oci` configs folder mounted.
 
 ```yaml
 volume:
-  - "/Users/dmcherka/.oci:/root/.oci"
+  - "/Users/<user>/.oci:/root/.oci"
 ```
 
 Mounting the OCI configs folder is only required if an OCI Object Storage bucket will be used to store the input forecasting data or output forecasting result. The input/output folders can also be mounted to the container.
 
 ```yaml
 volume:
-  - "/etc/forecast/data:/etc/operator/data"
-  - "/etc/forecast/result:/etc/operator/result"
-  - "/etc/.oci:/root/.oci"
+  - /Users/<user>/.oci:/root/.oci
+  - /Users/<user>/forecast/data:/etc/operator/data
+  - /Users/<user>/forecast/result:/etc/operator/result
+```
+
+The full config can look like:
+```yaml
+kind: operator.local
+spec:
+  image: forecast:v1
+  volume:
+  - /Users/<user>/.oci:/root/.oci
+  - /Users/<user>/forecast/data:/etc/operator/data
+  - /Users/<user>/forecast/result:/etc/operator/result
+type: container
+version: v1
 ```
 
 Run the forecasting within a container using the command below:
 
 ```bash
-ads opctl apply -f /dst/configs/forecast.yaml --backend-config /dst/configs/backend_operator_local_container_config.yaml
+ads opctl apply -f ~/forecast/forecast.yaml --backend-config ~/forecast/backend_operator_local_container_config.yaml
 ```
 
 ## 5. Running forecasting in the Data Science job within container runtime
 
-To run the forecasting operator within a Data Science job, follow these steps:
+To execute the forecasting operator within a Data Science job using container runtime, please follow the steps outlined below:
 
-Adjust the `forecast.yaml` config with proper input/output folders. When the forecasting is run in the Data Science job, it will not have access to local folders. Therefore, input data and output folders should be placed in the Object Storage bucket. Open the `forecast.yaml` and adjust the following fields:
+You can use the following command to build the forecast container. This step can be skipped if you have already done this for running the operator within a local container.
 
-```yaml
-historical_data:
-  url: oci://bucket@namespace/forecast/input_data/data.csv
-model: prophet
-output_directory:
-  url: oci://bucket@namespace/forecast/result/
-test_data:
-  url: oci://bucket@namespace/forecast/input_data/test.csv
+```bash
+ads opctl operator build-image -n forecast
 ```
+
+This will create a new `forecast:v1` image, with `/etc/operator` as the designated working directory within the container.
 
 Publish the `forecast:v1` container to the [Oracle Container Registry](https://docs.public.oneportal.content.oci.oraclecloud.com/en-us/iaas/Content/Registry/home.htm). To become familiar with OCI, read the documentation links posted below.
 
@@ -132,10 +138,74 @@ ads opctl operator publish-image forecast:v1 --registry <iad.ocir.io/tenancy/>
 
 After the container is published to OCR, it can be used within Data Science jobs service. Check the `backend_job_container_config.yaml` config file. It should contain pre-populated infrastructure and runtime sections. The runtime section should contain an image property, something like `image: iad.ocir.io/<tenancy>/forecast:v1`. More details about supported options can be found in the ADS Jobs documentation - [Run a Container](https://accelerated-data-science.readthedocs.io/en/latest/user_guide/jobs/run_container.html).
 
+Adjust the `forecast.yaml` config with proper input/output folders. When the forecasting is run in the Data Science job, it will not have access to local folders. Therefore, input data and output folders should be placed in the Object Storage bucket. Open the `forecast.yaml` and adjust the following fields:
+
+```yaml
+historical_data:
+  url: oci://bucket@namespace/forecast/input_data/data.csv
+output_directory:
+  url: oci://bucket@namespace/forecast/result/
+test_data:
+  url: oci://bucket@namespace/forecast/input_data/test.csv
+```
+
 Run the forecasting on the Data Science jobs using the command posted below:
 
 ```bash
-ads opctl apply -f /dst/configs/forecast.yaml --backend-config /dst/configs/backend_job_container_config.yaml
+ads opctl apply -f ~/forecast/forecast.yaml --backend-config ~/forecast/backend_job_container_config.yaml
+```
+
+The logs can be monitored using the `ads opctl watch` command.
+
+```bash
+ads opctl watch <OCID>
+```
+
+## 6. Running forecasting in the Data Science job within conda runtime
+
+To execute the forecasting operator within a Data Science job using conda runtime, please follow the steps outlined below:
+
+You can use the following command to build the forecast conda environment.
+
+```bash
+ads opctl operator build-conda -n forecast
+```
+
+This will create a new `forecast_v1` conda environment and place it in the folder specified within `ads opctl configure` command.
+
+Use the command below to Publish the `forecast_v1` conda environment to the Object Storage bucket.
+
+```bash
+ads opctl conda publish forecast_v1
+```
+More details about configuring CLI can be found here - [Configuring CLI](https://accelerated-data-science.readthedocs.io/en/latest/user_guide/cli/opctl/configure.html)
+
+
+After the conda environment is published to Object Storage, it can be used within Data Science jobs service. Check the `backend_job_python_config.yaml` config file. It should contain pre-populated infrastructure and runtime sections. The runtime section should contain a `conda` section.
+
+```yaml
+conda:
+  type: published
+  uri: oci://bucket@namespace/conda_environments/cpu/forecast/1/forecast_v1
+```
+
+More details about supported options can be found in the ADS Jobs documentation - [Run a Python Workload](https://accelerated-data-science.readthedocs.io/en/latest/user_guide/jobs/run_python.html).
+
+Adjust the `forecast.yaml` config with proper input/output folders. When the forecasting is run in the Data Science job, it will not have access to local folders. Therefore, input data and output folders should be placed in the Object Storage bucket. Open the `forecast.yaml` and adjust the following fields:
+
+```yaml
+historical_data:
+  url: oci://bucket@namespace/forecast/input_data/data.csv
+output_directory:
+  url: oci://bucket@namespace/forecast/result/
+test_data:
+  url: oci://bucket@namespace/forecast/input_data/test.csv
+```
+
+Run the forecasting on the Data Science jobs using the command posted below:
+
+```bash
+ads opctl apply -f ~/forecast/forecast.yaml --backend-config ~/forecast/backend_job_python_config.yaml
 ```
 
 The logs can be monitored using the `ads opctl watch` command.

--- a/ads/opctl/operator/lowcode/forecast/__init__.py
+++ b/ads/opctl/operator/lowcode/forecast/__init__.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
+import os
+
 __version__ = "v1"
 
 __type__ = "forecast"
@@ -16,17 +18,10 @@ __gpu__ = "no"  # yes/no
 
 __keywords__ = ["Prophet", "AutoML", "ARIMA", "RNN", "LSTM"]
 
+__operator_path__ = os.path.dirname(__file__)
+
 __short_description__ = """
 Forecasting operator, that leverages historical time series data to generate accurate
 forecasts for future trends. Use `ads opctl operator info forecast`
 to get more details about the forecasting operator.
-"""
-
-__description__ = """
-Forecasting operator, that leverages historical time series data to generate accurate
-forecasts for future trends. This operator aims to simplify and expedite the data science process by
-automating the selection of appropriate models and hyperparameters, as well as identifying relevant
-features for a given prediction task.
-
-The detained information, explaining how to deal with the forecasting operator will be placed here.
 """

--- a/ads/opctl/operator/lowcode/forecast/__main__.py
+++ b/ads/opctl/operator/lowcode/forecast/__main__.py
@@ -11,7 +11,6 @@ from typing import List
 
 import yaml
 
-from ads.common.auth import AuthContext
 from ads.opctl import logger
 from ads.opctl.operator.common.const import ENV_OPERATOR_ARGS
 from ads.opctl.operator.common.utils import _parse_input_args

--- a/ads/opctl/operator/runtime/const.py
+++ b/ads/opctl/operator/runtime/const.py
@@ -5,6 +5,9 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 
-from .runtime import ContainerRuntime
+from .runtime import ContainerRuntime, PythonRuntime
 
-RUNTIME_TYPE_MAP = {ContainerRuntime.type: ContainerRuntime}
+RUNTIME_TYPE_MAP = {
+    ContainerRuntime.type: ContainerRuntime,
+    PythonRuntime.type: PythonRuntime,
+}

--- a/ads/opctl/operator/runtime/container_runtime_schema.yaml
+++ b/ads/opctl/operator/runtime/container_runtime_schema.yaml
@@ -4,7 +4,7 @@ kind:
   required: true
   type: string
   meta:
-    description: "The operator local runtime. Kind should always be `local` when using an operator with local container runtime."
+    description: "The operator local runtime. Kind should always be `operator.local` when using an operator with local container runtime."
 version:
   allowed:
     - "v1"
@@ -41,10 +41,10 @@ spec:
             type: string
           value:
             type:
-            - number
-            - string
+              - number
+              - string
     volume:
       required: false
       type:
-      - string
-      - list
+        - string
+        - list

--- a/ads/opctl/operator/runtime/python_runtime_schema.yaml
+++ b/ads/opctl/operator/runtime/python_runtime_schema.yaml
@@ -1,0 +1,21 @@
+kind:
+  allowed:
+    - operator.local
+  required: true
+  type: string
+  meta:
+    description: "The operator local runtime. Kind should always be `operator.local` when using an operator with local python runtime."
+version:
+  allowed:
+    - "v1"
+  required: true
+  type: string
+  meta:
+    description: "Operator local runtime may change yaml file schemas from version to version, as well as implementation details. Double check the version to ensure compatibility."
+type:
+  allowed:
+    - python
+  required: true
+  type: string
+  meta:
+    description: "Type should always be `python` when using an operator with local python runtime."

--- a/ads/opctl/operator/runtime/runtime.py
+++ b/ads/opctl/operator/runtime/runtime.py
@@ -12,8 +12,17 @@ from typing import Any, ClassVar, Dict, List
 
 from cerberus import Validator
 
+from ads.common.extended_enum import ExtendedEnum
 from ads.common.serializer import DataClassSerializable
 from ads.opctl.operator.common.utils import _load_yaml_from_uri
+
+
+class OPERATOR_LOCAL_RUNTIME_TYPE(ExtendedEnum):
+    PYTHON = "python"
+    CONTAINER = "container"
+
+
+OPERATOR_LOCAL_RUNTIME_KIND = "operator.local"
 
 
 @dataclass(repr=True)
@@ -21,7 +30,7 @@ class Runtime(DataClassSerializable):
     """Base class for the operator's runtimes."""
 
     _schema: ClassVar[str] = None
-    kind: str = None
+    kind: str = OPERATOR_LOCAL_RUNTIME_KIND
     type: str = None
     version: str = None
     spec: Any = None
@@ -69,8 +78,7 @@ class ContainerRuntime(Runtime):
     """Represents a container operator runtime."""
 
     _schema: ClassVar[str] = "container_runtime_schema.yaml"
-    kind: str = "operator.local"
-    type: str = "container"
+    type: str = OPERATOR_LOCAL_RUNTIME_TYPE.CONTAINER.value
     version: str = "v1"
     spec: ContainerRuntimeSpec = field(default_factory=ContainerRuntimeSpec)
 
@@ -84,3 +92,23 @@ class ContainerRuntime(Runtime):
             The runtime instance.
         """
         return cls(spec=ContainerRuntimeSpec.from_dict(kwargs))
+
+
+@dataclass(repr=True)
+class PythonRuntime(Runtime):
+    """Represents a python operator runtime."""
+
+    _schema: ClassVar[str] = "python_runtime_schema.yaml"
+    type: str = OPERATOR_LOCAL_RUNTIME_TYPE.PYTHON.value
+    version: str = "v1"
+
+    @classmethod
+    def init(cls, **kwargs: Dict) -> "PythonRuntime":
+        """Initializes a starter specification for the runtime.
+
+        Returns
+        -------
+        PythonRuntime
+            The runtime instance.
+        """
+        return cls()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ opctl = [
   "nbconvert",
   "nbformat",
   "oci-cli",
+  "rich"
 ]
 optuna = [
   "optuna==2.9.0",


### PR DESCRIPTION
## Description
- Adds supporting of the Data Flow backend for the forecasting operator.
  https://jira.oci.oraclecorp.com/browse/ODSC-44202
- Improves the `ads opctl operator info -n forecast` command. The operator's `README.MD` will be used as a source of the information. The python `rich` module was utilized.
  https://jira.oci.oraclecorp.com/browse/ODSC-47051
- Adds supporting of a local backend for the operators. Now the operator can be run within a local environment: ```ads opctl apply -f forecast.yaml -b operator.local```. The local environment needs to be configured before running the operator locally.
https://jira.oci.oraclecorp.com/browse/ODSC-47048
https://jira.oci.oraclecorp.com/browse/ODSC-47047
- Adds supporting of short command to run the operators. Example: ```ads opctl apply -f forecasting.yaml -b job```. The backend config will be auto-generated based on the `.ini` config files and env variables.

## How To Test
- **Generating configs**
```ads opctl operator init -n forecast --overwrite --output ~/forecast/configs```
![image](https://github.com/oracle/accelerated-data-science/assets/5256765/a2c1294e-cde8-4ee5-a7be-d57bcbe284b8)


- **To get details about the particular operator**
```ads opctl operator info -n forecast```
![image](https://github.com/oracle/accelerated-data-science/assets/5256765/76c71ef7-9694-49bc-ab4b-6e592367411a)

- **To run operator in the local environment**
```ads opctl apply -f forecast.yaml -b operator.local```
![image](https://github.com/oracle/accelerated-data-science/assets/5256765/797fa2fb-540a-48a4-9d49-9599bf6a16b8)

- **To run operator within Data Flow backend**
```ads opctl apply -f ~/forecast/config/forecast_oci.yaml -b ~/forecast/config/backend_dataflow_dataflow_config.yaml --dry-run```
![image](https://github.com/oracle/accelerated-data-science/assets/5256765/c66f5003-7401-4ffd-bc75-fa8341b1410c)
![image](https://github.com/oracle/accelerated-data-science/assets/5256765/4a60fa92-1247-4b26-b18a-bd5903f458d5)
