### PR TITLE
Reduced horizon parameters and handled datetime error for AutoMLx model

### DIFF
--- a/ads/opctl/operator/lowcode/forecast/model/arima.py
+++ b/ads/opctl/operator/lowcode/forecast/model/arima.py
@@ -62,17 +62,13 @@ class ArimaOperatorModel(ForecastOperatorBaseModel):
 
             # Build future dataframe
             start_date = y.index.values[-1]
-            n_periods = self.spec.horizon.periods
-            interval_unit = self.spec.horizon.interval_unit
-            interval = int(self.spec.horizon.interval or 1)
+            n_periods = self.spec.horizon
             if len(additional_regressors):
                 X = df_clean[df_clean[target].isnull()].drop(target, axis=1)
             else:
                 X = pd.date_range(
-                    start=start_date, periods=n_periods, freq=interval_unit
+                    start=start_date, periods=n_periods, freq=self.spec.freq
                 )
-                # AttributeError: 'DatetimeIndex' object has no attribute 'iloc'
-                # X = X.iloc[::interval, :]
 
             # Predict and format forecast
             yhat, conf_int = model.predict(

--- a/ads/opctl/operator/lowcode/forecast/model/automlx.py
+++ b/ads/opctl/operator/lowcode/forecast/model/automlx.py
@@ -48,7 +48,7 @@ class AutoMLXOperatorModel(ForecastOperatorBaseModel):
         outputs_legacy = []
         selected_models = dict()
         date_column = self.spec.datetime_column.name
-        horizon = self.spec.horizon.periods
+        horizon = self.spec.horizon
 
         # Clean up kwargs for pass through
         model_kwargs_cleaned = self.spec.model_kwargs.copy()

--- a/ads/opctl/operator/lowcode/forecast/model/automlx.py
+++ b/ads/opctl/operator/lowcode/forecast/model/automlx.py
@@ -325,13 +325,13 @@ class AutoMLXOperatorModel(ForecastOperatorBaseModel):
                 model=self._custom_predict_automlx,
                 data=self.full_data_dict.get(self.series_id).set_index(
                     self.spec.datetime_column.name
-                )[: -self.spec.horizon.periods][list(self.dataset_cols)],
+                )[: -self.spec.horizon][list(self.dataset_cols)],
             )
 
             kernel_explnr_vals = kernel_explnr.shap_values(
                 self.full_data_dict.get(self.series_id).set_index(
                     self.spec.datetime_column.name
-                )[: -self.spec.horizon.periods][list(self.dataset_cols)],
+                )[: -self.spec.horizon][list(self.dataset_cols)],
                 nsamples=50,
             )
 
@@ -357,7 +357,7 @@ class AutoMLXOperatorModel(ForecastOperatorBaseModel):
         data = self.full_data_dict.get(self.series_id).set_index(
             self.spec.datetime_column.name
         )
-        data = data[-self.spec.horizon.periods :][list(self.dataset_cols)]
+        data = data[-self.spec.horizon :][list(self.dataset_cols)]
 
         # Generate local SHAP values using the kernel explainer
         local_kernel_explnr_vals = kernel_explainer.shap_values(data, nsamples=50)

--- a/ads/opctl/operator/lowcode/forecast/model/autots.py
+++ b/ads/opctl/operator/lowcode/forecast/model/autots.py
@@ -45,7 +45,7 @@ class AutoTSOperatorModel(ForecastOperatorBaseModel):
 
         # Initialize the AutoTS model with specified parameters
         model = AutoTS(
-            forecast_length=self.spec.horizon.periods,
+            forecast_length=self.spec.horizon,
             frequency="infer",
             prediction_interval=self.spec.confidence_interval_width,
             max_generations=self.spec.model_kwargs.get(

--- a/ads/opctl/operator/lowcode/forecast/model/base_model.py
+++ b/ads/opctl/operator/lowcode/forecast/model/base_model.py
@@ -242,6 +242,10 @@ class ForecastOperatorBaseModel(ABC):
             columns=self.spec.historical_data.columns,
         )
         self.original_user_data = raw_data.copy()
+        date_column = self.spec.datetime_column.name
+        freq = pd.infer_freq(raw_data[date_column].drop_duplicates().tail(5))
+        self.spec.freq = freq
+        utils.evaluate_model_compatibility(raw_data, self.spec)
         data = Transformations(raw_data, self.spec).run()
         self.original_total_data = data
         additional_data = None
@@ -263,7 +267,7 @@ class ForecastOperatorBaseModel(ABC):
             data=data,
             target_column=self.spec.target_column,
             datetime_column=self.spec.datetime_column.name,
-            horizon=self.spec.horizon.periods,
+            horizon=self.spec.horizon,
             target_category_columns=self.spec.target_category_columns,
             additional_data=additional_data,
         )

--- a/ads/opctl/operator/lowcode/forecast/model/base_model.py
+++ b/ads/opctl/operator/lowcode/forecast/model/base_model.py
@@ -345,15 +345,15 @@ class ForecastOperatorBaseModel(ABC):
         """Calculates Mean sMAPE, Median sMAPE, Mean MAPE, Median MAPE, Mean wMAPE, Median wMAPE values for each horizon
         if horizon <= 10."""
         target_columns_in_output = set(target_columns).intersection(data.columns)
-        if self.spec.horizon.periods <= SUMMARY_METRICS_HORIZON_LIMIT and len(
-            outputs
-        ) == len(target_columns_in_output):
+        if self.spec.horizon <= SUMMARY_METRICS_HORIZON_LIMIT and len(outputs) == len(
+            target_columns_in_output
+        ):
             metrics_per_horizon = utils._build_metrics_per_horizon(
                 data=data,
                 outputs=outputs,
                 target_columns=target_columns,
                 target_col=target_col,
-                horizon_periods=self.spec.horizon.periods,
+                horizon_periods=self.spec.horizon,
             )
 
             summary_metrics = summary_metrics.append(metrics_per_horizon)

--- a/ads/opctl/operator/lowcode/forecast/model/neuralprophet.py
+++ b/ads/opctl/operator/lowcode/forecast/model/neuralprophet.py
@@ -227,34 +227,34 @@ class NeuralProphetOperatorModel(ForecastOperatorBaseModel):
             output_i[f"p{int(quantiles[0]*100)}"] = float("nan")
 
             output_i.iloc[
-                : -self.spec.horizon.periods, output_i.columns.get_loc(f"fitted_value")
+                : -self.spec.horizon, output_i.columns.get_loc(f"fitted_value")
             ] = (
                 outputs[f"{col}_{cat}"]["yhat1"]
-                .iloc[: -self.spec.horizon.periods]
+                .iloc[: -self.spec.horizon]
                 .values
             )
             output_i.iloc[
-                -self.spec.horizon.periods :,
+                -self.spec.horizon :,
                 output_i.columns.get_loc(f"forecast_value"),
             ] = (
                 outputs[f"{col}_{cat}"]["yhat1"]
-                .iloc[-self.spec.horizon.periods :]
+                .iloc[-self.spec.horizon :]
                 .values
             )
             output_i.iloc[
-                -self.spec.horizon.periods :,
+                -self.spec.horizon :,
                 output_i.columns.get_loc(f"p{int(quantiles[1]*100)}"),
             ] = (
                 outputs[f"{col}_{cat}"][f"yhat1 {quantiles[1]*100}%"]
-                .iloc[-self.spec.horizon.periods :]
+                .iloc[-self.spec.horizon :]
                 .values
             )
             output_i.iloc[
-                -self.spec.horizon.periods :,
+                -self.spec.horizon :,
                 output_i.columns.get_loc(f"p{int(quantiles[0]*100)}"),
             ] = (
                 outputs[f"{col}_{cat}"][f"yhat1 {quantiles[0]*100}%"]
-                .iloc[-self.spec.horizon.periods :]
+                .iloc[-self.spec.horizon :]
                 .values
             )
             output_col = pd.concat([output_col, output_i])

--- a/ads/opctl/operator/lowcode/forecast/model/prophet.py
+++ b/ads/opctl/operator/lowcode/forecast/model/prophet.py
@@ -105,7 +105,7 @@ class ProphetOperatorModel(ForecastOperatorBaseModel):
                         unit = "D"
                         interval = interval * 365.25
                     horizon = _add_unit(
-                        int(self.spec.horizon.periods * interval), unit=unit
+                        int(self.spec.horizon * interval), unit=unit
                     )
                     initial = _add_unit((data_i.shape[0] * interval) // 2, unit=unit)
                     period = _add_unit((data_i.shape[0] * interval) // 4, unit=unit)
@@ -164,8 +164,8 @@ class ProphetOperatorModel(ForecastOperatorBaseModel):
                 future = df_clean.drop(target, axis=1)
             else:
                 future = model.make_future_dataframe(
-                    periods=self.spec.horizon.periods,
-                    freq=self.spec.horizon.interval_unit,
+                    periods=self.spec.horizon,
+                    freq=self.spec.freq,
                 )
             # Make Prediction
             forecast = model.predict(future)
@@ -202,32 +202,32 @@ class ProphetOperatorModel(ForecastOperatorBaseModel):
             output_i[yhat_lower_name] = float("nan")
 
             output_i.iloc[
-                : -self.spec.horizon.periods, output_i.columns.get_loc(f"fitted_value")
+                : -self.spec.horizon, output_i.columns.get_loc(f"fitted_value")
             ] = (
                 outputs[f"{col}_{cat}"]["yhat"]
-                .iloc[: -self.spec.horizon.periods]
+                .iloc[: -self.spec.horizon]
                 .values
             )
             output_i.iloc[
-                -self.spec.horizon.periods :,
+                -self.spec.horizon :,
                 output_i.columns.get_loc(f"forecast_value"),
             ] = (
                 outputs[f"{col}_{cat}"]["yhat"]
-                .iloc[-self.spec.horizon.periods :]
+                .iloc[-self.spec.horizon :]
                 .values
             )
             output_i.iloc[
-                -self.spec.horizon.periods :, output_i.columns.get_loc(yhat_upper_name)
+                -self.spec.horizon :, output_i.columns.get_loc(yhat_upper_name)
             ] = (
                 outputs[f"{col}_{cat}"]["yhat_upper"]
-                .iloc[-self.spec.horizon.periods :]
+                .iloc[-self.spec.horizon :]
                 .values
             )
             output_i.iloc[
-                -self.spec.horizon.periods :, output_i.columns.get_loc(yhat_lower_name)
+                -self.spec.horizon :, output_i.columns.get_loc(yhat_lower_name)
             ] = (
                 outputs[f"{col}_{cat}"]["yhat_lower"]
-                .iloc[-self.spec.horizon.periods :]
+                .iloc[-self.spec.horizon :]
                 .values
             )
             output_col = pd.concat([output_col, output_i])

--- a/ads/opctl/operator/lowcode/forecast/operator_config.py
+++ b/ads/opctl/operator/lowcode/forecast/operator_config.py
@@ -58,15 +58,6 @@ class DateTimeColumn(DataClassSerializable):
 
 
 @dataclass(repr=True)
-class Horizon(DataClassSerializable):
-    """Class representing operator specification horizon details."""
-
-    periods: int = None
-    interval: int = None
-    interval_unit: str = None
-
-
-@dataclass(repr=True)
 class Tuning(DataClassSerializable):
     """Class representing operator specification tuning details."""
 
@@ -91,7 +82,8 @@ class ForecastOperatorSpec(DataClassSerializable):
     preprocessing: bool = None
     datetime_column: DateTimeColumn = field(default_factory=DateTimeColumn)
     target_category_columns: List[str] = field(default_factory=list)
-    horizon: Horizon = field(default_factory=Horizon)
+    horizon: int = None
+    freq: str = None
     explain: bool = None
     model: str = None
     model_kwargs: Dict = field(default_factory=dict)

--- a/ads/opctl/operator/lowcode/forecast/schema.yaml
+++ b/ads/opctl/operator/lowcode/forecast/schema.yaml
@@ -231,28 +231,7 @@ spec:
 
     horizon:
       required: true
-      schema:
-        periods:
-          type: integer
-          default: 3
-          required: true
-        interval:
-          type: integer
-          required: false
-        interval_unit:
-          required: true
-          type: string
-          default: M
-          allowed:
-            - S
-            - M
-            - H
-            - D
-            - W
-            - Mo
-            - Q
-            - Y
-      type: dict
+      type: integer
 
     model:
       type: string

--- a/ads/opctl/operator/lowcode/forecast/utils.py
+++ b/ads/opctl/operator/lowcode/forecast/utils.py
@@ -24,8 +24,8 @@ from ads.dataset.label_encoder import DataFrameLabelEncoder
 from .const import SupportedModels, MAX_COLUMNS_AUTOMLX
 from .errors import ForecastInputDataError, ForecastSchemaYamlError
 import re
-from ads.opctl.operator.lowcode.forecast.operator_config import ForecastOperatorSpec
-from ads.opctl.operator.lowcode.forecast.const import SupportedModels
+from .operator_config import ForecastOperatorSpec
+from .const import SupportedModels
 
 
 def _label_encode_dataframe(df, no_encode=set()):
@@ -510,6 +510,6 @@ def to_timedelta(freq: str):
     """
     # Add '1' in case freq doesn't have any digit
     if not bool(re.search(r'\d', freq)):
-        freq = '1{}'.format(freq)
+        freq = f"1{freq}"
     # Convert to datetime.timedelta
     return pd.to_timedelta(freq)

--- a/ads/opctl/operator/lowcode/forecast/utils.py
+++ b/ads/opctl/operator/lowcode/forecast/utils.py
@@ -23,6 +23,9 @@ from .const import SupportedMetrics
 from ads.dataset.label_encoder import DataFrameLabelEncoder
 from .const import SupportedModels, MAX_COLUMNS_AUTOMLX
 from .errors import ForecastInputDataError, ForecastSchemaYamlError
+import re
+from ads.opctl.operator.lowcode.forecast.operator_config import ForecastOperatorSpec
+from ads.opctl.operator.lowcode.forecast.const import SupportedModels
 
 
 def _label_encode_dataframe(df, no_encode=set()):
@@ -382,7 +385,7 @@ def get_forecast_plots(
                         y=outputs[idx][ci_col_names[1]],
                         mode="lines",
                         line_color="rgba(0,0,0,0)",
-                        name=f"{ci_interval_width*100}% confidence interval",
+                        name=f"{ci_interval_width * 100}% confidence interval",
                         fill="tonexty",
                         fillcolor="rgba(211, 211, 211, 0.5)",
                     ),
@@ -465,3 +468,48 @@ def select_auto_model(columns: List[str]) -> str:
     if columns != None and len(columns) > MAX_COLUMNS_AUTOMLX:
         return SupportedModels.Arima
     return SupportedModels.AutoMLX
+
+
+def evaluate_model_compatibility(data: pd.DataFrame, dataset_info: ForecastOperatorSpec):
+    """
+    Function checks if the data is compatible with the model selected
+
+    Parameters
+    ------------
+    data:  pd.DataFrame
+            primary dataset
+    dataset_info:  ForecastOperatorSpec
+
+    Returns
+    --------
+    None
+
+    """
+    date_column = dataset_info.datetime_column.name
+    freq = pd.infer_freq(data[date_column].drop_duplicates().tail(5))
+    freq_in_secs = to_timedelta(freq) / to_timedelta("sec")
+    if freq_in_secs < 3600 and dataset_info.model == SupportedModels.AutoMLX:
+        message = "{} requires data with a frequency of at least one hour. Please try using a different model," \
+                  " or select the 'auto' option.".format(
+            SupportedModels.AutoMLX, freq)
+        raise Exception(message)
+
+
+def to_timedelta(freq: str):
+    """
+    Converts freq sting to time delta.
+
+    Parameters
+    ------------
+    freq:  str
+        freq e.g. T, 5T, 5H, Y
+
+    Returns
+    --------
+    timedelta
+    """
+    # Add '1' in case freq doesn't have any digit
+    if not bool(re.search(r'\d', freq)):
+        freq = '1{}'.format(freq)
+    # Convert to datetime.timedelta
+    return pd.to_timedelta(freq)


### PR DESCRIPTION

- Reduced the number of options for the forecasting horizon and automatically infer the data frequency. [ODSC-49026](
https://jira.oci.oraclecorp.com/browse/ODSC-49026)
- Added an exception for AutoML models if the data frequency is less than one hour. [ODSC-48875](https://jira.oci.oraclecorp.com/browse/ODSC-48875)