### PR TITLE
ODSC-47259 Local Explainer Class : Feature/forecast explain

### DIFF
--- a/ads/opctl/operator/lowcode/forecast/model/automlx.py
+++ b/ads/opctl/operator/lowcode/forecast/model/automlx.py
@@ -322,17 +322,13 @@ class AutoMLXOperatorModel(ForecastOperatorBaseModel):
 
             self.local_explainer(kernel_explnr)
 
-    def local_explainer(self, kernel_explainer) -> pd.DataFrame:
+    def local_explainer(self, kernel_explainer) -> None:
         """
         Generate local explanations using a kernel explainer.
 
         Parameters
         ----------
             kernel_explainer: The kernel explainer object to use for generating explanations.
-
-        Returns
-        -------
-            A pandas DataFrame containing the local explanation values.
         """
         # Get the data for the series ID and select the relevant columns
         data = self.full_data_dict.get(self.series_id).set_index(


### PR DESCRIPTION
Adds support for local explanation of the forecast horizon

Local explanations for a sample dataset:
![image](https://github.com/oracle/accelerated-data-science/assets/17523722/e9a6ff92-9d84-4372-92aa-26d8be38bef5)
- All the values are the same as the additional features have the same value in the forecast horizon, also the positive & negative values in the feature attribution represent the movement of the forecast value up/down from the mean forecast values.