### PR TITLE
Adds opctl environment validator decorator.

### DIFF
--- a/ads/opctl/decorator/common.py
+++ b/ads/opctl/decorator/common.py
@@ -4,22 +4,73 @@
 # Copyright (c) 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-from typing import Dict, Callable
 from functools import wraps
+from typing import Callable, Dict, List
+
+from ads.config import (
+    JOB_RUN_OCID,
+    NB_SESSION_OCID,
+    PIPELINE_RUN_OCID,
+    DATAFLOW_RUN_OCID,
+    MD_OCID,
+)
 
 RUN_ID_FIELD = "run_id"
 
-def print_watch_command(func: callable)->Callable:
+
+class OpctlEnvironmentError(Exception):
+    """The custom error to validate OPCTL environment."""
+
+    NOT_SUPPORTED_ENVIRONMENTS = (
+        "Notebook Sessions",
+        "Data Science Jobs",
+        "ML Pipelines",
+        "Data Flow Applications",
+    )
+
+    def __init__(self):
+        super().__init__(
+            "This operation cannot be executed in the current environment. "
+            f"It is not supported in: {', '.join(self.NOT_SUPPORTED_ENVIRONMENTS)}."
+        )
+
+
+def print_watch_command(func: callable) -> Callable:
     """The decorator to help build the `opctl watch` command."""
+
     @wraps(func)
-    def wrapper(*args, **kwargs)->Dict:
+    def wrapper(*args: List, **kwargs: Dict) -> Dict:
         result = func(*args, **kwargs)
         if result and isinstance(result, Dict) and RUN_ID_FIELD in result:
             msg_header = (
-                f"{'*' * 40} To monitor the progress of a task, execute the following command {'*' * 40}"
+                f"{'*' * 40} To monitor the progress of the task, "
+                "execute the following command {'*' * 40}"
             )
             print(msg_header)
             print(f"ads opctl watch {result[RUN_ID_FIELD]}")
             print("*" * len(msg_header))
         return result
+
+    return wrapper
+
+
+def validate_environment(func: callable) -> Callable:
+    """Validates whether an opctl command can be executed in the current environment."""
+
+    @wraps(func)
+    def wrapper(*args: List, **kwargs: Dict) -> Dict:
+        if any(
+            value
+            for value in (
+                JOB_RUN_OCID,
+                NB_SESSION_OCID,
+                PIPELINE_RUN_OCID,
+                DATAFLOW_RUN_OCID,
+                MD_OCID,
+            )
+        ):
+            raise OpctlEnvironmentError()
+
+        return func(*args, **kwargs)
+
     return wrapper

--- a/ads/opctl/operator/cmd.py
+++ b/ads/opctl/operator/cmd.py
@@ -36,6 +36,7 @@ from ads.opctl.constants import (
 )
 from ads.opctl.operator.common.const import PACK_TYPE
 from ads.opctl.operator.common.utils import OperatorInfo, _operator_info
+from ads.opctl.decorator.common import validate_environment
 from ads.opctl.utils import publish_image as publish_image_cmd
 
 from .__init__ import __operators__
@@ -46,7 +47,6 @@ from .common.errors import (
 )
 from .common.utils import (
     _build_image,
-    _load_yaml_from_uri,
     _operator_info_list,
 )
 
@@ -312,6 +312,7 @@ def init(
 
 
 @runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
+@validate_environment
 def build_image(
     name: str = None,
     source_folder: str = None,
@@ -442,6 +443,7 @@ def build_image(
 
 
 @runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
+@validate_environment
 def publish_image(
     name: str,
     registry: str = None,

--- a/tests/unitary/with_extras/opctl/test_opctl_decorators.py
+++ b/tests/unitary/with_extras/opctl/test_opctl_decorators.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+import pytest
+from ads.opctl.decorator import common
+from ads.opctl.decorator.common import validate_environment, OpctlEnvironmentError
+from unittest.mock import patch
+
+
+class TestOpctlDecorators:
+    """Tests the all OPCTL common decorators."""
+
+    @patch("ads.opctl.decorator.common.NB_SESSION_OCID", None)
+    @patch("ads.opctl.decorator.common.JOB_RUN_OCID", None)
+    @patch("ads.opctl.decorator.common.PIPELINE_RUN_OCID", None)
+    @patch("ads.opctl.decorator.common.DATAFLOW_RUN_OCID", None)
+    @patch("ads.opctl.decorator.common.MD_OCID", None)
+    def test_validate_environment_success(self):
+        """Tests validating environment decorator."""
+
+        @validate_environment
+        def mock_function():
+            return "SUCCESS"
+
+        assert mock_function() == "SUCCESS"
+
+    @patch("ads.opctl.decorator.common.NB_SESSION_OCID", "TEST")
+    def test_validate_environment_fail(self):
+        """Tests validating environment decorator fails."""
+
+        @validate_environment
+        def mock_function():
+            return "SUCCESS"
+
+        with pytest.raises(OpctlEnvironmentError):
+            assert mock_function()


### PR DESCRIPTION
## Description
https://jira.oci.oraclecorp.com/browse/ODSC-47201
Adds opctl environment validator decorator.

A Python decorator to validate whether a OPCTL CLI command can be executed in the current environment. This decorator will help ensure that CLI commands are only executed when the necessary conditions are met within the environment. For instance the operator's image cannot be created in the NB session or OCI Jobs.

## Pre-commit
![image](https://github.com/oracle/accelerated-data-science/assets/5256765/a4cd5684-d1c3-4610-a3b1-fe8506f31436)

## Tests
![image](https://github.com/oracle/accelerated-data-science/assets/5256765/18d13b07-1dfd-4acb-8eda-9b795a9fc1f3)
