### PR TITLE
ODSC-46642/pass model by reference

### DIFF
--- a/ads/model/artifact_uploader.py
+++ b/ads/model/artifact_uploader.py
@@ -213,6 +213,7 @@ class LargeArtifactUploader(ArtifactUploader):
     def _upload(self):
         """Uploads model artifacts to the model catalog."""
         bucket_uri = self.bucket_uri
+        self.progress.update("Copying model artifact to the Object Storage bucket")
         if not bucket_uri == self.artifact_zip_path:
             bucket_uri_file_name = os.path.basename(bucket_uri)
 
@@ -230,9 +231,6 @@ class LargeArtifactUploader(ArtifactUploader):
                 )
 
             try:
-                self.progress.update(
-                    "Copying model artifact to the Object Storage bucket"
-                )
                 utils.upload_to_os(
                     src_uri=self.artifact_zip_path,
                     dst_uri=bucket_uri,

--- a/ads/model/artifact_uploader.py
+++ b/ads/model/artifact_uploader.py
@@ -194,7 +194,9 @@ class LargeArtifactUploader(ArtifactUploader):
         if ObjectStorageDetails.is_oci_path(artifact_path):
             if not artifact_path.endswith(".zip"):
                 raise ValueError(
-                    f"The `artifact_path={artifact_path}` is invalid. Please check APIs doc to see the possible values for it."
+                    f"The `artifact_path={artifact_path}` is invalid."
+                    "The remote path for model artifact should be a zip archive, "
+                    "e.g. `oci://<bucket_name>@<namespace>/prefix/mymodel.zip`."
                 )
             if not utils.is_path_exists(uri=artifact_path, auth=self.auth):
                 raise ValueError(f"The `{artifact_path}` does not exist.")

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -673,13 +673,11 @@ class DataScienceModel(Builder):
                 "timeout": timeout,
             }
 
-        if (
-            ObjectStorageDetails.is_oci_path(self.artifact)
-            and self.artifact != bucket_uri
-        ):
-            logger.warn(
-                "The `bucket_uri` will be ignored and the value of `self.artifact` will be used instead."
-            )
+        if ObjectStorageDetails.is_oci_path(self.artifact):
+            if bucket_uri and bucket_uri != self.artifac:
+                logger.warn(
+                    "The `bucket_uri` will be ignored and the value of `self.artifact` will be used instead."
+                )
             bucket_uri = self.artifact
 
         if bucket_uri or utils.folder_size(self.artifact) > _MAX_ARTIFACT_SIZE_IN_BYTES:

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -549,6 +549,8 @@ class DataScienceModel(Builder):
                 The OCI Object Storage URI where model artifacts will be copied to.
                 The `bucket_uri` is only necessary for uploading large artifacts which
                 size is greater than 2GB. Example: `oci://<bucket_name>@<namespace>/prefix/`.
+                .. versionadded:: 2.8.10
+                If `artifact` is provided as an object storage path to a zip archive, `bucket_uri` will be ignored.
             overwrite_existing_artifact: (bool, optional). Defaults to `True`.
                 Overwrite target bucket artifact if exists.
             remove_existing_artifact: (bool, optional). Defaults to `True`.
@@ -637,6 +639,8 @@ class DataScienceModel(Builder):
             The OCI Object Storage URI where model artifacts will be copied to.
             The `bucket_uri` is only necessary for uploading large artifacts which
             size is greater than 2GB. Example: `oci://<bucket_name>@<namespace>/prefix/`.
+            .. versionadded:: 2.8.10
+            If `artifact` is provided as an object storage path to a zip archive, `bucket_uri` will be ignored.
         auth: (Dict, optional). Defaults to `None`.
             The default authentication is set using `ads.set_auth` API.
             If you need to override the default, use the `ads.common.auth.api_keys` or
@@ -669,7 +673,13 @@ class DataScienceModel(Builder):
                 "timeout": timeout,
             }
 
-        if ObjectStorageDetails.is_oci_path(self.artifact):
+        if (
+            ObjectStorageDetails.is_oci_path(self.artifact)
+            and self.artifact != bucket_uri
+        ):
+            logger.warn(
+                "The `bucket_uri` will be ignored and the value of `self.artifact` will be used instead."
+            )
             bucket_uri = self.artifact
 
         if bucket_uri or utils.folder_size(self.artifact) > _MAX_ARTIFACT_SIZE_IN_BYTES:

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -11,6 +11,7 @@ from typing import Dict, List, Optional, Union
 
 import pandas
 from ads.common import utils
+from ads.common.object_storage_details import ObjectStorageDetails
 from ads.config import COMPARTMENT_OCID, PROJECT_OCID
 from ads.feature_engineering.schema import Schema
 from ads.jobs.builders.base import Builder
@@ -667,6 +668,9 @@ class DataScienceModel(Builder):
                 **(self.dsc_model.__class__.kwargs or {}),
                 "timeout": timeout,
             }
+
+        if ObjectStorageDetails.is_oci_path(self.artifact):
+            bucket_uri = self.artifact
 
         if bucket_uri or utils.folder_size(self.artifact) > _MAX_ARTIFACT_SIZE_IN_BYTES:
             if not bucket_uri:

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -674,7 +674,7 @@ class DataScienceModel(Builder):
             }
 
         if ObjectStorageDetails.is_oci_path(self.artifact):
-            if bucket_uri and bucket_uri != self.artifac:
+            if bucket_uri and bucket_uri != self.artifact:
                 logger.warn(
                     "The `bucket_uri` will be ignored and the value of `self.artifact` will be used instead."
                 )

--- a/tests/unitary/default_setup/model/test_artifact_uploader.py
+++ b/tests/unitary/default_setup/model/test_artifact_uploader.py
@@ -76,10 +76,7 @@ class TestArtifactUploader:
                 )
 
             invalid_artifact_path = "oci://my-bucket@my-tenancy/mymodel"
-            with pytest.raises(
-                ValueError,
-                match=f"The `artifact_path={invalid_artifact_path}` is invalid. Please check APIs doc to see the possible values for it.",
-            ):
+            with pytest.raises(ValueError):
                 lg_artifact_uploader = LargeArtifactUploader(
                     dsc_model=self.mock_dsc_model,
                     artifact_path=invalid_artifact_path,

--- a/tests/unitary/default_setup/model/test_artifact_uploader.py
+++ b/tests/unitary/default_setup/model/test_artifact_uploader.py
@@ -97,14 +97,14 @@ class TestArtifactUploader:
                 == DEFAULT_PARALLEL_PROCESS_COUNT
             )
 
-    def test_prepare_artiact_tmp_zip(self):
+    def test_prepare_artifact_tmp_zip(self):
         # Tests case when a folder provided as artifacts location
         with patch("ads.model.common.utils.zip_artifact") as mock_zip_artifact:
             mock_zip_artifact.return_value = "test_artifact.zip"
             artifact_uploader = SmallArtifactUploader(
                 dsc_model=self.mock_dsc_model, artifact_path=self.mock_artifact_path
             )
-            test_result = artifact_uploader._prepare_artiact_tmp_zip()
+            test_result = artifact_uploader._prepare_artifact_tmp_zip()
             assert test_result == "test_artifact.zip"
 
         # Tests case when a zip file provided as artifacts location
@@ -114,17 +114,17 @@ class TestArtifactUploader:
                     dsc_model=self.mock_dsc_model,
                     artifact_path=self.mock_artifact_path + ".zip",
                 )
-                test_result = artifact_uploader._prepare_artiact_tmp_zip()
+                test_result = artifact_uploader._prepare_artifact_tmp_zip()
                 assert test_result == self.mock_artifact_path + ".zip"
 
-    def test_remove_artiact_tmp_zip(self):
+    def test_remove_artifact_tmp_zip(self):
         artifact_uploader = SmallArtifactUploader(
             dsc_model=self.mock_dsc_model, artifact_path=self.mock_artifact_path
         )
         with patch("shutil.rmtree") as mock_rmtree:
             # Tests case when tmp artifact needs to be removed
             artifact_uploader.artifact_zip_path = "artifacts.zip"
-            artifact_uploader._remove_artiact_tmp_zip()
+            artifact_uploader._remove_artifact_tmp_zip()
             mock_rmtree.assert_called_with("artifacts.zip", ignore_errors=True)
 
         with patch("os.path.exists", return_value=True):
@@ -135,41 +135,44 @@ class TestArtifactUploader:
                 # Tests case when tmp artifact shouldn't be removed
                 artifact_uploader.artifact_zip_path = "artifacts.zip"
                 artifact_uploader.artifact_path = "artifacts.zip"
-                artifact_uploader._remove_artiact_tmp_zip()
+                artifact_uploader._remove_artifact_tmp_zip()
                 mock_rmtree.assert_not_called()
 
     @patch.object(SmallArtifactUploader, "_upload")
-    @patch.object(SmallArtifactUploader, "_prepare_artiact_tmp_zip")
-    @patch.object(SmallArtifactUploader, "_remove_artiact_tmp_zip")
+    @patch.object(SmallArtifactUploader, "_prepare_artifact_tmp_zip")
+    @patch.object(SmallArtifactUploader, "_remove_artifact_tmp_zip")
     def test_upload(
-        self, mock__remove_artiact_tmp_zip, mock__prepare_artiact_tmp_zip, mock__upload
+        self,
+        mock__remove_artifact_tmp_zip,
+        mock__prepare_artifact_tmp_zip,
+        mock__upload,
     ):
         artifact_uploader = SmallArtifactUploader(
             dsc_model=self.mock_dsc_model, artifact_path=self.mock_artifact_path
         )
         artifact_uploader.upload()
-        mock__remove_artiact_tmp_zip.assert_called()
-        mock__prepare_artiact_tmp_zip.assert_called()
+        mock__remove_artifact_tmp_zip.assert_called()
+        mock__prepare_artifact_tmp_zip.assert_called()
         mock__upload.assert_called()
 
     def test_upload_small_artifact(self):
         with open(self.mock_artifact_zip_path, "rb") as file_data:
             with patch.object(
                 SmallArtifactUploader,
-                "_prepare_artiact_tmp_zip",
+                "_prepare_artifact_tmp_zip",
                 return_value=self.mock_artifact_zip_path,
-            ) as mock_prepare_artiact_tmp_zip:
+            ) as mock_prepare_artifact_tmp_zip:
                 with patch.object(
-                    SmallArtifactUploader, "_remove_artiact_tmp_zip"
-                ) as mock_remove_artiact_tmp_zip:
+                    SmallArtifactUploader, "_remove_artifact_tmp_zip"
+                ) as mock_remove_artifact_tmp_zip:
                     artifact_uploader = SmallArtifactUploader(
                         dsc_model=self.mock_dsc_model,
                         artifact_path=self.mock_artifact_path,
                     )
                     artifact_uploader.artifact_zip_path = self.mock_artifact_zip_path
                     artifact_uploader.upload()
-                    mock_prepare_artiact_tmp_zip.assert_called()
-                    mock_remove_artiact_tmp_zip.assert_called()
+                    mock_prepare_artifact_tmp_zip.assert_called()
+                    mock_remove_artifact_tmp_zip.assert_called()
                     self.mock_dsc_model.create_model_artifact.assert_called()
 
     @patch("ads.common.utils.is_path_exists")


### PR DESCRIPTION
# Description
https://jira.oci.oraclecorp.com/browse/ODSC-46642
Improve the [LargeArtifactUploader](https://github.com/oracle/accelerated-data-science/blob/main/ads/model/artifact_uploader.py#L106) class to understand OCI paths to upload model artifacts to the model catalog by reference.

# Changed
* Case1: user want to copy the model artifact in [ARTIFACT_PATH](https://github.com/oracle/accelerated-data-science/blob/main/ads/model/datascience_model.py#L131) to [bucket_uri](https://github.com/oracle/accelerated-data-science/blob/main/ads/model/datascience_model.py#L547), and then upload to MC. (this is the current case we are supporting).
* Case 2: user wants to upload model artifacts in [bucket_uri](https://github.com/oracle/accelerated-data-science/blob/main/ads/model/datascience_model.py#L547) to MC. (this is the new case we want to support)

Allow the [ARTIFACT_PATH](https://github.com/oracle/accelerated-data-science/blob/main/ads/model/datascience_model.py#L131)  to be oci:// path, and only allow for model zip file. e.g: `oci://xxx@tenency/my_model.zip` . Then if user is targeting on case2,  user can pass `ARTIFACT_PATH="oci://xxx@tenency/my_model.zip"`, we can set [bucket_uri](https://github.com/oracle/accelerated-data-science/blob/main/ads/model/datascience_model.py#L547)  for them internally.

# User experience
* Uploading any size model (include the LLM models) already exists in Object Storage
```
import ads
from ads.model import DataScienceModel

ads.set_auth("resource_principal")

MODEL_DISPLAY_NAME = "my_large_model"
OCI_BUCKET = "oci://bucket@namespace/prefix/my_large_model.zip"

model = (DataScienceModel()
         .with_display_name(MODEL_DISPLAY_NAME)
         .with_artifact(OCI_BUCKET)
         .create()
        ) 
```

* Uploading the large models not exist in Object Storage, but in local
```
import ads
from ads.model import DataScienceModel

ads.set_auth("resource_principal")

MODEL_DISPLAY_NAME = "my_large_model"
ARTFICAT_FILE_NAME = "./my_large_model.zip"  
OCI_BUCKET = "oci://bucket@namespace/prefix/my_large_model.zip"

model = (DataScienceModel()
         .with_display_name(MODEL_DISPLAY_NAME)
         .with_artifact(ARTFICAT_FILE_NAME)
         .create(
            bucket_uri=OCI_BUCKET, # model artifact already in this path
            overwrite_existing_artifact=True, # Overwrite target bucket artifact if exists.
            remove_existing_artifact=True # Whether artifacts uploaded to the object storage bucket need to be removed or not.
         )
        ) 
```
* Uploading the small model in local
```
import ads
from ads.model import DataScienceModel

ads.set_auth("resource_principal")

MODEL_DISPLAY_NAME = "my_large_model"
ARTFICAT_FILE_NAME = "./my_large_model.zip"  

model = (DataScienceModel()
         .with_display_name(MODEL_DISPLAY_NAME)
         .with_artifact(ARTFICAT_FILE_NAME)
         .create( )
        ) 
```

# Test
* Unit test 
![Screenshot 2023-09-21 at 4 44 10 PM](https://github.com/oracle/accelerated-data-science/assets/49049296/c263a084-0691-4452-8209-3846ea26a741)

* Test create MC for the model in OS
![Screenshot 2023-09-21 at 5 48 29 PM](https://github.com/oracle/accelerated-data-science/assets/49049296/bdc43c81-aa3a-43d0-99d7-a4bd8f0d6d2b)

![Screenshot 2023-09-21 at 5 51 35 PM](https://github.com/oracle/accelerated-data-science/assets/49049296/f25db59e-bd4a-42ef-a6c7-4a9d50bfb864)