### PR TITLE
ADS release 2.8.11

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,15 @@
 Release Notes
 =============
 
+2.8.11
+------
+Release date: October 18, 2023
+
+* Added support to mount file systems in Data Science notebook sessions and jobs.
+* Added support to cancel all job runs in the ADS ``api`` and ``opctl`` commands.
+* Updated ``ads.set_auth()`` to use both ``config`` and ``signer`` when provided.
+* Fixed a bug when initializing distributed training artifacts with "Ray" framework.
+
 2.8.10
 ------
 Release date: September 27, 2023

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
   "jinja2>=2.11.2",
   "matplotlib>=3.1.3",
   "numpy>=1.19.2",
-  "oci>=2.104.3",
+  "oci>=2.113.0",
   "ocifs>=1.1.3",
   "pandas>1.2.1,<2.1",
   "psutil>=5.7.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "flit_core.buildapi"
 
 # Required
 name = "oracle_ads"  # the install (PyPI) name; name for local build in [tool.flit.module] section below
-version = "2.8.10"
+version = "2.8.11"
 
 # Optional
 description = "Oracle Accelerated Data Science SDK"


### PR DESCRIPTION
### Description

Running release v2.8.11. Jira: [ODSC-47991](https://jira.oci.oraclecorp.com/browse/ODSC-48360)

- bumped version to 2.8.11
- added release notes
- updated oci version to >=2.113.0

### Pre-commit check

```
check python ast.....................................(no files to check)Skipped
check docstring is first.............................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check yaml...........................................(no files to check)Skipped
detect private key.......................................................Passed
fix end of files.........................................................Passed
pretty format json...................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
black................................................(no files to check)Skipped
rst ``code`` is two backticks........................(no files to check)Skipped
rst ``inline code`` next to normal text..............(no files to check)Skipped
Detect hardcoded secrets.................................................Passed
check-copyright......................................(no files to check)Skipped
[ODSC-48360/release_2_8_11 ce6e1db] ODSC-48360. ADS release 2.8.11
```