### PR TITLE
Added reference for nb_session to avoid unreferenced variable error

### DIFF
--- a/ads/model/deployment/model_deployment_infrastructure.py
+++ b/ads/model/deployment/model_deployment_infrastructure.py
@@ -221,6 +221,7 @@ class ModelDeploymentInfrastructure(Builder):
         defaults[self.CONST_BANDWIDTH_MBPS] = DEFAULT_BANDWIDTH_MBPS
         defaults[self.CONST_WEB_CONCURRENCY] = DEFAULT_WEB_CONCURRENCY
         defaults[self.CONST_REPLICA] = DEFAULT_REPLICA
+        nb_session = None
 
         if NB_SESSION_OCID:
             try:

--- a/ads/model/deployment/model_deployment_infrastructure.py
+++ b/ads/model/deployment/model_deployment_infrastructure.py
@@ -221,7 +221,6 @@ class ModelDeploymentInfrastructure(Builder):
         defaults[self.CONST_BANDWIDTH_MBPS] = DEFAULT_BANDWIDTH_MBPS
         defaults[self.CONST_WEB_CONCURRENCY] = DEFAULT_WEB_CONCURRENCY
         defaults[self.CONST_REPLICA] = DEFAULT_REPLICA
-        nb_session = None
 
         if NB_SESSION_OCID:
             try:
@@ -232,6 +231,7 @@ class ModelDeploymentInfrastructure(Builder):
                     f"session: {NB_SESSION_OCID}. {e}"
                 )
                 logger.debug(traceback.format_exc())
+                nb_session = None
 
             nb_config = (
                 getattr(nb_session, "notebook_session_config_details", None)


### PR DESCRIPTION
When DSCNotebookSession fails to return a notebook session object, the try/except block does not define nb_session. Subsequent reference to nb_session generates an UnboundedLocalError. Because this occurs in a function that just populates a default settings dictionary, nb_session should be None if DSCNotebookSession fails.

https://jira.oci.oraclecorp.com/browse/ODSC-47429