### PR TITLE
ODSC-49155: Operator init method fails when OCI config is not provided.

### DIFF
--- a/ads/jobs/builders/infrastructure/dsc_job.py
+++ b/ads/jobs/builders/infrastructure/dsc_job.py
@@ -741,8 +741,8 @@ class DataScienceJobRun(
         self.client.cancel_job_run(self.id)
         if wait_for_completion:
             while (
-                self.lifecycle_state != 
-                oci.data_science.models.JobRun.LIFECYCLE_STATE_CANCELED
+                self.lifecycle_state
+                != oci.data_science.models.JobRun.LIFECYCLE_STATE_CANCELED
             ):
                 self.sync()
                 time.sleep(SLEEP_INTERVAL)
@@ -1480,9 +1480,7 @@ class DataScienceJob(Infrastructure):
             ] = JobInfrastructureConfigurationDetails.JOB_INFRASTRUCTURE_TYPE_STANDALONE
 
         if self.storage_mount:
-            if not hasattr(
-                oci.data_science.models, "StorageMountConfigurationDetails"
-            ):
+            if not hasattr(oci.data_science.models, "StorageMountConfigurationDetails"):
                 raise EnvironmentError(
                     "Storage mount hasn't been supported in the current OCI SDK installed."
                 )
@@ -1494,6 +1492,12 @@ class DataScienceJob(Infrastructure):
 
     def build(self) -> DataScienceJob:
         self.dsc_job.load_defaults()
+
+        try:
+            self.dsc_job.load_defaults()
+        except Exception:
+            logger.exception("Failed to load default properties.")
+
         self._update_from_dsc_model(self.dsc_job, overwrite=False)
         return self
 

--- a/ads/opctl/operator/common/backend_factory.py
+++ b/ads/opctl/operator/common/backend_factory.py
@@ -190,7 +190,13 @@ class BackendFactory:
             backends = cls._init_backend_config(
                 operator_info=operator_info, backend_kind=backend_kind, **kwargs
             )
-            backend = backends[cls.BACKEND_RUNTIME_MAP[backend_kind][runtime_type]]
+
+            backend = backends.get(cls.BACKEND_RUNTIME_MAP[backend_kind][runtime_type])
+            if not backend:
+                raise RuntimeError(
+                    "An error occurred while attempting to load the "
+                    f"configuration for the `{backend_kind}.{runtime_type}` backend."
+                )
 
         p_backend = ConfigProcessor(
             {**backend, **{"execution": {"backend": backend_kind}}}
@@ -400,24 +406,35 @@ class BackendFactory:
             supported_backends = (backend_kind,)
 
         for resource_type in supported_backends:
-            for runtime_type_item in RUNTIME_TYPE_MAP.get(resource_type.lower(), []):
-                runtime_type, runtime_kwargs = next(iter(runtime_type_item.items()))
+            try:
+                for runtime_type_item in RUNTIME_TYPE_MAP.get(
+                    resource_type.lower(), []
+                ):
+                    runtime_type, runtime_kwargs = next(iter(runtime_type_item.items()))
 
-                # get config info from ini files
-                p = ConfigProcessor(
-                    {**runtime_kwargs, **{"execution": {"backend": resource_type}}}
-                ).step(
-                    ConfigMerger,
-                    ads_config=ads_config or DEFAULT_ADS_CONFIG_FOLDER,
-                    **kwargs,
+                    # get config info from ini files
+                    p = ConfigProcessor(
+                        {**runtime_kwargs, **{"execution": {"backend": resource_type}}}
+                    ).step(
+                        ConfigMerger,
+                        ads_config=ads_config or DEFAULT_ADS_CONFIG_FOLDER,
+                        **kwargs,
+                    )
+
+                    # generate YAML specification template
+                    result[
+                        (resource_type.lower(), runtime_type.value.lower())
+                    ] = yaml.load(
+                        _BackendFactory(p.config).backend.init(
+                            runtime_type=runtime_type.value,
+                            **{**kwargs, **runtime_kwargs},
+                        ),
+                        Loader=yaml.FullLoader,
+                    )
+            except Exception as ex:
+                logger.warning(
+                    f"Unable to generate the configuration for the `{resource_type}` backend. "
+                    f"{ex}"
                 )
 
-                # generate YAML specification template
-                result[(resource_type.lower(), runtime_type.value.lower())] = yaml.load(
-                    _BackendFactory(p.config).backend.init(
-                        runtime_type=runtime_type.value,
-                        **{**kwargs, **runtime_kwargs},
-                    ),
-                    Loader=yaml.FullLoader,
-                )
         return result


### PR DESCRIPTION
## Description
https://jira.oci.oraclecorp.com/browse/ODSC-48954

The OCI configuration is necessary to retrieve information about the potential resource where the operator can be executed. For instance, when the operator's initialization method is called within an NB session, it allows to access details regarding the shape and memory. This PR replaces the error with a warning message, providing users with guidance on resolving the situation. The functionality to generate a local configuration will remain unaffected.

The second part of this PR validates whether the OCI configuration is needed to access input data from a remote resource. If all the required files are located in the local folder, the OCI configuration is not required.

## How To Test

### Scenario 1
* Rename the folder where the OCI and ADS configs located.
* Run the ```ads operator init -t forecast --output ~/your/destination/config -o
* The configs should be generated only for the local bacends

### Scenario 2
* Rename the folder where the OCI and ADS configs located.
* Run the ```ads operator run -f  ~/your/destination/config/forecast.yaml -b local``` or ```ads opctl run -f  ~/your/destination/config/forecast.yaml ```
* The operator should be successfully run.
