### PR TITLE
ODSC-48247/Update Doc On ModelDeployment Default Shape Name Selection

### DIFF
--- a/ads/model/artifact_uploader.py
+++ b/ads/model/artifact_uploader.py
@@ -128,8 +128,11 @@ class LargeArtifactUploader(ArtifactUploader):
         The OCI Object Storage URI where model artifacts will be copied to.
         The `bucket_uri` is only necessary for uploading large artifacts which
         size is greater than 2GB. Example: `oci://<bucket_name>@<namespace>/prefix/`.
+
         .. versionadded:: 2.8.10
-        If artifact_path is object storage path to a zip archive, bucket_uri will be ignored.
+
+            If artifact_path is object storage path to a zip archive, bucket_uri will be ignored.
+
     dsc_model: OCIDataScienceModel
         The data scince model instance.
     overwrite_existing_artifact: bool
@@ -173,8 +176,11 @@ class LargeArtifactUploader(ArtifactUploader):
             The OCI Object Storage URI where model artifacts will be copied to.
             The `bucket_uri` is only necessary for uploading large artifacts from local which
             size is greater than 2GB. Example: `oci://<bucket_name>@<namespace>/prefix/`.
+
             .. versionadded:: 2.8.10
-            If `artifact_path` is object storage path to a zip archive, `bucket_uri` will be ignored.
+
+                If `artifact_path` is object storage path to a zip archive, `bucket_uri` will be ignored.
+
         auth: (Dict, optional). Defaults to `None`.
             The default authetication is set using `ads.set_auth` API.
             If you need to override the default, use the `ads.common.auth.api_keys` or

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -549,8 +549,11 @@ class DataScienceModel(Builder):
                 The OCI Object Storage URI where model artifacts will be copied to.
                 The `bucket_uri` is only necessary for uploading large artifacts which
                 size is greater than 2GB. Example: `oci://<bucket_name>@<namespace>/prefix/`.
+
                 .. versionadded:: 2.8.10
-                If `artifact` is provided as an object storage path to a zip archive, `bucket_uri` will be ignored.
+
+                    If `artifact` is provided as an object storage path to a zip archive, `bucket_uri` will be ignored.
+
             overwrite_existing_artifact: (bool, optional). Defaults to `True`.
                 Overwrite target bucket artifact if exists.
             remove_existing_artifact: (bool, optional). Defaults to `True`.
@@ -639,8 +642,11 @@ class DataScienceModel(Builder):
             The OCI Object Storage URI where model artifacts will be copied to.
             The `bucket_uri` is only necessary for uploading large artifacts which
             size is greater than 2GB. Example: `oci://<bucket_name>@<namespace>/prefix/`.
+
             .. versionadded:: 2.8.10
-            If `artifact` is provided as an object storage path to a zip archive, `bucket_uri` will be ignored.
+
+                If `artifact` is provided as an object storage path to a zip archive, `bucket_uri` will be ignored.
+
         auth: (Dict, optional). Defaults to `None`.
             The default authentication is set using `ads.set_auth` API.
             If you need to override the default, use the `ads.common.auth.api_keys` or

--- a/docs/source/user_guide/model_registration/_template/deploy.rst
+++ b/docs/source/user_guide/model_registration/_template/deploy.rst
@@ -7,12 +7,11 @@ You can use the ``.deploy()`` method to deploy a model. You must first save the 
 
 The ``.deploy()`` method returns a ``ModelDeployment`` object.  Specify deployment attributes such as display name, instance type, number of instances,  maximum router bandwidth, and logging groups.  The API takes the following parameters:
 
-See `API documentation <../../ads.model.html#id1>`__ for more details about the parameters.
-
+See :py:meth:`~ads.model.GenericModel.deploy`  for more details about the parameters.
 
 .. admonition:: Tips
    :class: note
 
    * Providing ``deployment_access_log_id`` and ``deployment_predict_log_id`` helps in debugging your model inference setup.
-   * Default Load Balancer configuration has bandwidth of 10 Mbps. `Refer service document to help you choose the right setup. <https://docs.oracle.com/en-us/iaas/data-science/using/model_dep_create.htm>`_ 
-   * Check for supported instance shapes `here <https://docs.oracle.com/en-us/iaas/data-science/using/overview.htm#supported-shapes>`_ .
+   * Default Load Balancer configuration has bandwidth of 10 Mbps. `Refer service document to help you choose the right setup. <https://docs.oracle.com/en-us/iaas/data-science/using/model_dep_create.htm>`_
+   * Check for supported instance shapes `here <https://docs.oracle.com/en-us/iaas/data-science/using/supported-shapes.htm>`_ .

--- a/docs/source/user_guide/model_registration/_template/prepare_save_deploy.rst
+++ b/docs/source/user_guide/model_registration/_template/prepare_save_deploy.rst
@@ -27,7 +27,7 @@ The ``.prepare_save_deploy()`` method is a shortcut for the functions ``.prepare
     Namespace of region. Use this parameter to identify the service pack region
     when you pass a slug to ``inference_conda_env`` and ``training_conda_env``.
 * ``use_case_type``: str
-    The use case type of the model. Assign a value using the``UseCaseType`` class or provide a string in ``UseCaseType``. For
+    The use case type of the model. Assign a value using the ``UseCaseType`` class or provide a string in ``UseCaseType``. For
     example, use_case_type=UseCaseType.BINARY_CLASSIFICATION or use_case_type="binary_classification". Check
     the ``UseCaseType`` class to see supported types.
 * ``X_sample``: Union[list, tuple, pd.Series, np.ndarray, pd.DataFrame]. Defaults to None.
@@ -60,7 +60,7 @@ The ``.prepare_save_deploy()`` method is a shortcut for the functions ``.prepare
     The name of the model.
 * ``description``: (str, optional). Defaults to None.
     The description of the model.
-* ``deployment_instance_shape``: (str, optional). Default to ``VM.Standard2.1``.
+* ``deployment_instance_shape``: (str, optional).
     The shape of the instance used for deployment.
 * ``deployment_instance_count``: (int, optional). Defaults to 1.
     The number of instances used for deployment.

--- a/docs/source/user_guide/model_serialization/_template/prepare_save_deploy.rst
+++ b/docs/source/user_guide/model_serialization/_template/prepare_save_deploy.rst
@@ -27,7 +27,7 @@ The ``.prepare_save_deploy()`` method is a shortcut for the functions ``.prepare
     Namespace of region. Use this parameter to identify the service pack region
     when you pass a slug to ``inference_conda_env`` and ``training_conda_env``.
 * ``use_case_type``: str
-    The use case type of the model. Assign a value using the``UseCaseType`` class or provide a string in ``UseCaseType``. For
+    The use case type of the model. Assign a value using the ``UseCaseType`` class or provide a string in ``UseCaseType``. For
     example, use_case_type=UseCaseType.BINARY_CLASSIFICATION or use_case_type="binary_classification". Check
     the ``UseCaseType`` class to see supported types.
 * ``X_sample``: Union[list, tuple, pd.Series, np.ndarray, pd.DataFrame]. Defaults to None.
@@ -60,7 +60,7 @@ The ``.prepare_save_deploy()`` method is a shortcut for the functions ``.prepare
     The name of the model.
 * ``description``: (str, optional). Defaults to None.
     The description of the model.
-* ``deployment_instance_shape``: (str, optional). Default to ``VM.Standard2.1``.
+* ``deployment_instance_shape``: (str, optional).
     The shape of the instance used for deployment.
 * ``deployment_instance_count``: (int, optional). Defaults to 1.
     The number of instances used for deployment.

--- a/docs/source/user_guide/model_serialization/boilerplate/deploy.rst
+++ b/docs/source/user_guide/model_serialization/boilerplate/deploy.rst
@@ -1,11 +1,11 @@
-You can use the ``.deploy()`` method to deploy a model. You must first save the model to the model catalog, and then deploy it. 
+You can use the ``.deploy()`` method to deploy a model. You must first save the model to the model catalog, and then deploy it.
 
 The ``.deploy()`` method returns a ``ModelDeployment`` object.  Specify deployment attributes such as display name, instance type, number of instances,  maximum router bandwidth, and logging groups.  The API takes the following parameters:
 
 - ``deployment_access_log_id: (str, optional)``: Defaults to ``None``. The access log OCID for the access logs, see `logging <https://docs.oracle.com/en-us/iaas/data-science/using/model_dep_using_logging.htm>`_.
 - ``deployment_bandwidth_mbps: (int, optional)``: Defaults to 10. The bandwidth limit on the load balancer in Mbps.
 - ``deployment_instance_count: (int, optional)``: Defaults to 1. The number of instances used for deployment.
-- ``deployment_instance_shape: (str, optional)``: Default to VM.Standard2.1. The shape of the instance used for deployment.
+- ``deployment_instance_shape: (str, optional)``: The shape of the instance used for deployment.
 - ``deployment_log_group_id: (str, optional)``: Defaults to ``None``. The OCI logging group OCID. The access log and predict log share the same log group.
 - ``deployment_predict_log_id: (str, optional)``: Defaults to ``None``. The predict log OCID for the predict logs, see `logging <https://docs.oracle.com/en-us/iaas/data-science/using/model_dep_using_logging.htm>`_.
 - ``description: (str, optional)``: Defaults to ``None``. The description of the model.
@@ -16,4 +16,3 @@ The ``.deploy()`` method returns a ``ModelDeployment`` object.  Specify deployme
     - ``max_wait_time : (int, optional)``: Defaults to 1200 seconds. The maximum amount of time to wait in seconds. A negative value implies an infinite wait time.
     - ``poll_interval : (int, optional)``: Defaults to 60 seconds. Poll interval in seconds.
     - ``project_id: (str, optional)``: Project OCID. If not specified, the value is taken from the environment variables.
-

--- a/docs/source/user_guide/model_serialization/boilerplate/initialize.rst
+++ b/docs/source/user_guide/model_serialization/boilerplate/initialize.rst
@@ -19,7 +19,7 @@ The ``properties`` is an instance of the ``ModelProperties`` class and has the f
 By default, ``properties`` is populated from the appropriate environment variables if it's
 not specified. For example, in a notebook session, the environment variables
 for project id and compartment id are preset and stored in ``PROJECT_OCID`` and
-``NB_SESSION_COMPARTMENT_OCID`` by default. So ``properties`` populates these variables 
+``NB_SESSION_COMPARTMENT_OCID`` by default. So ``properties`` populates these variables
 from the environment variables and uses the values in methods such as ``.save()`` and ``.deploy()``.
 However, you can explicitly pass in values to overwrite the defaults.
 When you use a method that includes an instance of  ``properties``, then ``properties`` records the values that you pass in.


### PR DESCRIPTION
# Description
Jira: https://jira.oci.oraclecorp.com/browse/ODSC-48247

For ads>=2.8.8, the default deployment_instance_shape set in GenericModel will depend on the following values (they are listed by following the priority, the top is the most prioritized one):

1. deployment_instance_shape value user passed in deploy()
1. shape in notebook_session_config_details
1. self.properties.shape (if the user passed ModelProperties object when initializing GenericModel )
1. environment variable if any
1. ads.model.generic_model.MODEL_DEPLOYMENT_INSTANCE_SHAPE = “VM.Standard.E4.Flex”
