### PR TITLE
ODSC-49703: Move the ADS config errors into debug level.

### DIFF
--- a/ads/opctl/config/merger.py
+++ b/ads/opctl/config/merger.py
@@ -182,7 +182,7 @@ class ConfigMerger(ConfigProcessor):
                 "conda_pack_os_prefix": parser["CONDA"].get("conda_pack_os_prefix"),
             }
         else:
-            logger.info(
+            logger.debug(
                 f"{os.path.join(ads_config_folder, 'config.ini')} does not exist. No config loaded."
             )
             return {}
@@ -205,7 +205,7 @@ class ConfigMerger(ConfigProcessor):
             if DEFAULT_PROFILE in parser:
                 return parser[DEFAULT_PROFILE]
         else:
-            logger.info(
+            logger.debug(
                 f"{os.path.join(ads_config_folder, config_file)} does not exist. No config loaded."
             )
         return {}

--- a/ads/opctl/operator/lowcode/forecast/MLoperator
+++ b/ads/opctl/operator/lowcode/forecast/MLoperator
@@ -12,7 +12,6 @@ keywords:
   - LSTM
 backends:
   - job
-  - dataflow
 description: |
   Forecasting operator, that leverages historical time series data to generate accurate
   forecasts for future trends. Use `ads operator info -t forecast` to get more details about


### PR DESCRIPTION
## Description

In case if the ads config not created, the ADS shows the log info:

```
".ads_ops/<backend>_config.ini does not exist. No config loaded."
```

These messages was moved on the debug level. 

Also from the forecasting operator was removed supporting dataflow backend. This can easily returned back by demand.