### PR TITLE
Update `ads.set_auth()` to use both customized config and signer

### DIFF
--- a/ads/common/auth.py
+++ b/ads/common/auth.py
@@ -416,7 +416,7 @@ def create_signer(
     >>> auth = ads.auth.create_signer(auth_type="security_token", config=config) # security token authentication created based on provided config
     """
     if signer or signer_callable:
-        configuration = ads.telemetry.update_oci_client_config()
+        configuration = ads.telemetry.update_oci_client_config(config)
         if signer_callable:
             signer = signer_callable(**signer_kwargs)
         signer_dict = {
@@ -479,7 +479,7 @@ def default_signer(client_kwargs: Optional[Dict] = None) -> Dict:
     """
     auth_state = AuthState()
     if auth_state.oci_signer or auth_state.oci_signer_callable:
-        configuration = ads.telemetry.update_oci_client_config()
+        configuration = ads.telemetry.update_oci_client_config(auth_state.oci_config)
         signer = auth_state.oci_signer
         if auth_state.oci_signer_callable:
             signer_kwargs = auth_state.oci_signer_kwargs or {}


### PR DESCRIPTION
When users passed in both `config` and `signer` in `ads.set_auth()`, the `config` is ignored and only the `signer` is used at the moment. For the use case similar to session token signer, information from the `config` is also needed.

This PR updates the behavior to use both `config` and `signer` if they are both passed into `ads.set_auth()`.