### PR TITLE
Update distributed training CLI to add "ray" framework.

### DIFF
--- a/ads/opctl/distributed/cli.py
+++ b/ads/opctl/distributed/cli.py
@@ -30,7 +30,14 @@ def commands():
     "-f",
     help="Distributed training framework type",
     type=click.Choice(
-        ["dask", "horovod-tensorflow", "horovod-pytorch", "pytorch", "tensorflow"]
+        [
+            "dask",
+            "horovod-tensorflow",
+            "horovod-pytorch",
+            "pytorch",
+            "tensorflow",
+            "ray",
+        ]
     ),
     default=None,
     required=True,


### PR DESCRIPTION
The support for Ray has been added to ADS distributed training. 
https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/distributed_training/ray.md

We need to update `ads opctl distributed-training` CLI to take "ray" as a valid framework.

With this PR, users can run the following command to download the artifacts:
```
ads opctl distributed-training init --framework ray
```
```
Downloading from https://raw.githubusercontent.com/oracle-samples/oci-data-science-ai-samples/master/distributed_training/artifacts/ray_v1.tar.gz to .tmp_ray_v1.tar.gz
x ray/
x ray/v1/
x ray/v1/Dockerfile
x ray/v1/README.md
x ray/v1/__init__.py
x ray/v1/cleanup.py
x ray/v1/cleanup.sh
x ray/v1/environment.yaml
x ray/v1/ray_cluster.py
x ray/v1/run.py
x ray/v1/run.sh
x ray/v1/start-head.sh
x ray/v1/start-worker.sh
Check oci_dist_training_artifacts/ray/v1/README.md for build instructions
```