### PR TITLE
Add Dockerfile.job.arm to opctl

### DIFF
--- a/ads/opctl/docker/Dockerfile.job
+++ b/ads/opctl/docker/Dockerfile.job
@@ -62,7 +62,7 @@ RUN chown -R $DATASCIENCE_USER /opt
 
 USER $DATASCIENCE_USER
 WORKDIR /home/datascience
-ARG MINICONDA_VERSION=23.5.2-0
+ARG MINICONDA_VER=23.5.2-0
 RUN wget -nv https://repo.anaconda.com/miniconda/Miniconda3-py38_${MINICONDA_VER}-Linux-x86_64.sh -O /home/datascience/Miniconda3.sh \
     && /bin/bash /home/datascience/Miniconda3.sh -f -b -p /opt/conda \
     && rm /home/datascience/Miniconda3.sh \

--- a/ads/opctl/docker/Dockerfile.job.arm
+++ b/ads/opctl/docker/Dockerfile.job.arm
@@ -66,8 +66,8 @@ RUN chown -R $DATASCIENCE_USER /opt
 USER $DATASCIENCE_USER
 WORKDIR /home/datascience
 # Note in order to run sudo commands as a non root user, you must specify --credential yes if using qemu static to build the image
-ARG MINICONDA_VERSION=23.5.2-0
-RUN wget -nv https://repo.anaconda.com/miniconda/Miniconda3-py38_${MINICONDA_VERSION}-Linux-aarch64.sh -O /home/datascience/Miniconda3.sh \
+ARG MINICONDA_VER=23.5.2-0
+RUN wget -nv https://repo.anaconda.com/miniconda/Miniconda3-py38_${MINICONDA_VER}-Linux-aarch64.sh -O /home/datascience/Miniconda3.sh \
     && /bin/bash /home/datascience/Miniconda3.sh -f -b -p /opt/conda \
     && rm /home/datascience/Miniconda3.sh \
     && /opt/conda/bin/conda clean -yaf

--- a/ads/opctl/docker/Dockerfile.job.arm
+++ b/ads/opctl/docker/Dockerfile.job.arm
@@ -1,7 +1,8 @@
-# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-FROM ghcr.io/oracle/oraclelinux:7-slim
+# Used OL8 because miniconda required a higher version of glibc that was unavoidable
+FROM ghcr.io/oracle/oraclelinux:8-slim
 
 # Configure environment
 ENV DATASCIENCE_USER datascience
@@ -10,12 +11,14 @@ ENV HOME /home/$DATASCIENCE_USER
 ENV DATASCIENCE_INSTALL_DIR /etc/datascience
 
 ARG release=19
-ARG update=13
+ARG update=10
+
+RUN microdnf install yum yum-utils && yum clean all && rm -rf /var/cache/yum
 
 RUN \
-    yum -y -q install oracle-release-el7 && \
-    yum-config-manager --add-repo http://yum.oracle.com/repo/OracleLinux/OL7/developer_EPEL/x86_64 && \
-    yum-config-manager --enable ol7_optional_latest --enable ol7_addons --enable ol7_software_collections --enable ol7_oracle_instantclient > /dev/null && \
+    yum -y -q install \
+    oracle-release-el8 && \
+    yum-config-manager --enable ol8_addons --enable ol8_oracle_instantclient > /dev/null && \
     yum groupinstall -y -q 'Development Tools' && \
     yum update -y && \
     yum install -y --setopt=skip_missing_names_on_install=False \
@@ -25,7 +28,7 @@ RUN \
     gcc-gfortran \
     libcurl-devel \
     libxml2-devel \
-    oracle-instantclient${release}.${update}-basic \
+    oracle-instantclient${release}.${update}-basic  \
     oracle-instantclient${release}.${update}-sqlplus \
     openssl \
     openssl-devel \
@@ -62,8 +65,9 @@ RUN chown -R $DATASCIENCE_USER /opt
 
 USER $DATASCIENCE_USER
 WORKDIR /home/datascience
+# Note in order to run sudo commands as a non root user, you must specify --credential yes if using qemu static to build the image
 ARG MINICONDA_VERSION=23.5.2-0
-RUN wget -nv https://repo.anaconda.com/miniconda/Miniconda3-py38_${MINICONDA_VER}-Linux-x86_64.sh -O /home/datascience/Miniconda3.sh \
+RUN wget -nv https://repo.anaconda.com/miniconda/Miniconda3-py38_${MINICONDA_VERSION}-Linux-aarch64.sh -O /home/datascience/Miniconda3.sh \
     && /bin/bash /home/datascience/Miniconda3.sh -f -b -p /opt/conda \
     && rm /home/datascience/Miniconda3.sh \
     && /opt/conda/bin/conda clean -yaf

--- a/ads/opctl/docker/Dockerfile.job.gpu
+++ b/ads/opctl/docker/Dockerfile.job.gpu
@@ -107,9 +107,10 @@ RUN chown -R $DATASCIENCE_USER /opt
 
 USER $DATASCIENCE_USER
 WORKDIR /home/datascience
-RUN wget -nv https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /home/datascience/miniconda.sh \
-    && /bin/bash /home/datascience/miniconda.sh -f -b -p /opt/conda \
-    && rm /home/datascience/miniconda.sh \
+ARG MINICONDA_VERSION=23.5.2-0
+RUN wget -nv https://repo.anaconda.com/miniconda/Miniconda3-py38_${MINICONDA_VER}-Linux-x86_64.sh -O /home/datascience/Miniconda3.sh \
+    && /bin/bash /home/datascience/Miniconda3.sh -f -b -p /opt/conda \
+    && rm /home/datascience/Miniconda3.sh \
     && /opt/conda/bin/conda clean -yaf
 
 WORKDIR /
@@ -132,16 +133,14 @@ WORKDIR /
 
 RUN conda list
 
-USER root
-
-ARG PIP_INDEX_URL
-
 ############# Setup Conda environment tools ###########################
+USER root
 ARG RAND=1
 
 ARG RUN_WORKING_DIR="/home/datascience"
 WORKDIR $RUN_WORKING_DIR
 
+# For CUDA - required to support older gpu conda packs
 RUN ln -s /opt/conda/lib/libnvrtc.so.10.0.130 /opt/conda/lib/libnvrtc.so.10 && \
 ln -s /opt/conda/lib/libnvrtc-builtins.so.10.0.130 /opt/conda/lib/libnvrtc-builtins.so.10 && \
 ln -s /opt/conda/lib/libnvgraph.so.10.0.130 /opt/conda/lib/libnvgraph.so.10 && \

--- a/ads/opctl/docker/Dockerfile.job.gpu
+++ b/ads/opctl/docker/Dockerfile.job.gpu
@@ -107,7 +107,7 @@ RUN chown -R $DATASCIENCE_USER /opt
 
 USER $DATASCIENCE_USER
 WORKDIR /home/datascience
-ARG MINICONDA_VERSION=23.5.2-0
+ARG MINICONDA_VER=23.5.2-0
 RUN wget -nv https://repo.anaconda.com/miniconda/Miniconda3-py38_${MINICONDA_VER}-Linux-x86_64.sh -O /home/datascience/Miniconda3.sh \
     && /bin/bash /home/datascience/Miniconda3.sh -f -b -p /opt/conda \
     && rm /home/datascience/Miniconda3.sh \


### PR DESCRIPTION
### Description

To support arm in ads opctl we need new Dockerfile.job.arm. This PR also include minor updates in Dockerfile.job and Dockerfile.job.gpu.  Regular Dockerfile not in scope.

Jira: https://jira.oci.oraclecorp.com/browse/ODSC-46619

### What was done

- added new Dockerfile.job.arm
- set Miniconda version in Dockerfile.job
- set Miniconda version in Dockerfile.job.gpu
- removed log folder and harness setup in Dockerfile.job

### Pre-commit

```
11:32:42.136: [accelerated-data-science] git -c credential.helper= -c core.quotepath=false -c log.showSignature=false checkout -b ODSC-46619/add_opctl_dockerfile_arm HEAD --
Switched to a new branch 'ODSC-46619/add_opctl_dockerfile_arm'
11:42:13.498: [accelerated-data-science] git -c credential.helper= -c core.quotepath=false -c log.showSignature=false add --ignore-errors -A -- ads/opctl/docker/Dockerfile.job.arm
12:57:25.419: [accelerated-data-science] git -c credential.helper= -c core.quotepath=false -c log.showSignature=false add --ignore-errors -A -f -- ads/opctl/docker/Dockerfile.job.arm ads/opctl/docker/Dockerfile.job ads/opctl/docker/Dockerfile.job.gpu
12:57:25.457: [accelerated-data-science] git -c credential.helper= -c core.quotepath=false -c log.showSignature=false commit -F /private/var/folders/r3/1cpcpp4x6213j9wgyxvnhwc80000gn/T/git-commit-msg-.txt --
check python ast.....................................(no files to check)Skipped
check docstring is first.............................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check yaml...........................................(no files to check)Skipped
detect private key.......................................................Passed
fix end of files.........................................................Passed
pretty format json...................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
black................................................(no files to check)Skipped
rst ``code`` is two backticks........................(no files to check)Skipped
rst ``inline code`` next to normal text..............(no files to check)Skipped
Detect hardcoded secrets.................................................Passed
check-copyright......................................(no files to check)Skipped
[ODSC-46619/add_opctl_dockerfile_arm bef248e] ODSC-46619. Add Dockerfile.job.arm to opctl
 3 files changed, 119 insertions(+), 18 deletions(-)
```

### Validation

1. build image
2. prepare conda pack yaml
3. build conda packs
4. publish conda pack

### CPU (locally)
_Note: pack builded in image and successfully packed, not published - auth error._
```
(empty) lrudenka@lrudenka-mac ~ % ads opctl build-image job-local
Sending build context to Docker daemon  635.4kB
Step 1/38 : FROM ghcr.io/oracle/oraclelinux:7-slim
 ---> 1d56b1a0fd84
Step 2/38 : ENV DATASCIENCE_USER datascience
 ---> Running in ca01be950a95
Removing intermediate container ca01be950a95
 ---> f55aa2508d2d
Step 3/38 : ENV DATASCIENCE_UID 1000
 ---> Running in fbcd2bf29748
...

Step 38/38 : USER datascience
 ---> Running in 47d0101571ef
Removing intermediate container 47d0101571ef
 ---> bf81a5c06d35
Successfully built bf81a5c06d35
Successfully tagged ml-job:latest
(empty) lrudenka@lrudenka-mac ~ % ads opctl conda create -n liuda-test-pack -f liuda-environment.yaml -v "007"
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
...
Installing pip dependencies: ...working... Ran pip subprocess with arguments:
['/home/datascience/liuda-test-pack_v007/bin/python', '-m', 'pip', 'install', '-U', '-r', '/home/datascience/condaenv.jl0l3eq_.requirements.txt', '--exists-action=b']
Pip subprocess output:                               
Collecting oracle-ads (from -r /home/datascience/condaenv.jl0l3eq_.requirements.txt (line 1))
  Downloading oracle_ads-2.8.11-py3-none-any.whl.metadata (11 kB)
...
Successfully installed Markdown-3.5 MarkupSafe-2.1.3 PyYAML-6.0.1 asteval-0.9.31 attrs-23.1.0 cerberus-1.3.5 certifi-2023.7.22 cffi-1.16.0 charset-normalizer-3.3.1 circuitbreaker-1.4.0 cloudpickle-3.0.0 contourpy-1.1.1 cryptography-41.0.5 cycler-0.12.1 fonttools-4.43.1 fsspec-2023.9.0 gitdb-4.0.11 gitpython-3.1.40 idna-3.4 inflection-0.5.1 jinja2-3.1.2 jsonschema-4.19.1 jsonschema-specifications-2023.7.1 kiwisolver-1.4.5 matplotlib-3.8.0 oci-2.114.0 ocifs-1.2.1 oracle-ads-2.8.11 packaging-23.2 pandas-2.0.3 pillow-10.1.0 psutil-5.9.6 pyOpenSSL-23.3.0 pycparser-2.21 pyparsing-3.1.1 python-dateutil-2.8.2 python_jsonschema_objects-0.5.0 pytz-2023.3.post1 referencing-0.30.2 requests-2.31.0 rpds-py-0.10.6 six-1.16.0 smmap-5.0.1 tabulate-0.9.0 tqdm-4.66.1 tzdata-2023.3 urllib3-2.0.7

...

Pack liuda-test-pack_v007 created under /Users/lrudenka/conda/liuda-test-pack_v007.
(empty) lrudenka@lrudenka-mac ~ % ads opctl conda publish -d -o -p oci://liuda-bucket-test-upload@ociodscdev/conda_environments/cpu/liuda-test-pack_v007 -s liuda-test-pack_v007
..
Config: {'execution': {'debug': True, 'overwrite': True, 'conda_pack_os_prefix': 'oci://liuda-bucket-test-upload@ociodscdev/conda_environments/cpu/liuda-test-pack_v007', 'slug': 'liuda-test-pack_v007', 'version': '1', 'gpu': False, 'auth': 'api_key', 'oci_profile': 'DEFAULT', 'oci_config': '~/.oci/config', 'conda_pack_folder': '~/conda'}, 'infrastructure': {}}
...
DEBUG:ads.opctl:>>> docker run --rm -v /Users/lrudenka/conda/liuda-test-pack_v007:/home/datascience/liuda-test-pack_v007 -v /Users/lrudenka/github/accelerated-data-science/ads/opctl/conda/pack.py:/home/datascience/pack.py ml-job python /home/datascience/pack.py /home/datascience/liuda-test-pack_v007
Container ID: a2ff0f43caa727597c9aadc03a13f1321bdd090e668dc3e3d71c573af323e263
INFO:ads.opctl:Container ID: a2ff0f43caa727597c9aadc03a13f1321bdd090e668dc3e3d71c573af323e263
changing permission for /home/datascience/liuda-test-pack_v007/liuda-test-pack_v007.tar.gz
..
```

### ARM (used instance in dev)
1. copied Dockerfile.job.arm
2. copied base-env.yaml
3. builded image with command docker build -t ml-job-arm -f Dockerfile.job.arm .
```
[opc@jstest-arm liuda-123]$ docker build --network=host \
> --build-arg http_proxy=http://10.68.69.53:80 \
> --build-arg https_proxy=http://10.68.69.53:80 \
> --build-arg HTTP_PROXY=http://10.68.69.53:80 \
> --build-arg HTTPS_PROXY=http://10.68.69.53:80 \
> --build-arg NO_PROXY=localhost,127.0.0.1,100.100.87.49,100.126.5.5,10.242.12.81,96.16.208.148,10.89.228.14,10.89.228.16,10.89.228.17,.oraclecorp.com,23.196.45.131 \
> --build-arg no_proxy=localhost,127.0.0.1,100.100.87.49,100.126.5.5,10.242.12.81,96.16.208.148,10.89.228.14,10.89.228.16,10.89.228.17,.oraclecorp.com,23.196.45.131 \
> -t ml-job-arm -f Dockerfile.job.arm .
Sending build context to Docker daemon  6.144kB
Step 1/39 : FROM ghcr.io/oracle/oraclelinux:8-slim
 ---> 61005385bc33
Step 2/39 : ENV DATASCIENCE_USER datascience
 ---> Using cache
 ---> bf24cfcc723f
...
Step 39/39 : USER datascience
 ---> Running in 233296f7e78a
Removing intermediate container 233296f7e78a
 ---> a948e234a5f0
Successfully built a948e234a5f0
Successfully tagged ml-job-arm:latest
```
Run container and inside created conda env with pytorch for arm:
_Note: I am not changing anything in opctl commands and code, this validation is to check that inside arm image conda env can be created_
```
(base) bash-4.4$ cat <<EOF > liuda-environment.yaml
> channels:
> - defaults
> - conda-forge
> - pytorch
> dependencies:
>   - main::pip
>   - pytorch
>   - torchvision
>   - pip:
>     - oracle-ads
> EOF
NO_CONTAINER=1 ads opctl conda create -n liuda-test-pack-arm -f liuda-environment.yaml -v "001"
Conda pack with slug liuda-test-pack-arm_v001 already exists. Do you wish to overwrite? [y/N]: y
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
...
Installing pip dependencies: ...working... Ran pip subprocess with arguments:
['/home/datascience/conda/liuda-test-pack-arm_v001/bin/python', '-m', 'pip', 'install', '-U', '-r', '/home/datascience/condaenv.0qg5rvpl.requirements.txt', '--exists-action=b']
Pip subprocess output:
Collecting oracle-ads (from -r /home/datascience/condaenv.0qg5rvpl.requirements.txt (line 1))
  Using cached oracle_ads-2.8.11-py3-none-any.whl.metadata (11 kB)
...
Successfully installed Markdown-3.5 PyYAML-6.0.1 asteval-0.9.31 attrs-23.1.0 cerberus-1.3.5 circuitbreaker-1.4.0 cloudpickle-3.0.0 contourpy-1.1.1 cycler-0.12.1 fonttools-4.43.1 fsspec-2023.9.0 gitdb-4.0.11 gitpython-3.1.40 importlib-metadata-6.8.0 importlib-resources-6.1.0 inflection-0.5.1 joblib-1.3.2 jsonschema-4.19.1 jsonschema-specifications-2023.7.1 kiwisolver-1.4.5 matplotlib-3.8.0 numpy-1.26.1 oci-2.114.0 ocifs-1.2.1 oracle-ads-2.8.11 packaging-23.2 pandas-2.0.3 psutil-5.9.6 pyparsing-3.1.1 python-dateutil-2.8.2 python_jsonschema_objects-0.5.0 pytz-2023.3.post1 referencing-0.30.2 rpds-py-0.10.6 scikit-learn-1.3.2 scipy-1.11.3 six-1.16.0 smmap-5.0.1 tabulate-0.9.0 threadpoolctl-3.2.0 tqdm-4.66.1 tzdata-2023.3 zipp-3.17.0

done
#
# To activate this environment, use
#
#     $ conda activate /home/datascience/conda/liuda-test-pack-arm_v001
#
# To deactivate an active environment, use
#
#     $ conda deactivate

Pack liuda-test-pack-arm_v001 created under /home/datascience/conda/liuda-test-pack-arm_v001.

```

### GPU (locally)
_Note: Validated only successful building of gpu image_
```
(empty) lrudenka@lrudenka-mac ~ % ads opctl build-image -g -d job-local
Build image with command ['docker', 'build', '-t', 'ml-job-gpu', '-f', '/Users/lrudenka/github/accelerated-data-science/ads/opctl/docker/Dockerfile.job.gpu', '/Users/lrudenka/github/accelerated-data-science/ads/opctl']
INFO:ads.opctl:Build image with command ['docker', 'build', '-t', 'ml-job-gpu', '-f', '/Users/lrudenka/github/accelerated-data-science/ads/opctl/docker/Dockerfile.job.gpu', '/Users/lrudenka/github/accelerated-data-science/ads/opctl']
Sending build context to Docker daemon  635.4kB

Step 1/54 : FROM ghcr.io/oracle/oraclelinux:7-slim
 ---> 1d56b1a0fd84
Step 2/54 : ENV DATASCIENCE_USER datascience
 ---> Using cache
 ---> f55aa2508d2d
...
Step 54/54 : USER datascience
 ---> Running in eba7b4d27373
Removing intermediate container eba7b4d27373
 ---> 342f4c4b50fb
Successfully built 342f4c4b50fb
Successfully tagged ml-job-gpu:latest
```