### PR TITLE
Added support to cancel all job runs

### DIFF
--- a/ads/jobs/builders/infrastructure/dsc_job.py
+++ b/ads/jobs/builders/infrastructure/dsc_job.py
@@ -725,9 +725,14 @@ class DataScienceJobRun(
 
         return self
 
-    def cancel(self) -> DataScienceJobRun:
+    def cancel(self, wait_for_completion: bool = True) -> DataScienceJobRun:
         """Cancels a job run
-        This method will wait for the job run to be canceled before returning.
+
+        Parameters
+        ----------
+        wait_for_completion: bool
+            Whether to wait for job run to be cancelled before proceeding.
+            Defaults to True.
 
         Returns
         -------
@@ -735,9 +740,13 @@ class DataScienceJobRun(
             The job run instance.
         """
         self.client.cancel_job_run(self.id)
-        while self.lifecycle_state != "CANCELED":
-            self.sync()
-            time.sleep(SLEEP_INTERVAL)
+        if wait_for_completion:
+            while (
+                self.lifecycle_state != 
+                oci.data_science.models.JobRun.LIFECYCLE_STATE_CANCELED
+            ):
+                self.sync()
+                time.sleep(SLEEP_INTERVAL)
         return self
 
     def __repr__(self) -> str:

--- a/ads/opctl/backend/ads_ml_job.py
+++ b/ads/opctl/backend/ads_ml_job.py
@@ -217,10 +217,22 @@ class MLJobBackend(Backend):
         """
         Cancel Job Run from OCID.
         """
-        run_id = self.config["execution"]["run_id"]
         with AuthContext(auth=self.auth_type, profile=self.profile):
-            DataScienceJobRun.from_ocid(run_id).cancel()
-            print(f"Job run {run_id} has been cancelled.")
+            wait_for_completion = self.config["execution"].get("wait_for_completion")
+            if self.config["execution"].get("id"):
+                id = self.config["execution"]["id"]
+                Job.from_datascience_job(id).cancel(
+                    wait_for_completion=wait_for_completion
+                )
+                if wait_for_completion:
+                    print(f"All job runs under {id} have been cancelled.")
+            elif self.config["execution"].get("run_id"):
+                run_id = self.config["execution"]["run_id"]
+                DataScienceJobRun.from_ocid(run_id).cancel(
+                    wait_for_completion=wait_for_completion
+                )
+                if wait_for_completion:
+                    print(f"Job run {run_id} has been cancelled.")
 
     def watch(self):
         """

--- a/ads/opctl/cmds.py
+++ b/ads/opctl/cmds.py
@@ -374,7 +374,7 @@ def delete(**kwargs) -> None:
     ):
         kwargs["id"] = kwargs.pop("ocid")
     else:
-        raise ValueError(f"{kwargs['ocid']} is valid or supported.")
+        raise ValueError(f"{kwargs['ocid']} is invalid or not supported.")
 
     p = ConfigProcessor().step(ConfigMerger, **kwargs)
     return _BackendFactory(p.config).backend.delete()
@@ -388,13 +388,24 @@ def cancel(**kwargs) -> None:
     ----------
     kwargs: dict
         keyword argument, stores command line args
+    
     Returns
     -------
     None
     """
-    kwargs["run_id"] = kwargs.pop("ocid")
-    if not kwargs.get("backend"):
-        kwargs["backend"] = _get_backend_from_run_id(kwargs["run_id"])
+    kwargs["backend"] = _get_backend_from_ocid(kwargs["ocid"])
+    if (
+        DataScienceResourceRun.JOB_RUN in kwargs["ocid"]
+        or DataScienceResourceRun.DATAFLOW_RUN in kwargs["ocid"]
+        or DataScienceResourceRun.PIPELINE_RUN in kwargs["ocid"]
+    ):
+        kwargs["run_id"] = kwargs.pop("ocid")
+    elif (
+        DataScienceResource.JOB in kwargs["ocid"]
+    ):
+        kwargs["id"] = kwargs.pop("ocid")
+    else:
+        raise ValueError(f"{kwargs['ocid']} is invalid or not supported.")
     p = ConfigProcessor().step(ConfigMerger, **kwargs)
     return _BackendFactory(p.config).backend.cancel()
 

--- a/tests/unitary/default_setup/jobs/test_jobs_base.py
+++ b/tests/unitary/default_setup/jobs/test_jobs_base.py
@@ -20,6 +20,7 @@ from ads.jobs import (
     ScriptRuntime,
     NotebookRuntime,
 )
+from ads.jobs.builders.infrastructure.dsc_job import DataScienceJobRun
 from ads.jobs.builders.infrastructure.dsc_job_runtime import (
     CondaRuntimeHandler,
     ScriptRuntimeHandler,
@@ -603,3 +604,25 @@ class TestRunInstance:
         test_run_instance = RunInstance()
         test_result = test_run_instance.run_details_link
         assert test_result == ""
+
+
+class DataScienceJobMethodTest(DataScienceJobPayloadTest):
+
+    @patch("ads.jobs.builders.infrastructure.dsc_job.DataScienceJobRun.cancel")
+    @patch("ads.jobs.ads_job.Job.run_list")
+    def test_job_cancel(self, mock_run_list, mock_cancel):
+        mock_run_list.return_value = [
+            DataScienceJobRun(
+                lifecycle_state="CANCELED"
+            )
+        ] * 3
+
+        job = (
+            Job(name="test")
+            .with_infrastructure(infrastructure.DataScienceJob())
+            .with_runtime(ScriptRuntime().with_script(self.SCRIPT_URI))
+        )
+
+        job.cancel()
+        mock_run_list.assert_called()
+        mock_cancel.assert_called_with(wait_for_completion=False)

--- a/tests/unitary/with_extras/opctl/test_opctl_cmds.py
+++ b/tests/unitary/with_extras/opctl/test_opctl_cmds.py
@@ -181,8 +181,9 @@ key_file = ~/.oci/oci_api_key.pem
         monkeypatch.delenv("NB_SESSION_OCID", raising=False)
         cancel(ocid="...datasciencejobrun...")
         job_cancel_func.assert_called()
-        with pytest.raises(ValueError):
-            cancel(ocid="....datasciencejob....")
+
+        cancel(ocid="....datasciencejob....")
+        job_cancel_func.assert_called()
 
         cancel(ocid="...datasciencepipelinerun...")
         pipeline_cancel_func.assert_called()


### PR DESCRIPTION
### Added support to cancel all job runs

- Now user can cancel all job runs by calling `Job().cancel()` and `ads opctl cancel <job_ocid>`