### PR TITLE
Updates environment.yaml for the forecast operator.

### DIFF
--- a/ads/opctl/operator/lowcode/forecast/environment.yaml
+++ b/ads/opctl/operator/lowcode/forecast/environment.yaml
@@ -14,6 +14,5 @@ dependencies:
       - json2table
       - sktime
       - optuna==2.9.0
-      # - https://objectstorage.us-ashburn-1.oraclecloud.com/p/YTUkGbX6_IJzGEh0uHfI-6LbiBqW-8OYgq44wJdRabF6B3vbHKJYpaU_rAdoPakH/n/ociodscdev/b/ads_preview_sdk/o/Forecasting/wheels/oracle_ads-2.8.8b0-py3-none-any.whl
-      - ./oracle_ads-2.8.7b0-py3-none-any.whl
-      - ./automlx-23.2.2-py38-none-any.whl
+      - oracle-automlx==23.2.3
+      - "--editable=git+https://github.com/oracle/accelerated-data-science.git@feature/forecasting#egg=oracle-ads"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,18 @@ viz = [
   "scipy>=1.5.4",
   "seaborn>=0.11.0",
 ]
+forecast = [
+  "oracle_ads[optuna]",
+  "prophet",
+  "neuralprophet",
+  "pmdarima",
+  "statsmodels",
+  "datapane",
+  "json2table",
+  "sktime",
+  "oracle-automlx==23.2.3",
+  "autots"
+]
 
 [project.urls]
 "Github" = "https://github.com/oracle/accelerated-data-science"


### PR DESCRIPTION
## Description
* Introduces a dedicated `forecast` optional dependency group in the project.toml file. This change aims to streamline the configuration of the local environment. You can install it using the following command: `pip3 install oracle-ads[forecast]`.
* Enhances the `environment.yaml` file for the forecasting operator with the following modifications:
  * Replaced the `oracle-automlx` dependency with a publicly available one.
  * Added the `oracle-ads` dependency from the GitHub repository. This serves as a temporary solution until the forecasting operator becomes publicly available. 
