### PR TITLE
Added support for customizing path for job mount file system

### DIFF
--- a/ads/common/dsc_file_system.py
+++ b/ads/common/dsc_file_system.py
@@ -204,10 +204,14 @@ class OCIFileStorage(DSCFileSystem):
             raise ValueError(
                 "Missing parameter `destination_directory_name` from service. Check service log to see the error."
             )
+        
+        dest = dsc_model.destination_directory_name
+        if dsc_model.destination_path:
+            dest = f"{dsc_model.destination_path.rstrip('/')}/{dsc_model.destination_directory_name}"
 
         return {
             "src" : f"{dsc_model.mount_target_id}:{dsc_model.export_id}",
-            "dest" : f"{(dsc_model.destination_path or '').rstrip('/')}/{dsc_model.destination_directory_name}"
+            "dest" : dest
         }
 
 @dataclass
@@ -249,9 +253,13 @@ class OCIObjectStorage(DSCFileSystem):
                 "Missing parameter `destination_directory_name` from service. Check service log to see the error."
             )
 
+        dest = dsc_model.destination_directory_name
+        if dsc_model.destination_path:
+            dest = f"{dsc_model.destination_path.rstrip('/')}/{dsc_model.destination_directory_name}"
+
         return {
             "src" : f"oci://{dsc_model.bucket}@{dsc_model.namespace}/{dsc_model.prefix or ''}",
-            "dest" : f"{(dsc_model.destination_path or '').rstrip('/')}/{dsc_model.destination_directory_name}"
+            "dest" : dest
         }
 
 

--- a/ads/common/dsc_file_system.py
+++ b/ads/common/dsc_file_system.py
@@ -68,7 +68,7 @@ class DSCFileSystem:
             A tuple of destination path and destination directory name.
         """
         return (
-            os.path.dirname(dest.rstrip("/")),
+            os.path.dirname(dest.rstrip("/")) or None, # when destination path is omitted, oci api requires it to be None
             os.path.basename(dest.rstrip("/"))
         )
 

--- a/ads/jobs/builders/infrastructure/dsc_job.py
+++ b/ads/jobs/builders/infrastructure/dsc_job.py
@@ -1482,7 +1482,7 @@ class DataScienceJob(Infrastructure):
 
         if self.storage_mount:
             if not hasattr(
-                oci.data_science.models, "JobStorageMountConfigurationDetails"
+                oci.data_science.models, "StorageMountConfigurationDetails"
             ):
                 raise EnvironmentError(
                     "Storage mount hasn't been supported in the current OCI SDK installed."

--- a/tests/unitary/default_setup/jobs/test_jobs_mount_file_system.py
+++ b/tests/unitary/default_setup/jobs/test_jobs_mount_file_system.py
@@ -392,7 +392,6 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
             "namespace" : "Missing parameter `namespace` from service. Check service log to see the error.",
             "bucket" : "Missing parameter `bucket` from service. Check service log to see the error.",
             "destination_directory_name" : "Missing parameter `destination_directory_name` from service. Check service log to see the error.",
-            "destination_path" : "Missing parameter `destination_path` from service. Check service log to see the error."
         }
 
         dsc_model_dict = {
@@ -509,7 +508,6 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
             "mount_target_id" : "Missing parameter `mount_target_id` from service. Check service log to see the error.",
             "export_id" : "Missing parameter `export_id` from service. Check service log to see the error.",
             "destination_directory_name" : "Missing parameter `destination_directory_name` from service. Check service log to see the error.",
-            "destination_path" : "Missing parameter `destination_path` from service. Check service log to see the error."
         }
 
         dsc_model_dict = {
@@ -530,3 +528,24 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
                 OCIFileStorage.update_from_dsc_model(
                     FileStorageMountConfigurationDetails(**dsc_model_copy)
                 )
+
+    def test_get_destination_path_and_name(self):
+        path, directory = OCIFileStorage.get_destination_path_and_name("abc")
+
+        assert path == ""
+        assert directory == "abc"
+
+        path, directory = OCIFileStorage.get_destination_path_and_name("/abc")
+
+        assert path == "/"
+        assert directory == "abc"
+
+        path, directory = OCIFileStorage.get_destination_path_and_name("/abc/def")
+
+        assert path == "/abc"
+        assert directory == "def"
+
+        path, directory = OCIFileStorage.get_destination_path_and_name("/abc/def/ghi")
+
+        assert path == "/abc/def"
+        assert directory == "ghi"

--- a/tests/unitary/default_setup/jobs/test_jobs_mount_file_system.py
+++ b/tests/unitary/default_setup/jobs/test_jobs_mount_file_system.py
@@ -532,7 +532,7 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
     def test_get_destination_path_and_name(self):
         path, directory = OCIFileStorage.get_destination_path_and_name("abc")
 
-        assert path == ""
+        assert path == None
         assert directory == "abc"
 
         path, directory = OCIFileStorage.get_destination_path_and_name("/abc")

--- a/tests/unitary/default_setup/jobs/test_jobs_mount_file_system.py
+++ b/tests/unitary/default_setup/jobs/test_jobs_mount_file_system.py
@@ -15,7 +15,6 @@ from ads.jobs.builders.infrastructure import DataScienceJob
 from ads.jobs.builders.runtimes.python_runtime import PythonRuntime
 
 try:
-    from oci.data_science.models import JobStorageMountConfigurationDetails
     from oci.data_science.models import FileStorageMountConfigurationDetails
     from oci.data_science.models import ObjectStorageMountConfigurationDetails
 except (ImportError, AttributeError) as e:
@@ -50,6 +49,7 @@ dsc_job_payload = oci.data_science.models.Job(
         FileStorageMountConfigurationDetails(
             **{
                 "destination_directory_name": "test_destination_directory_name_from_dsc",
+                "destination_path": "/test_destination_path",
                 "export_id": "export_id_from_dsc",
                 "mount_target_id": "mount_target_id_from_dsc",
                 "storage_type": "FILE_STORAGE",
@@ -58,6 +58,7 @@ dsc_job_payload = oci.data_science.models.Job(
         FileStorageMountConfigurationDetails(
             **{
                 "destination_directory_name": "test_destination_directory_name_from_dsc",
+                "destination_path": "/test_destination_path",
                 "export_id": "export_id_from_dsc",
                 "mount_target_id": "mount_target_id_from_dsc",
                 "storage_type": "FILE_STORAGE",
@@ -80,15 +81,15 @@ job = (
         .with_storage_mount(
             {
                 "src" : "1.1.1.1:test_export_path_one",
-                "dest" : "test_mount_one",
+                "dest" : "/test_path_one/test_mount_one",
             },
             {
                 "src" : "2.2.2.2:test_export_path_two",
-                "dest" : "test_mount_two",
+                "dest" : "/test_path_two/test_mount_two",
             }, 
             {
                 "src" : "oci://bucket_name@namespace/synthetic/",
-                "dest" : "test_mount_three",
+                "dest" : "/test_path_three/test_mount_three",
             } 
         )
     )
@@ -114,11 +115,11 @@ spec:
       shapeName: VM.Standard.E3.Flex
       storageMount:
       - src: 1.1.1.1:test_export_path_one
-        dest: test_mount_one
+        dest: /test_path_one/test_mount_one
       - src: 2.2.2.2:test_export_path_two
-        dest: test_mount_two
+        dest: /test_path_two/test_mount_two
       - src: oci://bucket_name@namespace/synthetic/
-        dest: test_mount_three
+        dest: /test_path_three/test_mount_three
       subnetId: ocid1.subnet.oc1.iad.xxxx
     type: dataScienceJob
   name: My Job
@@ -142,17 +143,17 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
         dsc_file_storage_one = job.infrastructure.storage_mount[0]
         assert isinstance(dsc_file_storage_one, dict)
         assert dsc_file_storage_one["src"] == "1.1.1.1:test_export_path_one"
-        assert dsc_file_storage_one["dest"] == "test_mount_one"
+        assert dsc_file_storage_one["dest"] == "/test_path_one/test_mount_one"
 
         dsc_file_storage_two = job.infrastructure.storage_mount[1]
         assert isinstance(dsc_file_storage_two, dict)
         assert dsc_file_storage_two["src"] == "2.2.2.2:test_export_path_two"
-        assert dsc_file_storage_two["dest"] == "test_mount_two"
+        assert dsc_file_storage_two["dest"] == "/test_path_two/test_mount_two"
 
         dsc_object_storage = job.infrastructure.storage_mount[2]
         assert isinstance(dsc_object_storage, dict)
         assert dsc_object_storage["src"] == "oci://bucket_name@namespace/synthetic/"
-        assert dsc_object_storage["dest"] == "test_mount_three"
+        assert dsc_object_storage["dest"] == "/test_path_three/test_mount_three"
 
     def test_data_science_job_from_yaml(self):
         job_from_yaml = Job.from_yaml(job_yaml_string)
@@ -161,17 +162,17 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
         dsc_file_storage_one = job_from_yaml.infrastructure.storage_mount[0]
         assert isinstance(dsc_file_storage_one, dict)
         assert dsc_file_storage_one["src"] == "1.1.1.1:test_export_path_one"
-        assert dsc_file_storage_one["dest"] == "test_mount_one"
+        assert dsc_file_storage_one["dest"] == "/test_path_one/test_mount_one"
 
         dsc_file_storage_two = job.infrastructure.storage_mount[1]
         assert isinstance(dsc_file_storage_two, dict)
         assert dsc_file_storage_two["src"] == "2.2.2.2:test_export_path_two"
-        assert dsc_file_storage_two["dest"] == "test_mount_two"
+        assert dsc_file_storage_two["dest"] == "/test_path_two/test_mount_two"
 
         dsc_object_storage = job.infrastructure.storage_mount[2]
         assert isinstance(dsc_object_storage, dict)
         assert dsc_object_storage["src"] == "oci://bucket_name@namespace/synthetic/"
-        assert dsc_object_storage["dest"] == "test_mount_three"
+        assert dsc_object_storage["dest"] == "/test_path_three/test_mount_three"
 
     def test_data_science_job_to_dict(self):
         assert job.to_dict() == {
@@ -201,15 +202,15 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
                         "storageMount": [
                             {
                                 "src" : "1.1.1.1:test_export_path_one",
-                                "dest" : "test_mount_one",
+                                "dest" : "/test_path_one/test_mount_one",
                             },
                             {
                                 "src" : "2.2.2.2:test_export_path_two",
-                                "dest" : "test_mount_two",
+                                "dest" : "/test_path_two/test_mount_two",
                             },
                             {
                                 "src" : "oci://bucket_name@namespace/synthetic/",
-                                "dest" : "test_mount_three",
+                                "dest" : "/test_path_three/test_mount_three",
                             } 
                         ],
                     },
@@ -260,11 +261,11 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
         assert isinstance(infrastructure.storage_mount[1], dict)
         assert infrastructure.storage_mount[0] == {
             "src" : "mount_target_id_from_dsc:export_id_from_dsc",
-            "dest" : "test_destination_directory_name_from_dsc"
+            "dest" : "/test_destination_path/test_destination_directory_name_from_dsc"
         }
         assert infrastructure.storage_mount[1] == {
             "src" : "mount_target_id_from_dsc:export_id_from_dsc",
-            "dest" : "test_destination_directory_name_from_dsc"
+            "dest" : "/test_destination_path/test_destination_directory_name_from_dsc"
         }
 
     @patch.object(OCIFileStorage, "update_to_dsc_model")
@@ -276,6 +277,7 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
 
         mock_update_to_dsc_model.return_value = {
             "destinationDirectoryName": "test_destination_directory_name_from_dsc",
+            "destination_path": "/test_destination_path",
             "exportId": "test_export_id_one",
             "mountTargetId": "test_mount_target_id_one",
             "storageType": "FILE_STORAGE",
@@ -293,6 +295,7 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
             0
         ] == {
             "destinationDirectoryName": "test_destination_directory_name_from_dsc",
+            "destination_path": "/test_destination_path",
             "exportId": "test_export_id_one",
             "mountTargetId": "test_mount_target_id_one",
             "storageType": "FILE_STORAGE",
@@ -358,7 +361,7 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
     def test_dsc_object_storage(self):
         object_storage = OCIObjectStorage(
             src="oci://bucket@namespace/prefix",
-            dest="test_dest",
+            dest="/test_path/test_dest",
         )
 
         result = object_storage.update_to_dsc_model()
@@ -367,10 +370,12 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
         assert result["prefix"] == "prefix"
         assert result["storageType"] == "OBJECT_STORAGE"
         assert result["destinationDirectoryName"] == "test_dest"
+        assert result["destinationPath"] == "/test_path"
 
         dsc_model = ObjectStorageMountConfigurationDetails(
             **{
                 "destination_directory_name": "test_destination_directory_name_from_dsc",
+                "destination_path": "/test_destination_path",
                 "storage_type": "OBJECT_STORAGE",
                 "bucket": "bucket",
                 "namespace": "namespace",
@@ -380,17 +385,19 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
         
         result = OCIObjectStorage.update_from_dsc_model(dsc_model)
         assert result["src"] == "oci://bucket@namespace/prefix"
-        assert result["dest"] == "test_destination_directory_name_from_dsc"
+        assert result["dest"] == "/test_destination_path/test_destination_directory_name_from_dsc"
 
     def test_dsc_object_storage_error(self):
         error_messages = {
             "namespace" : "Missing parameter `namespace` from service. Check service log to see the error.",
             "bucket" : "Missing parameter `bucket` from service. Check service log to see the error.",
-            "destination_directory_name" : "Missing parameter `destination_directory_name` from service. Check service log to see the error."
+            "destination_directory_name" : "Missing parameter `destination_directory_name` from service. Check service log to see the error.",
+            "destination_path" : "Missing parameter `destination_path` from service. Check service log to see the error."
         }
 
         dsc_model_dict = {
             "destination_directory_name": "test_destination_directory_name_from_dsc",
+            "destination_path": "/test_path",
             "storage_type": "OBJECT_STORAGE",
             "bucket": "bucket",
             "namespace": "namespace",
@@ -412,11 +419,12 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
     def test_dsc_file_storage(self, mock_search_resources):
         file_storage = OCIFileStorage(
             src="ocid1.mounttarget.oc1.iad.xxxx:ocid1.export.oc1.iad.xxxx",
-            dest="test_dest",
+            dest="/test_path/test_dest",
         )
         file_storage = file_storage.update_to_dsc_model()
         assert file_storage == {
             "destinationDirectoryName" : "test_dest",
+            "destinationPath" : "/test_path",
             "exportId" : "ocid1.export.oc1.iad.xxxx",
             "mountTargetId" : "ocid1.mounttarget.oc1.iad.xxxx",
             "storageType" : "FILE_STORAGE"
@@ -424,7 +432,7 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
 
         file_storage = OCIFileStorage(
             src="1.1.1.1:/test_export",
-            dest="test_dest",
+            dest="/test_path/test_dest",
         )
 
         items = [
@@ -477,6 +485,7 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
         file_storage = file_storage.update_to_dsc_model()
         assert file_storage == {
             "destinationDirectoryName" : "test_dest",
+            "destinationPath" : "/test_path",
             "exportId" : "ocid1.export.oc1.iad.xxxx",
             "mountTargetId" : "ocid1.mounttarget.oc1.iad.xxxx",
             "storageType" : "FILE_STORAGE"
@@ -485,6 +494,7 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
         dsc_model = FileStorageMountConfigurationDetails(
             **{
                 "destination_directory_name": "test_dest",
+                "destination_path" : "/test_path",
                 "storage_type": "FILE_STORAGE",
                 "export_id": "ocid1.export.oc1.iad.xxxx",
                 "mount_target_id": "ocid1.mounttarget.oc1.iad.xxxx"
@@ -492,17 +502,19 @@ class TestDataScienceJobMountFileSystem(unittest.TestCase):
         )
         result = OCIFileStorage.update_from_dsc_model(dsc_model)
         assert result["src"] == "ocid1.mounttarget.oc1.iad.xxxx:ocid1.export.oc1.iad.xxxx"
-        assert result["dest"] == "test_dest"
+        assert result["dest"] == "/test_path/test_dest"
 
     def test_dsc_file_storage_error(self):
         error_messages = {
             "mount_target_id" : "Missing parameter `mount_target_id` from service. Check service log to see the error.",
             "export_id" : "Missing parameter `export_id` from service. Check service log to see the error.",
-            "destination_directory_name" : "Missing parameter `destination_directory_name` from service. Check service log to see the error."
+            "destination_directory_name" : "Missing parameter `destination_directory_name` from service. Check service log to see the error.",
+            "destination_path" : "Missing parameter `destination_path` from service. Check service log to see the error."
         }
 
         dsc_model_dict = {
             "destination_directory_name": "test_destination_directory_name_from_dsc",
+            "destination_path": "/test_path",
             "storage_type": "FILE_STORAGE",
             "mount_target_id": "ocid1.mounttarget.oc1.iad.xxxx",
             "export_id": "ocid1.export.oc1.iad.xxxx",


### PR DESCRIPTION
### Added support for customizing path for job mount file system

- Previously all file systems will be mounted under `/mnt` and now we added support for customizing the destination path in the format: `"dest" : "<destination_path>/<destination_directory_name>"`
** dir - "fss" & path - "/opc" : mount happens under "/opc/fss"
**  dir - "fss" & path - "/" : mount happens under "/fss"
** dir - "fss" & path - omitted : mount happens under "/mnt/fss" (for backward compatibility of current users)

### User experience

```
infrastructure = (
    DataScienceJob()
    .with_log_group_id("<log_group_ocid>")
    .with_log_id("<log_ocid>")
    .with_storage_mount(
      {
        "src" : "<mount_target_ip_address>@<export_path>",
        "dest" : "/test_path/test_directory_name"
      }
    )
)
```
The file system will be mounted to the `test_directory_name` folder under `/test_path`.

```
infrastructure = (
    DataScienceJob()
    .with_log_group_id("<log_group_ocid>")
    .with_log_id("<log_ocid>")
    .with_storage_mount(
      {
        "src" : "<mount_target_ip_address>@<export_path>",
        "dest" : "/test_directory_name"
      }
    )
)
```
The file system will be mounted to the `test_directory_name` folder under `/`.

```
infrastructure = (
    DataScienceJob()
    .with_log_group_id("<log_group_ocid>")
    .with_log_id("<log_ocid>")
    .with_storage_mount(
      {
        "src" : "<mount_target_ip_address>@<export_path>",
        "dest" : "test_directory_name"
      }
    )
)
```
The file system will be mounted to the `test_directory_name` folder under `/mnt`.