### PR TITLE
Moved geopandas file load out of constructor

### DIFF
--- a/ads/dataset/sampled_dataset.py
+++ b/ads/dataset/sampled_dataset.py
@@ -47,13 +47,13 @@ from ads.common.decorator.runtime_dependency import (
     OptionalDependency,
 )
 
+NATURAL_EARTH_DATASET = "naturalearth_lowres"
 
 class PandasDataset(object):
     """
     This class provides APIs that can work on a sampled dataset.
     """
 
-    @runtime_dependency(module="geopandas", install_from=OptionalDependency.GEO)
     def __init__(
         self,
         sampled_df,
@@ -67,6 +67,7 @@ class PandasDataset(object):
         self.correlation = None
         self.feature_dist_html_dict = {}
         self.feature_types = metadata if metadata is not None else {}
+        self.world = None
 
         self.numeric_columns = self.sampled_df.select_dtypes(
             utils.numeric_pandas_dtypes()
@@ -559,7 +560,7 @@ class PandasDataset(object):
                 ),
             )
             world = geopandas.read_file(
-                geopandas.datasets.get_path("naturalearth_lowres")
+                geopandas.datasets.get_path(NATURAL_EARTH_DATASET)
             )
             ax1 = world.plot(ax=ax, color="lightgrey", linewidth=0.5, edgecolor="white")
             gdf.plot(ax=ax1, color="blue", markersize=10)
@@ -704,9 +705,9 @@ class PandasDataset(object):
                     df, geometry=geopandas.points_from_xy(df["lon"], df["lat"])
                 )
 
-                if not hasattr(self, "world"):
+                if not self.world:
                     self.world = geopandas.read_file(
-                        geopandas.datasets.get_path("naturalearth_lowres")
+                        geopandas.datasets.get_path(NATURAL_EARTH_DATASET)
                     )
 
                 self.world.plot(

--- a/ads/dataset/sampled_dataset.py
+++ b/ads/dataset/sampled_dataset.py
@@ -704,9 +704,10 @@ class PandasDataset(object):
                     df, geometry=geopandas.points_from_xy(df["lon"], df["lat"])
                 )
 
-                self.world = geopandas.read_file(
-                    geopandas.datasets.get_path("naturalearth_lowres")
-                )
+                if not hasattr(self, "world"):
+                    self.world = geopandas.read_file(
+                        geopandas.datasets.get_path("naturalearth_lowres")
+                    )
 
                 self.world.plot(
                     ax=ax, color="lightgrey", linewidth=0.5, edgecolor="white"

--- a/ads/dataset/sampled_dataset.py
+++ b/ads/dataset/sampled_dataset.py
@@ -67,9 +67,6 @@ class PandasDataset(object):
         self.correlation = None
         self.feature_dist_html_dict = {}
         self.feature_types = metadata if metadata is not None else {}
-        self.world = geopandas.read_file(
-            geopandas.datasets.get_path("naturalearth_lowres")
-        )
 
         self.numeric_columns = self.sampled_df.select_dtypes(
             utils.numeric_pandas_dtypes()
@@ -706,6 +703,11 @@ class PandasDataset(object):
                 gdf = geopandas.GeoDataFrame(
                     df, geometry=geopandas.points_from_xy(df["lon"], df["lat"])
                 )
+
+                self.world = geopandas.read_file(
+                    geopandas.datasets.get_path("naturalearth_lowres")
+                )
+
                 self.world.plot(
                     ax=ax, color="lightgrey", linewidth=0.5, edgecolor="white"
                 )


### PR DESCRIPTION
ADSDataset fails without geopandas installation because its parent class PandasDataset attempts to load a file using geopandas in the constructor. The file is only used in a plot method. This PR moves the geopandas load to the plot routine where it used and adds protection so that it will only be loaded once.

There are no functionality changes.

Jira: https://jira.oci.oraclecorp.com/browse/ODSC-47518