### PR TITLE
ODSC-49028/sort by datetime col & ODSC-48265/training metrics mismatch

### DIFF
--- a/ads/opctl/operator/lowcode/forecast/model/automlx.py
+++ b/ads/opctl/operator/lowcode/forecast/model/automlx.py
@@ -76,7 +76,9 @@ class AutoMLXOperatorModel(ForecastOperatorBaseModel):
             series_values = df[df[target].notna()]
             # drop NaNs for the time period where data wasn't recorded
             series_values.dropna(inplace=True)
-            df[date_column] = pd.to_datetime(df[date_column])
+            df[date_column] = pd.to_datetime(
+                df[date_column], format=self.spec.datetime_column.format
+            )
             df = df.set_index(date_column)
             if len(df.columns) > 1:
                 # when additional columns are present

--- a/ads/opctl/operator/lowcode/forecast/model/autots.py
+++ b/ads/opctl/operator/lowcode/forecast/model/autots.py
@@ -263,7 +263,10 @@ class AutoTSOperatorModel(ForecastOperatorBaseModel):
 
         other_sections = all_sections
 
-        ds_column_series = pd.to_datetime(self.data[self.spec.datetime_column.name])
+        ds_column_series = pd.to_datetime(
+            self.data[self.spec.datetime_column.name],
+            format=self.spec.datetime_column.format,
+        )
         ds_forecast_col = self.outputs[0].index
         ci_col_names = ["yhat_lower", "yhat_upper"]
 

--- a/ads/opctl/operator/lowcode/forecast/model/base_model.py
+++ b/ads/opctl/operator/lowcode/forecast/model/base_model.py
@@ -82,6 +82,7 @@ class ForecastOperatorBaseModel(ABC):
                     self.target_columns,
                     self.data,
                     self.outputs,
+                    self.spec.datetime_column.name,
                     target_col=self.forecast_col_name,
                 )
 

--- a/ads/opctl/operator/lowcode/forecast/model/base_model.py
+++ b/ads/opctl/operator/lowcode/forecast/model/base_model.py
@@ -271,7 +271,9 @@ class ForecastOperatorBaseModel(ABC):
                 format=self.spec.additional_data.format,
                 columns=self.spec.additional_data.columns,
             )
-
+            additional_data = Transformations(
+                raw_data, self.spec
+            )._sort_by_datetime_col(additional_data)
             self.original_additional_data = additional_data.copy()
             self.original_total_data = pd.concat([data, additional_data], axis=1)
         (

--- a/ads/opctl/operator/lowcode/forecast/model/transformations.py
+++ b/ads/opctl/operator/lowcode/forecast/model/transformations.py
@@ -9,6 +9,7 @@ from ads.opctl import logger
 
 class Transformations:
     """A class which implements transformation for forecast operator"""
+
     def __init__(self, data, dataset_info):
         """
         Initializes the transformation.
@@ -22,6 +23,7 @@ class Transformations:
         self.series_id_column = dataset_info.target_category_columns
         self.target_variables = dataset_info.target_column
         self.date_column = dataset_info.datetime_column.name
+        self.date_format = dataset_info.datetime_column.format
         self.preprocessing = dataset_info.preprocessing
 
     def run(self):
@@ -33,8 +35,9 @@ class Transformations:
             A new Pandas DataFrame with treated / transformed target values.
         """
         imputed_df = self._missing_value_imputation(self.data)
+        sorted_df = self._sort_by_datetime_col(imputed_df)
         if self.preprocessing:
-            treated_df = self._outlier_treatment(imputed_df)
+            treated_df = self._outlier_treatment(sorted_df)
         else:
             logger.info("Skipping outlier treatment as preprocessing is disabled")
             treated_df = imputed_df
@@ -53,8 +56,9 @@ class Transformations:
             A new Pandas DataFrame without missing values.
         """
         # missing value imputation using linear interpolation
-        df[self.target_variables] = df.groupby(self.series_id_column)[self.target_variables].transform(
-            lambda x: x.interpolate(limit_direction='both'))
+        df[self.target_variables] = df.groupby(self.series_id_column)[
+            self.target_variables
+        ].transform(lambda x: x.interpolate(limit_direction="both"))
         return df
 
     def _outlier_treatment(self, df):
@@ -69,10 +73,39 @@ class Transformations:
         -------
             A new Pandas DataFrame with treated outliears.
         """
-        df['z_score'] = df.groupby(self.series_id_column)[self.target_variables].transform(
-            lambda x: (x - x.mean()) / x.std())
-        outliers_mask = df['z_score'].abs() > 3
-        df.loc[outliers_mask, self.target_variables] = df.groupby(self.series_id_column)[
-            self.target_variables].transform(lambda x: x.mean())
-        df.drop('z_score', axis=1, inplace=True)
+        df["z_score"] = df.groupby(self.series_id_column)[
+            self.target_variables
+        ].transform(lambda x: (x - x.mean()) / x.std())
+        outliers_mask = df["z_score"].abs() > 3
+        df.loc[outliers_mask, self.target_variables] = df.groupby(
+            self.series_id_column
+        )[self.target_variables].transform(lambda x: x.mean())
+        df.drop("z_score", axis=1, inplace=True)
+        return df
+
+    def _sort_by_datetime_col(self, df):
+        """
+        Function sorts by date
+
+        Parameters
+        ----------
+            df : The Pandas DataFrame.
+
+        Returns
+        -------
+            A new Pandas DataFrame with sorted dates for each category
+        """
+        import pandas as pd
+
+        # Temporary column for sorting
+        df["tmp_col_for_sorting"] = pd.to_datetime(
+            df[self.date_column], format=self.date_format
+        )
+        df = (
+            df.groupby(self.series_id_column)
+            .apply(lambda x: x.sort_values(by="tmp_col_for_sorting", ascending=True))
+            .reset_index(drop=True)
+        )
+        # Drop the temporary column
+        df.drop(columns=["tmp_col_for_sorting"], inplace=True)
         return df

--- a/ads/opctl/operator/lowcode/forecast/utils.py
+++ b/ads/opctl/operator/lowcode/forecast/utils.py
@@ -340,12 +340,13 @@ def _build_metrics_df(y_true, y_pred, column_name):
     return pd.DataFrame.from_dict(metrics, orient="index", columns=[column_name])
 
 
-def evaluate_metrics(target_columns, data, outputs, target_col="yhat"):
+def evaluate_metrics(target_columns, data, outputs, datetime_col, target_col="yhat"):
     total_metrics = pd.DataFrame()
     for idx, col in enumerate(target_columns):
         try:
-            y_true = np.asarray(data[col])
-            y_pred = np.asarray(outputs[idx][target_col][: len(y_true)])
+            dates = np.intersect1d(data[datetime_col], outputs[idx]["ds"])
+            y_true = np.asarray(data[col][data[datetime_col].isin(dates)])
+            y_pred = outputs[idx][outputs[idx]["ds"].isin(dates)][target_col]
 
             metrics_df = _build_metrics_df(
                 y_true=y_true, y_pred=y_pred, column_name=col

--- a/ads/opctl/operator/lowcode/forecast/utils.py
+++ b/ads/opctl/operator/lowcode/forecast/utils.py
@@ -503,7 +503,9 @@ def get_frequency_of_datetime(data: pd.DataFrame, dataset_info: ForecastOperator
 
     """
     date_column = dataset_info.datetime_column.name
-    datetimes = pd.to_datetime(data[date_column].drop_duplicates())
+    datetimes = pd.to_datetime(
+        data[date_column].drop_duplicates(), format=dataset_info.datetime_column.format
+    )
     freq = pd.DatetimeIndex(datetimes).inferred_freq
     if dataset_info.model == SupportedModels.AutoMLX:
         freq_in_secs = datetimes.tail().diff().min().total_seconds()

--- a/tests/unitary/with_extras/operator/forecast/test_model_automlx.py
+++ b/tests/unitary/with_extras/operator/forecast/test_model_automlx.py
@@ -4,8 +4,145 @@
 # Copyright (c) 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
+import unittest
+from unittest.mock import patch, Mock
+import pandas as pd
+import datapane as dp
+from ads.opctl.operator.lowcode.forecast.model.automlx import AutoMLXOperatorModel
 
-class TestAutoMLXOperatorModel:
+from ads.opctl.operator.lowcode.forecast.operator_config import (
+    ForecastOperatorConfig,
+    ForecastOperatorSpec,
+    DateTimeColumn,
+    InputData,
+)
+
+
+class TestAutoMLXOperatorModel(unittest.TestCase):
     """Tests the automlx operator model class."""
 
-    pass
+    def setUp(self):
+        self.target_columns = ["Sales_Product Group 107", "Sales_Product Group 108"]
+        self.target_category_columns = ["PPG_Code"]
+        self.test_filename = "test.csv"
+        self.primary_data = pd.DataFrame(
+            {
+                "PPG_Code": [
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                ],
+                "last_day_of_week": [
+                    "12-01-2019",
+                    "19-01-2019",
+                    "05-01-2019",
+                    "26-01-2019",
+                    "02-02-2019",
+                    "09-02-2019",
+                    "16-02-2019",
+                    "23-02-2019",
+                    "02-03-2019",
+                    "09-03-2019",
+                    "16-03-2019",
+                ],
+                "Sales": [
+                    2187.0,
+                    1149.0,
+                    2070.0,
+                    5958.0,
+                    9540.0,
+                    2883.0,
+                    968.0,
+                    1245.0,
+                    1689.0,
+                    1514.0,
+                    1083.0,
+                ],
+            }
+        )
+        self.additional_data = pd.DataFrame(
+            {
+                "PPG_Code": [
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                    "Product Group 107",
+                ],
+                "last_day_of_week": [
+                    "12-01-2019",
+                    "19-01-2019",
+                    "05-01-2019",
+                    "26-01-2019",
+                    "02-02-2019",
+                    "09-02-2019",
+                    "16-02-2019",
+                    "23-02-2019",
+                    "02-03-2019",
+                    "09-03-2019",
+                    "16-03-2019",
+                    "23-03-2019",
+                ],
+                "pt1": [0, 0, 0, 3, 7, 4, 0, 0, 0, 0, 0, 0],
+            }
+        )
+
+        self.target_col = "yhat"
+        self.datetime_column_name = "last_day_of_week"
+        self.original_target_column = "Sales"
+
+        spec = Mock(spec=ForecastOperatorSpec)
+        spec.target_column = self.target_col
+        spec.target_category_columns = self.target_category_columns
+        spec.target_column = self.original_target_column
+        spec.datetime_column = Mock(spec=DateTimeColumn)
+        spec.datetime_column.name = self.datetime_column_name
+        spec.datetime_column.format = "%d-%m-%Y"
+        spec.horizon = 1
+        spec.tuning = None
+        spec.confidence_interval_width = None
+        spec.historical_data = Mock(spec="InputData")
+        spec.historical_data.url = "primary.csv"
+        spec.historical_data.format = None
+        spec.historical_data.columns = None
+        spec.additional_data = Mock(spec="InputData")
+        spec.additional_data.url = "additional.csv"
+        spec.additional_data.format = None
+        spec.additional_data.columns = None
+        spec.model_kwargs = {}
+        config = Mock(spec=ForecastOperatorConfig)
+        config.spec = spec
+
+        self.config = config
+
+    @patch("ads.opctl.operator.lowcode.forecast.utils._call_pandas_fsspec")
+    def test_automlx_for_unsorted_data(self, mock__call_pandas_fsspec):
+        mock__call_pandas_fsspec.side_effect = (
+            lambda read_fn, filename, storage_options: self.primary_data
+            if filename == "primary.csv"
+            else self.additional_data
+        )
+        automlx = AutoMLXOperatorModel(self.config)
+
+        automlx._load_data()
+        outputs = automlx._build_model()
+        self.assertFalse(outputs.empty)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unitary/with_extras/operator/forecast/test_model_base_model.py
+++ b/tests/unitary/with_extras/operator/forecast/test_model_base_model.py
@@ -17,7 +17,6 @@ from ads.opctl.operator.lowcode.forecast.operator_config import (
     ForecastOperatorSpec,
     TestData,
     DateTimeColumn,
-    Horizon,
 )
 from ads.opctl.operator.lowcode.forecast.const import SupportedMetrics
 
@@ -40,8 +39,10 @@ from ads.opctl.operator.lowcode.forecast.operator_config import (
 )
 from ads.opctl.operator.lowcode.forecast.const import SupportedMetrics
 
+
 class TestForecastOperatorBaseModel(unittest.TestCase):
     """Tests the base class for the forecasting models"""
+
     def setUp(self):
         self.target_columns = ["Sales_Product Group 107", "Sales_Product Group 108"]
         self.target_category_columns = ["PPG_Code"]
@@ -98,9 +99,13 @@ class TestForecastOperatorBaseModel(unittest.TestCase):
                 }
             ),
         ]
+        self.data = pd.DataFrame({"last_day_of_week": ["2020-10-31", "2020-11-07"]})
         self.target_col = "yhat"
         self.datetime_column_name = "last_day_of_week"
         self.original_target_column = "Sales"
+        self.eval_metrics = pd.DataFrame(
+            {"Sales_Product Group 107": [25.07]}, index=["sMAPE"]
+        )
         self.evaluation_metrics = [
             SupportedMetrics.SMAPE,
             SupportedMetrics.MAPE,
@@ -297,8 +302,7 @@ class TestForecastOperatorBaseModel(unittest.TestCase):
         # All metrics should be present
         self.assertEquals(total_metrics.index.to_list(), self.evaluation_metrics)
         self.assertEquals(summary_metrics.columns.to_list(), self.summary_metrics)
-        
-        
+
     @patch("datapane.save_report")
     @patch("ads.opctl.operator.lowcode.forecast.utils.get_forecast_plots")
     @patch("ads.opctl.operator.lowcode.forecast.utils.evaluate_metrics")


### PR DESCRIPTION
https://jira.oci.oraclecorp.com/browse/ODSC-49028
Added code to sort primary and additional data by datetime column
Added format parmater to the to_datetime function calls, so that it doesn't infer wrong format.
Added unit test for automlx on unsorted data

https://jira.oci.oraclecorp.com/browse/ODSC-48265
Added fix in evaluate_metrics function