### PR TITLE
ODSC-46458/add metrics.csv

### DIFF
--- a/ads/opctl/operator/lowcode/forecast/model/base_model.py
+++ b/ads/opctl/operator/lowcode/forecast/model/base_model.py
@@ -336,10 +336,10 @@ class ForecastOperatorBaseModel(ABC):
                 ) as f2:
                     f2.write(f1.read())
 
-        # results csv report
+        # forecast csv report
         utils._write_data(
             data=result_df,
-            filename=os.path.join(output_dir, self.spec.report_results_name),
+            filename=os.path.join(output_dir, self.spec.forecast_filename),
             format="csv",
             storage_options=default_signer(),
         )
@@ -347,7 +347,7 @@ class ForecastOperatorBaseModel(ABC):
         # metrics csv report
         utils._write_data(
             data=metrics_df,
-            filename=os.path.join(output_dir, self.spec.report_metrics_name),
+            filename=os.path.join(output_dir, self.spec.metrics_filename),
             format="csv",
             storage_options=default_signer(),
             index = True

--- a/ads/opctl/operator/lowcode/forecast/model/base_model.py
+++ b/ads/opctl/operator/lowcode/forecast/model/base_model.py
@@ -350,6 +350,7 @@ class ForecastOperatorBaseModel(ABC):
             filename=os.path.join(output_dir, self.spec.report_metrics_name),
             format="csv",
             storage_options=default_signer(),
+            index = True
         )
 
         logger.warn(

--- a/ads/opctl/operator/lowcode/forecast/model/base_model.py
+++ b/ads/opctl/operator/lowcode/forecast/model/base_model.py
@@ -225,7 +225,7 @@ class ForecastOperatorBaseModel(ABC):
         )
 
         # save the report and result CSV
-        self._save_report(report_sections=report_sections, result_df=result_df)
+        self._save_report(report_sections=report_sections, result_df=result_df, metrics_df=self.test_eval_metrics)
 
     def _load_data(self):
         """Loads forecasting input data."""
@@ -315,7 +315,7 @@ class ForecastOperatorBaseModel(ABC):
         )
         return total_metrics, summary_metrics, data
 
-    def _save_report(self, report_sections: Tuple, result_df: pd.DataFrame):
+    def _save_report(self, report_sections: Tuple, result_df: pd.DataFrame, metrics_df: pd.DataFrame):
         """Saves resulting reports to the given folder."""
         if self.spec.output_directory:
             output_dir = self.spec.output_directory.url
@@ -336,9 +336,17 @@ class ForecastOperatorBaseModel(ABC):
                 ) as f2:
                     f2.write(f1.read())
 
-        # metrics csv report
+        # results csv report
         utils._write_data(
             data=result_df,
+            filename=os.path.join(output_dir, self.spec.report_results_name),
+            format="csv",
+            storage_options=default_signer(),
+        )
+
+        # metrics csv report
+        utils._write_data(
+            data=metrics_df,
             filename=os.path.join(output_dir, self.spec.report_metrics_name),
             format="csv",
             storage_options=default_signer(),

--- a/ads/opctl/operator/lowcode/forecast/operator_config.py
+++ b/ads/opctl/operator/lowcode/forecast/operator_config.py
@@ -85,8 +85,8 @@ class ForecastOperatorSpec(DataClassSerializable):
     report_file_name: str = None
     report_title: str = None
     report_theme: str = None
-    report_metrics_name: str = None
-    report_results_name: str = None
+    metrics_filename: str = None
+    forecast_filename: str = None
     target_column: str = None
     datetime_column: DateTimeColumn = field(default_factory=DateTimeColumn)
     target_category_columns: List[str] = field(default_factory=list)
@@ -103,8 +103,8 @@ class ForecastOperatorSpec(DataClassSerializable):
         self.confidence_interval_width = self.confidence_interval_width or 0.80
         self.report_file_name = self.report_file_name or "report.html"
         self.report_theme = self.report_theme or "light"
-        self.report_metrics_name = self.report_metrics_name or "metrics.csv"
-        self.report_results_name = self.report_results_name or "forecast.csv"
+        self.metrics_filename = self.metrics_filename or "metrics.csv"
+        self.forecast_filename = self.forecast_filename or "forecast.csv"
         self.target_column = self.target_column or "Sales"
         self.model_kwargs = self.model_kwargs or dict()
 

--- a/ads/opctl/operator/lowcode/forecast/operator_config.py
+++ b/ads/opctl/operator/lowcode/forecast/operator_config.py
@@ -86,6 +86,7 @@ class ForecastOperatorSpec(DataClassSerializable):
     report_title: str = None
     report_theme: str = None
     report_metrics_name: str = None
+    report_results_name: str = None
     target_column: str = None
     datetime_column: DateTimeColumn = field(default_factory=DateTimeColumn)
     target_category_columns: List[str] = field(default_factory=list)
@@ -102,7 +103,8 @@ class ForecastOperatorSpec(DataClassSerializable):
         self.confidence_interval_width = self.confidence_interval_width or 0.80
         self.report_file_name = self.report_file_name or "report.html"
         self.report_theme = self.report_theme or "light"
-        self.report_metrics_name = self.report_metrics_name or "report.csv"
+        self.report_metrics_name = self.report_metrics_name or "metrics.csv"
+        self.report_results_name = self.report_results_name or "forecast.csv"
         self.target_column = self.target_column or "Sales"
         self.model_kwargs = self.model_kwargs or dict()
 

--- a/ads/opctl/operator/lowcode/forecast/utils.py
+++ b/ads/opctl/operator/lowcode/forecast/utils.py
@@ -65,14 +65,14 @@ def _load_data(filename, format, storage_options, columns, **kwargs):
     raise ValueError(f"Unrecognized format: {format}")
 
 
-def _write_data(data, filename, format, storage_options, **kwargs):
+def _write_data(data, filename, format, storage_options, index=False, **kwargs):
     if not format:
         _, format = os.path.splitext(filename)
         format = format[1:]
     if format in ["json", "clipboard", "excel", "csv", "feather", "hdf"]:
         write_fn = getattr(data, f"to_{format}")
         return _call_pandas_fsspec(
-            write_fn, filename, index=False, storage_options=storage_options
+            write_fn, filename, index=index, storage_options=storage_options
         )
     raise ValueError(f"Unrecognized format: {format}")
 


### PR DESCRIPTION
https://jira.oci.oraclecorp.com/browse/ODSC-46458
Added code to store Holdout Data Evaluation Metrics as metrics.csv.
Added optional parameter index in _write_data so that index can also be written if needed.
In operator_config, 
1. metrics_filename is the file name in which metrics should be stored. Set as metrics.csv by default.
2. forecast_filename is the file name in which forecasts should be stored. Set as forecast.csv by default.
<img width="1146" alt="image" src="https://github.com/oracle/accelerated-data-science/assets/138288858/24d5a755-42f7-4b0b-8268-b699f056a106">
