### PR TITLE
ODSC-49565/corrections in metrics calculation per horizon

### DIFF
--- a/ads/opctl/operator/lowcode/forecast/model/base_model.py
+++ b/ads/opctl/operator/lowcode/forecast/model/base_model.py
@@ -25,6 +25,7 @@ from .transformations import Transformations
 from ads.common.decorator.runtime_dependency import runtime_dependency
 from .forecast_datasets import ForecastDatasets
 
+
 class ForecastOperatorBaseModel(ABC):
     """The base class for the forecast operator models."""
 
@@ -350,24 +351,25 @@ class ForecastOperatorBaseModel(ABC):
                     horizon_periods=self.spec.horizon,
                 )
 
-                summary_metrics = summary_metrics.append(metrics_per_horizon)
+                if not metrics_per_horizon.empty:
+                    summary_metrics = summary_metrics.append(metrics_per_horizon)
 
-                new_column_order = [
-                    SupportedMetrics.MEAN_SMAPE,
-                    SupportedMetrics.MEDIAN_SMAPE,
-                    SupportedMetrics.MEAN_MAPE,
-                    SupportedMetrics.MEDIAN_MAPE,
-                    SupportedMetrics.MEAN_WMAPE,
-                    SupportedMetrics.MEDIAN_WMAPE,
-                    SupportedMetrics.MEAN_RMSE,
-                    SupportedMetrics.MEDIAN_RMSE,
-                    SupportedMetrics.MEAN_R2,
-                    SupportedMetrics.MEDIAN_R2,
-                    SupportedMetrics.MEAN_EXPLAINED_VARIANCE,
-                    SupportedMetrics.MEDIAN_EXPLAINED_VARIANCE,
-                    SupportedMetrics.ELAPSED_TIME,
-                ]
-                summary_metrics = summary_metrics[new_column_order]
+                    new_column_order = [
+                        SupportedMetrics.MEAN_SMAPE,
+                        SupportedMetrics.MEDIAN_SMAPE,
+                        SupportedMetrics.MEAN_MAPE,
+                        SupportedMetrics.MEDIAN_MAPE,
+                        SupportedMetrics.MEAN_WMAPE,
+                        SupportedMetrics.MEDIAN_WMAPE,
+                        SupportedMetrics.MEAN_RMSE,
+                        SupportedMetrics.MEDIAN_RMSE,
+                        SupportedMetrics.MEAN_R2,
+                        SupportedMetrics.MEDIAN_R2,
+                        SupportedMetrics.MEAN_EXPLAINED_VARIANCE,
+                        SupportedMetrics.MEDIAN_EXPLAINED_VARIANCE,
+                        SupportedMetrics.ELAPSED_TIME,
+                    ]
+                    summary_metrics = summary_metrics[new_column_order]
 
         return total_metrics, summary_metrics, data
 

--- a/ads/opctl/operator/lowcode/forecast/model/forecast_datasets.py
+++ b/ads/opctl/operator/lowcode/forecast/model/forecast_datasets.py
@@ -57,9 +57,9 @@ class ForecastDatasets:
                 storage_options=default_signer(),
                 columns=spec.additional_data.columns,
             )
-            additional_data = Transformations(
-                raw_data, self.spec
-            )._sort_by_datetime_col(additional_data)
+            additional_data = Transformations(raw_data, spec)._sort_by_datetime_col(
+                additional_data
+            )
 
             self.original_additional_data = additional_data.copy()
             self.original_total_data = pd.concat([data, additional_data], axis=1)


### PR DESCRIPTION
1. When test data has more values than horizon, operator fails.
2. When there is a horizon value missing for all series in test data, then test dataframe wont have that horizon. In the present code, that missing horizon is not removed from outputs so there is mismatch in the metrics calculation per horizon i.e; mismatch in the horizon picked from outputs and test data.
Changes:
outputs and test data frames should have same dates. So removed the extra dates that are not present in both test data & outputs and ensured that the dates are sorted in both dataframes so that there is no mismatch in metrics calculation.