### PR TITLE
 Update Docs to link to Github for sample notebooks

### DIFF
--- a/docs/source/user_guide/apachespark/dataflow-spark-magic.rst
+++ b/docs/source/user_guide/apachespark/dataflow-spark-magic.rst
@@ -23,8 +23,8 @@ This section demonstrates how to run interactive Spark workloads on a long lasti
 
 **Notebook Examples:**
 
-* `Introduction to the Oracle Cloud Infrastructure Data Flow Studio <https://github.com/oracle-samples/oci-data-science-ai-samples/blob/master/notebook_examples/pyspark-data_flow_studio-introduction.ipynb>`__
-* `Spark NLP within Oracle Cloud Infrastructure Data Flow Studio <https://github.com/oracle-samples/oci-data-science-ai-samples/blob/master/notebook_examples/pyspark-data_flow_studio-spark_nlp.ipynb>`__
+* `Introduction to the Oracle Cloud Infrastructure Data Flow Studio <https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/notebook_examples/pyspark-data_flow_studio-introduction.ipynb>`_
+* `Spark NLP within Oracle Cloud Infrastructure Data Flow Studio <https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/notebook_examples/pyspark-data_flow_studio-spark_nlp.ipynb>`_
 
 Prerequisite
 ============
@@ -72,7 +72,7 @@ Data Flow Spark Magic is used for interactively working with remote Spark cluste
 
   %load_ext dataflow.magics
 
-Use the `%help` method to get a list of all the available commands, along with a list of their arguments and example calls.
+Use the ``%help`` method to get a list of all the available commands, along with a list of their arguments and example calls.
 
 .. code-block:: python
 
@@ -130,7 +130,7 @@ To help you save resources and reduce time on management, Spark `dynamic allocat
 
 **Example command with third-party libraries**
 
-The Data Flow Sessions support `custom dependencies <https://docs.oracle.com/iaas/data-flow/using/third-party-libraries.htm>`__ in the form of Python wheels or virtual environments. You might want to make native code or other assets available within your Spark runtime. The dependencies can be attached by using the `archiveUri` attribute.
+The Data Flow Sessions support `custom dependencies <https://docs.oracle.com/iaas/data-flow/using/third-party-libraries.htm>`__ in the form of Python wheels or virtual environments. You might want to make native code or other assets available within your Spark runtime. The dependencies can be attached by using the ``archiveUri`` attribute.
 
 .. code-block:: python
 
@@ -148,7 +148,7 @@ The Data Flow Sessions support `custom dependencies <https://docs.oracle.com/iaa
 
 **Example command with the Data Catalog Hive Metastore**
 
-The `Data Catalog Hive Metastore <https://docs.oracle.com/iaas/data-catalog/using/metastore.htm>`__  provides schema definitions for objects in structured and unstructured data assets. Use the `metastoreId` to access the Data Catalog Metastore.
+The `Data Catalog Hive Metastore <https://docs.oracle.com/iaas/data-catalog/using/metastore.htm>`__  provides schema definitions for objects in structured and unstructured data assets. Use the ``metastoreId`` to access the Data Catalog Metastore.
 
 .. code-block:: python
 
@@ -195,7 +195,7 @@ Example path : ``oci://<your-bucket>@<your-tenancy-namespace>/conda_environments
 
 .. versionadded:: 2.8.7
 
-The `Data Flow Pools <https://docs.oracle.com/en-us/iaas/data-flow/using/pools.htm>`__  achieve fast job startup, resource isolation, manage budgets, and prioritize your Spark workloads. Use the `poolId` to use the Pool resources.
+The `Data Flow Pools <https://docs.oracle.com/en-us/iaas/data-flow/using/pools.htm>`__  achieve fast job startup, resource isolation, manage budgets, and prioritize your Spark workloads. Use the ``poolId`` to use the Pool resources.
 
 .. code-block:: python
 
@@ -256,7 +256,7 @@ To re-activate the existing session, use the ``%activate_session`` magic command
 
 Use Existing Session
 ********************
-To connect to the existing session use the `%use_session` magic command.
+To connect to the existing session use the ``%use_session`` magic command.
 
 .. code-block:: python
 

--- a/docs/source/user_guide/configuration/authentication.rst
+++ b/docs/source/user_guide/configuration/authentication.rst
@@ -27,7 +27,7 @@ Within your notebook session, you can choose to use the resource principal to au
 API Keys
 ========
 
-This is the default method of authentication. You can also authenticate as your own personal IAM user by creating or uploading OCI configuration and API key files inside your notebook session environment. The OCI configuration file contains the necessary credentials to authenticate your user against the model catalog and other OCI services like Object Storage. The example notebook, `api_keys.ipynb` demonstrates how to create these files.
+This is the default method of authentication. You can also authenticate as your own personal IAM user by creating or uploading OCI configuration and API key files inside your notebook session environment. The OCI configuration file contains the necessary credentials to authenticate your user against the model catalog and other OCI services like Object Storage. To setup API Key refer to `Required Keys and OCIDs <https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm>`_ and `SDK and CLI Configuration File <https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm>`_.
 
 The ``getting-started.ipynb`` notebook in the home directory of the notebook session environment demonstrates all the steps needed to create the configuration file and the keys. Follow the steps in that notebook before importing and using ADS in your notebooks.
 
@@ -79,4 +79,3 @@ In the this example, the default authentication uses API keys specified with the
   os_auth = authutil.resource_principal() # use resource principal to as the preferred way to access object store
 
 ``AuthContext`` context class can also be used to specify the desired type of authentication. It supports API key configuration, resource principal, and instance principal authentication, as well as predefined signers, callable signers, or API keys configurations from specified locations. See `API Documentation <../../ads.common.html#ads.common.auth.AuthContext>`__ for more details.
-

--- a/docs/source/user_guide/configuration/autonomous_database.rst
+++ b/docs/source/user_guide/configuration/autonomous_database.rst
@@ -33,7 +33,7 @@ Use these steps to access Oracle ADB:
 
   METHOD_DATA = (DIRECTORY="<path_to_wallet_folder>")
 
-7. To find the location of the ``sqlnet.ora`` file, the ``TNS_ADMIN`` environment variable must point to that location. We suggest that you create a Python dictionary to store all of the connection information. In this example, this dictionary is called ``creds``. It is generally poor security practice to store credentials in your notebook. We recommend that you use the ``ads-examples/ADB_working_with.ipynb`` notebook example that demonstrates how to store them outside the notebook in a configuration file.
+7. To find the location of the ``sqlnet.ora`` file, the ``TNS_ADMIN`` environment variable must point to that location. We suggest that you create a Python dictionary to store all of the connection information. In this example, this dictionary is called ``creds``. It is generally poor security practice to store credentials in your notebook. We recommend that you use the `Bank Graph Example Notebook <https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/notebook_examples/graph_insight-autonomous_database.ipynb>`_ notebook example that demonstrates how to store them outside the notebook in a configuration file.
 
    The environment variable should be set in your notebooks. For example: 
 
@@ -72,4 +72,3 @@ Messages similar to the following display if the connection is successful:
      :align: center
 
 An introduction to loading data from ADB into ADS using ``cx_Oracle`` and ``SQLAlchemy`` is in :ref:`Loading Data <loading-data-10>`.
-

--- a/docs/source/user_guide/configuration/configuration.rst
+++ b/docs/source/user_guide/configuration/configuration.rst
@@ -32,7 +32,7 @@ Within your notebook session, you can choose to use the resource principal to au
 **2. Authenticating Using API Keys**
 ---------------------------------------------------------------------------------------------
 
-This is the default method of authentication. You can also authenticate as your own personal IAM user by creating or uploading OCI configuration and API key files inside your notebook session environment. The OCI configuration file contains the necessary credentials to authenticate your user against the model catalog and other OCI services like Object Storage. The example notebook, `api_keys.ipynb` demonstrates how to create these files.
+This is the default method of authentication. You can also authenticate as your own personal IAM user by creating or uploading OCI configuration and API key files inside your notebook session environment. The OCI configuration file contains the necessary credentials to authenticate your user against the model catalog and other OCI services like Object Storage. To setup API Key refer to `Required Keys and OCIDs <https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm>`_ and `SDK and CLI Configuration File <https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm>`_.
 
 The ``getting-started.ipynb`` notebook in the home directory of the notebook session environment demonstrates all the steps needed to create the configuration file and the keys. Follow the steps in that notebook before importing and using ADS in your notebooks.
 
@@ -117,7 +117,7 @@ Use these steps to access Oracle ADB:
 
   METHOD_DATA = (DIRECTORY="<path_to_wallet_folder>")
 
-7. To find the location of the ``sqlnet.ora`` file, the ``TNS_ADMIN`` environment variable must point to that location. We suggest that you create a Python dictionary to store all of the connection information. In this example, this dictionary is called ``creds``. It is generally poor security practice to store credentials in your notebook. We recommend that you use the ``ads-examples/ADB_working_with.ipynb`` notebook example that demonstrates how to store them outside the notebook in a configuration file.
+7. To find the location of the ``sqlnet.ora`` file, the ``TNS_ADMIN`` environment variable must point to that location. We suggest that you create a Python dictionary to store all of the connection information. In this example, this dictionary is called ``creds``. It is generally poor security practice to store credentials in your notebook. We recommend that you use the `Bank Graph Example Notebook <https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/notebook_examples/graph_insight-autonomous_database.ipynb>`_ notebook example that demonstrates how to store them outside the notebook in a configuration file.
 
    The environment variable should be set in your notebooks. For example: 
 
@@ -440,11 +440,11 @@ dictionary. To store your secret, just modify the dictionary.
                   'password': 'MySecretPassword',
                   'database_type': 'oracle'}
 
-Note, to connect to an Oracle database the `database_name` value should be its 
+Note, to connect to an Oracle database the ``database_name`` value should be its
 connection identifier. You can find the connection identifier by extracting the 
-credential wallet zip file and opening the `tnsnames.ora` file 
+credential wallet zip file and opening the ``tnsnames.ora`` file
 (connection_identifier = (...)). Usually the connection identifier will 
-end with `_high`, `_medium` or `_low` i.e. `'MyDatabaseName_high'`.
+end with ``_high``, ``_medium`` or ``_low`` i.e. ``'MyDatabaseName_high'``.
 
 **Create a Vault**
 

--- a/docs/source/user_guide/data_flow/dataflow.rst
+++ b/docs/source/user_guide/data_flow/dataflow.rst
@@ -791,7 +791,7 @@ You can work with different compression formats within Data Flow. For example, s
 
 Other compression formats that Data Flow supports include snappy Parquet, and Gzip on both CSV and Parquet.
 
-You might have query that you want to run in Data Flow from previous explorations, review the `dataflow.ipynb` notebook example that shows you how to submit a job to Data Flow.
+You might have query that you want to run in Data Flow from previous explorations.
 
 .. code-block:: python3
 
@@ -1025,12 +1025,11 @@ The required variables to set up are:
    that the secret is the credential needed to access a database. This
    notebook is designed so that any secret can be stored as long as it
    is in the form of a dictionary. To store your secret, just modify the
-   dictionary, see the ``vault.ipynb`` example notebook for detailed
-   steps to generate this OCID.
+   dictionary.
 2. ``tnsname``: A TNS name valid for the database.
 3. ``wallet_path``: The local path to your wallet ZIP file, see the
-   ``autonomous_database.ipynb`` example notebook for instructions on
-   accessing the wallet file.
+   `Loading Data from Different Sources Using Pandas and Dask <https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/notebook_examples/load_data-object_storage-hive-autonomous-database.ipynb>`_
+   example notebook for instructions on accessing the wallet file.
 
 .. code-block:: python3
 
@@ -1137,4 +1136,3 @@ This notebook creates a table in your database with the name specified with ``ta
         )
     else:
         print("Skipping as it appears that you do not have tnsname specified.")
-

--- a/docs/source/user_guide/model_training/ads_tuner.rst
+++ b/docs/source/user_guide/model_training/ads_tuner.rst
@@ -341,7 +341,7 @@ space is being used for your model class when ``strategy`` is
 ``perfunctory`` or ``detailed`` use the ``search_space()`` method to see
 the details.
 
-The ``adstuner_search_space_update.ipynb`` notebook has detailed
+The `Introduction to ADSTuner <https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/notebook_examples/hyperparameter_tuning.ipynb>`_ notebook has detailed
 examples about how to work with and update the search space.
 
 The next cell displaces the search strategy and the search space.
@@ -363,7 +363,7 @@ parameter. When it is set to ``False``, the tuning process runs
 asynchronously so it runs in the background and allows you to continue
 your work in the notebook. When ``synchronous`` is set to ``True``, the
 notebook is blocked until ``tune()`` finishes running. The
-``adntuner_sync_and_async.ipynb`` notebook illustrates this feature in a
+`Introduction to ADSTuner <https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/notebook_examples/hyperparameter_tuning.ipynb>`_ notebook illustrates this feature in a
 more detailed way.
 
 The ``ADSTuner`` object needs to know when to stop tuning. The
@@ -739,7 +739,7 @@ You can change the search space in the following three ways:
 hyperparameter or make any changes to a hyperparameter that is based on
 a categorical distribution. You need to initiate a new ``ADSTuner``
 object for those cases. For more detailed information, review the
-``adstuner_search_space_update.ipynb`` notebook.
+`Introduction to ADSTuner <https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/notebook_examples/hyperparameter_tuning.ipynb>`_ notebook.
 
 The next cell switches to a ``detailed`` strategy. All previous values
 set for ``C``, ``solver``, and ``max_iter`` are kept, and ``ADSTuner``


### PR DESCRIPTION
### Description

In the various sections of the ADS docs that relate to sample notebooks, add links to github for those sample notebooks.
Jira: https://jira.oci.oraclecorp.com/browse/ODSC-34428

### What was done

- updated 6 doc rst files with links to github for sample notebook
- fixes for issues detected by pre-commit

### Pre-commit

```
check python ast.....................................(no files to check)Skipped
check docstring is first.............................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check yaml...........................................(no files to check)Skipped
detect private key.......................................................Passed
fix end of files.........................................................Passed
pretty format json...................................(no files to check)Skipped
trim trailing whitespace.............................(no files to check)Skipped
black................................................(no files to check)Skipped
rst ``code`` is two backticks............................................Passed
rst ``inline code`` next to normal text..................................Passed
Detect hardcoded secrets.................................................Passed
check-copyright......................................(no files to check)Skipped
[ODSC-34428/update_nbs_links_in_docs 49e8026] ODSC-34428. Update Docs to link to Github for sample notebooks
 6 files changed, 21 insertions(+), 25 deletions(-)
```