### PR TITLE
Fixed model deployment failed return value

### DIFF
--- a/ads/model/deployment/model_deployment.py
+++ b/ads/model/deployment/model_deployment.py
@@ -614,17 +614,14 @@ class ModelDeployment(Builder):
             else self.properties.build()
         )
 
-        try:
-            response = self.dsc_model_deployment.create(
-                create_model_deployment_details=create_model_deployment_details,
-                wait_for_completion=wait_for_completion,
-                max_wait_time=max_wait_time,
-                poll_interval=poll_interval,
-            )
-        except Exception as ex:
-            raise ex
-        finally:
-            return self._update_from_oci_model(response)
+        response = self.dsc_model_deployment.create(
+            create_model_deployment_details=create_model_deployment_details,
+            wait_for_completion=wait_for_completion,
+            max_wait_time=max_wait_time,
+            poll_interval=poll_interval,
+        )
+
+        return self._update_from_oci_model(response)
 
     def delete(
         self,
@@ -650,16 +647,13 @@ class ModelDeployment(Builder):
         ModelDeployment
             The instance of ModelDeployment.
         """
-        try:
-            response = self.dsc_model_deployment.delete(
-                wait_for_completion=wait_for_completion,
-                max_wait_time=max_wait_time,
-                poll_interval=poll_interval,
-            )
-        except Exception as ex:
-            raise ex
-        finally:
-            return self._update_from_oci_model(response)
+        response = self.dsc_model_deployment.delete(
+            wait_for_completion=wait_for_completion,
+            max_wait_time=max_wait_time,
+            poll_interval=poll_interval,
+        )
+
+        return self._update_from_oci_model(response)
 
     def update(
         self,
@@ -715,17 +709,14 @@ class ModelDeployment(Builder):
             else self._update_model_deployment_details(**kwargs)
         )
 
-        try:
-            response = self.dsc_model_deployment.update(
-                update_model_deployment_details=update_model_deployment_details,
-                wait_for_completion=wait_for_completion,
-                max_wait_time=max_wait_time,
-                poll_interval=poll_interval,
-            )
-        except Exception as ex:
-            raise ex
-        finally:
-            return self._update_from_oci_model(response)
+        response = self.dsc_model_deployment.update(
+            update_model_deployment_details=update_model_deployment_details,
+            wait_for_completion=wait_for_completion,
+            max_wait_time=max_wait_time,
+            poll_interval=poll_interval,
+        )
+
+        return self._update_from_oci_model(response)
 
     def watch(
         self,
@@ -891,10 +882,10 @@ class ModelDeployment(Builder):
 
         """
         current_state = self.sync().lifecycle_state
-        if current_state != "ACTIVE":
+        if current_state != State.ACTIVE.name:
             raise ModelDeploymentPredictError(
-                f"Predict() can't be called when model deployment is `{current_state}`. "
-                "Make sure model deployment is `ACTIVE` before calling predict."
+                "This model deployment is not in active state, you will not be able to use predict end point. "
+                f"Current model deployment state: {current_state} "
             )
         endpoint = f"{self.url}/predict"
         signer = authutil.default_signer()["signer"]
@@ -991,16 +982,13 @@ class ModelDeployment(Builder):
         ModelDeployment
             The instance of ModelDeployment.
         """
-        try:
-            response = self.dsc_model_deployment.activate(
-                wait_for_completion=wait_for_completion,
-                max_wait_time=max_wait_time,
-                poll_interval=poll_interval,
-            )
-        except Exception as ex:
-            raise ex
-        finally:
-            return self._update_from_oci_model(response)
+        response = self.dsc_model_deployment.activate(
+            wait_for_completion=wait_for_completion,
+            max_wait_time=max_wait_time,
+            poll_interval=poll_interval,
+        )
+
+        return self._update_from_oci_model(response)
 
     def deactivate(
         self,
@@ -1026,16 +1014,13 @@ class ModelDeployment(Builder):
         ModelDeployment
             The instance of ModelDeployment.
         """
-        try:
-            response = self.dsc_model_deployment.deactivate(
-                wait_for_completion=wait_for_completion,
-                max_wait_time=max_wait_time,
-                poll_interval=poll_interval,
-            )
-        except Exception as ex:
-            raise ex
-        finally:
-            return self._update_from_oci_model(response)
+        response = self.dsc_model_deployment.deactivate(
+            wait_for_completion=wait_for_completion,
+            max_wait_time=max_wait_time,
+            poll_interval=poll_interval,
+        )
+
+        return self._update_from_oci_model(response)
 
     def _log_details(self, log_type: str = ModelDeploymentLogType.ACCESS):
         """Gets log details for the provided `log_type`.

--- a/ads/model/deployment/model_deployment.py
+++ b/ads/model/deployment/model_deployment.py
@@ -890,9 +890,11 @@ class ModelDeployment(Builder):
             Prediction results.
 
         """
-        if self.sync().lifecycle_state != "ACTIVE":
+        current_state = self.sync().lifecycle_state
+        if current_state != "ACTIVE":
             raise ModelDeploymentPredictError(
-                "Model Deployment must be in `ACTIVE` state before predict can be called."
+                f"Predict() can't be called when model deployment is in {current_state} state. "
+                "Make sure model deployment is `ACTIVE` before calling predict."
             )
         endpoint = f"{self.url}/predict"
         signer = authutil.default_signer()["signer"]

--- a/ads/model/deployment/model_deployment.py
+++ b/ads/model/deployment/model_deployment.py
@@ -893,7 +893,7 @@ class ModelDeployment(Builder):
         current_state = self.sync().lifecycle_state
         if current_state != "ACTIVE":
             raise ModelDeploymentPredictError(
-                f"Predict() can't be called when model deployment is in {current_state} state. "
+                f"Predict() can't be called when model deployment is `{current_state}`. "
                 "Make sure model deployment is `ACTIVE` before calling predict."
             )
         endpoint = f"{self.url}/predict"

--- a/ads/model/deployment/model_deployment.py
+++ b/ads/model/deployment/model_deployment.py
@@ -621,8 +621,8 @@ class ModelDeployment(Builder):
                 max_wait_time=max_wait_time,
                 poll_interval=poll_interval,
             )
-        except:
-            raise
+        except Exception as ex:
+            raise ex
         finally:
             return self._update_from_oci_model(response)
 
@@ -656,8 +656,8 @@ class ModelDeployment(Builder):
                 max_wait_time=max_wait_time,
                 poll_interval=poll_interval,
             )
-        except:
-            raise
+        except Exception as ex:
+            raise ex
         finally:
             return self._update_from_oci_model(response)
 
@@ -722,8 +722,8 @@ class ModelDeployment(Builder):
                 max_wait_time=max_wait_time,
                 poll_interval=poll_interval,
             )
-        except:
-            raise
+        except Exception as ex:
+            raise ex
         finally:
             return self._update_from_oci_model(response)
 
@@ -995,8 +995,8 @@ class ModelDeployment(Builder):
                 max_wait_time=max_wait_time,
                 poll_interval=poll_interval,
             )
-        except:
-            raise
+        except Exception as ex:
+            raise ex
         finally:
             return self._update_from_oci_model(response)
 
@@ -1030,8 +1030,8 @@ class ModelDeployment(Builder):
                 max_wait_time=max_wait_time,
                 poll_interval=poll_interval,
             )
-        except:
-            raise
+        except Exception as ex:
+            raise ex
         finally:
             return self._update_from_oci_model(response)
 

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -2325,8 +2325,8 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
                 detail="Deployed the model",
                 status=self.model_deployment.state.name.upper(),
             )
-        except:
-            raise
+        except Exception as ex:
+            raise ex
         finally:
             return self.model_deployment
 
@@ -2815,8 +2815,8 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
             logger.info(
                 f"Model deployment {self.model_deployment.model_deployment_id} has successfully been activated."
             )
-        except:
-            raise
+        except Exception as ex:
+            raise ex
         finally:
             return self.model_deployment
 

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -2324,13 +2324,13 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
                 max_wait_time=max_wait_time,
                 poll_interval=poll_interval,
             )
+        except Exception as ex:
+            raise ex
+        finally:
             self._summary_status.update_status(
                 detail="Deployed the model",
                 status=self.model_deployment.state.name.upper(),
             )
-        except Exception as ex:
-            raise ex
-        finally:
             return self.model_deployment
 
     def prepare_save_deploy(

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -1575,7 +1575,7 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         current_state = model_deployment.state.name.upper()
         if current_state != ModelDeploymentState.ACTIVE.name:
             logger.warning(
-                "Model deployment should be in `ACTIVE` state while being fetched. "
+                "This model deployment is not in active state, you will not be able to use predict end point. "
                 f"Current model deployment state: `{current_state}`"
             )
 
@@ -2318,20 +2318,16 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
             .with_runtime(runtime)
         )
 
-        try:
-            self.model_deployment = model_deployment.deploy(
-                wait_for_completion=wait_for_completion,
-                max_wait_time=max_wait_time,
-                poll_interval=poll_interval,
-            )
-        except Exception as ex:
-            raise ex
-        finally:
-            self._summary_status.update_status(
-                detail="Deployed the model",
-                status=self.model_deployment.state.name.upper(),
-            )
-            return self.model_deployment
+        self.model_deployment = model_deployment.deploy(
+            wait_for_completion=wait_for_completion,
+            max_wait_time=max_wait_time,
+            poll_interval=poll_interval,
+        )
+        self._summary_status.update_status(
+            detail="Deployed the model",
+            status=self.model_deployment.state.name.upper(),
+        )
+        return self.model_deployment
 
     def prepare_save_deploy(
         self,
@@ -2799,29 +2795,25 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         """
         if not self.model_deployment:
             raise ValueError("Use `deploy()` method to start model deployment.")
-        try:
-            logger.info(
-                f"Deactivating model deployment {self.model_deployment.model_deployment_id}."
-            )
-            self.model_deployment.deactivate(
-                max_wait_time=max_wait_time, poll_interval=poll_interval
-            )
-            logger.info(
-                f"Model deployment {self.model_deployment.model_deployment_id} has successfully been deactivated."
-            )
-            logger.info(
-                f"Activating model deployment {self.model_deployment.model_deployment_id}."
-            )
-            self.model_deployment.activate(
-                max_wait_time=max_wait_time, poll_interval=poll_interval
-            )
-            logger.info(
-                f"Model deployment {self.model_deployment.model_deployment_id} has successfully been activated."
-            )
-        except Exception as ex:
-            raise ex
-        finally:
-            return self.model_deployment
+        logger.info(
+            f"Deactivating model deployment {self.model_deployment.model_deployment_id}."
+        )
+        self.model_deployment.deactivate(
+            max_wait_time=max_wait_time, poll_interval=poll_interval
+        )
+        logger.info(
+            f"Model deployment {self.model_deployment.model_deployment_id} has successfully been deactivated."
+        )
+        logger.info(
+            f"Activating model deployment {self.model_deployment.model_deployment_id}."
+        )
+        self.model_deployment.activate(
+            max_wait_time=max_wait_time, poll_interval=poll_interval
+        )
+        logger.info(
+            f"Model deployment {self.model_deployment.model_deployment_id} has successfully been activated."
+        )
+        return self.model_deployment
 
     @class_or_instance_method
     def delete(

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -2315,16 +2315,20 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
             .with_runtime(runtime)
         )
 
-        self.model_deployment = model_deployment.deploy(
-            wait_for_completion=wait_for_completion,
-            max_wait_time=max_wait_time,
-            poll_interval=poll_interval,
-        )
-        self._summary_status.update_status(
-            detail="Deployed the model",
-            status=self.model_deployment.state.name.upper(),
-        )
-        return self.model_deployment
+        try:
+            self.model_deployment = model_deployment.deploy(
+                wait_for_completion=wait_for_completion,
+                max_wait_time=max_wait_time,
+                poll_interval=poll_interval,
+            )
+            self._summary_status.update_status(
+                detail="Deployed the model",
+                status=self.model_deployment.state.name.upper(),
+            )
+        except:
+            raise
+        finally:
+            return self.model_deployment
 
     def prepare_save_deploy(
         self,
@@ -2792,25 +2796,29 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         """
         if not self.model_deployment:
             raise ValueError("Use `deploy()` method to start model deployment.")
-        logger.info(
-            f"Deactivating model deployment {self.model_deployment.model_deployment_id}."
-        )
-        self.model_deployment.deactivate(
-            max_wait_time=max_wait_time, poll_interval=poll_interval
-        )
-        logger.info(
-            f"Model deployment {self.model_deployment.model_deployment_id} has successfully been deactivated."
-        )
-        logger.info(
-            f"Activating model deployment {self.model_deployment.model_deployment_id}."
-        )
-        self.model_deployment.activate(
-            max_wait_time=max_wait_time, poll_interval=poll_interval
-        )
-        logger.info(
-            f"Model deployment {self.model_deployment.model_deployment_id} has successfully been activated."
-        )
-        return self.model_deployment
+        try:
+            logger.info(
+                f"Deactivating model deployment {self.model_deployment.model_deployment_id}."
+            )
+            self.model_deployment.deactivate(
+                max_wait_time=max_wait_time, poll_interval=poll_interval
+            )
+            logger.info(
+                f"Model deployment {self.model_deployment.model_deployment_id} has successfully been deactivated."
+            )
+            logger.info(
+                f"Activating model deployment {self.model_deployment.model_deployment_id}."
+            )
+            self.model_deployment.activate(
+                max_wait_time=max_wait_time, poll_interval=poll_interval
+            )
+            logger.info(
+                f"Model deployment {self.model_deployment.model_deployment_id} has successfully been activated."
+            )
+        except:
+            raise
+        finally:
+            return self.model_deployment
 
     @class_or_instance_method
     def delete(

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -1574,7 +1574,10 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
 
         current_state = model_deployment.state.name.upper()
         if current_state != ModelDeploymentState.ACTIVE.name:
-            raise NotActiveDeploymentError(current_state)
+            logger.warning(
+                "Model deployment should be in `ACTIVE` state while being fetched. "
+                f"Current model deployment state: `{current_state}`"
+            )
 
         model = cls.from_model_catalog(
             model_id=model_deployment.properties.model_id,

--- a/ads/model/service/oci_datascience_model_deployment.py
+++ b/ads/model/service/oci_datascience_model_deployment.py
@@ -212,6 +212,8 @@ class OCIDataScienceModelDeployment(
                         f"Error while trying to activate model deployment: {self.id}"
                     )
                     raise e
+                finally:
+                    return self.sync()
 
             return self.sync()
         else:
@@ -264,6 +266,8 @@ class OCIDataScienceModelDeployment(
                     f"Error while trying to create model deployment: {self.id}"
                 )
                 raise e
+            finally:
+                return self.sync()
 
         return self.sync()
 
@@ -328,6 +332,8 @@ class OCIDataScienceModelDeployment(
                         f"Error while trying to deactivate model deployment: {self.id}"
                     )
                     raise e
+                finally:
+                    return self.sync()
 
             return self.sync()
         else:
@@ -399,6 +405,8 @@ class OCIDataScienceModelDeployment(
                     f"Error while trying to delete model deployment: {self.id}"
                 )
                 raise e
+            finally:
+                return self.sync()
 
         return self.sync()
 
@@ -454,8 +462,8 @@ class OCIDataScienceModelDeployment(
         except Exception as e:
             logger.error(f"Error while trying to update model deployment: {self.id}")
             raise e
-
-        return self.sync()
+        finally:
+            return self.sync()
 
     @classmethod
     def list(

--- a/ads/model/service/oci_datascience_model_deployment.py
+++ b/ads/model/service/oci_datascience_model_deployment.py
@@ -209,11 +209,8 @@ class OCIDataScienceModelDeployment(
                     )
                 except Exception as e:
                     logger.error(
-                        f"Error while trying to activate model deployment: {self.id}"
+                        "Error while trying to activate model deployment: " + str(e)
                     )
-                    raise e
-                finally:
-                    return self.sync()
 
             return self.sync()
         else:
@@ -263,11 +260,8 @@ class OCIDataScienceModelDeployment(
                 )
             except Exception as e:
                 logger.error(
-                    f"Error while trying to create model deployment: {self.id}"
+                    "Error while trying to create model deployment: " + str(e)
                 )
-                raise e
-            finally:
-                return self.sync()
 
         return self.sync()
 
@@ -329,11 +323,8 @@ class OCIDataScienceModelDeployment(
                     )
                 except Exception as e:
                     logger.error(
-                        f"Error while trying to deactivate model deployment: {self.id}"
+                        "Error while trying to deactivate model deployment: " + str(e)
                     )
-                    raise e
-                finally:
-                    return self.sync()
 
             return self.sync()
         else:
@@ -402,11 +393,8 @@ class OCIDataScienceModelDeployment(
                 )
             except Exception as e:
                 logger.error(
-                    f"Error while trying to delete model deployment: {self.id}"
+                    "Error while trying to delete model deployment: " + str(e)
                 )
-                raise e
-            finally:
-                return self.sync()
 
         return self.sync()
 
@@ -460,10 +448,11 @@ class OCIDataScienceModelDeployment(
             )
             self.workflow_req_id = response.headers.get("opc-work-request-id", None)
         except Exception as e:
-            logger.error(f"Error while trying to update model deployment: {self.id}")
-            raise e
-        finally:
-            return self.sync()
+            logger.error(
+                "Error while trying to update model deployment: " + str(e)
+            )
+
+        return self.sync()
 
     @classmethod
     def list(

--- a/tests/unitary/default_setup/model_deployment/test_model_deployment.py
+++ b/tests/unitary/default_setup/model_deployment/test_model_deployment.py
@@ -28,8 +28,10 @@ class ModelDeploymentTestCase(unittest.TestCase):
         )
 
     @patch("requests.post")
-    def test_predict(self, mock_post):
+    @patch("ads.model.deployment.model_deployment.ModelDeployment.sync")
+    def test_predict(self, mock_sync, mock_post):
         """Ensures predict model passes with valid input parameters."""
+        mock_sync.return_value = Mock(lifecycle_state="ACTIVE")
         mock_post.return_value = Mock(
             status_code=200, json=lambda: {"result": "result"}
         )
@@ -50,8 +52,10 @@ class ModelDeploymentTestCase(unittest.TestCase):
             self.test_model_deployment.predict(data=np.array([1, 2, 3]))
 
     @patch("requests.post")
-    def test_predict_with_bytes(self, mock_post):
+    @patch("ads.model.deployment.model_deployment.ModelDeployment.sync")
+    def test_predict_with_bytes(self, mock_sync, mock_post):
         """Ensures predict model passes with bytes input."""
+        mock_sync.return_value = Mock(lifecycle_state="ACTIVE")
         byte_data = b"[[1,2,3,4]]"
         with patch.object(authutil, "default_signer") as mock_auth:
             auth = MagicMock()
@@ -66,8 +70,10 @@ class ModelDeploymentTestCase(unittest.TestCase):
             )
 
     @patch("requests.post")
-    def test_predict_with_auto_serialize_data(self, mock_post):
+    @patch("ads.model.deployment.model_deployment.ModelDeployment.sync")
+    def test_predict_with_auto_serialize_data(self, mock_sync, mock_post):
         """Ensures predict model passes with valid input parameters."""
+        mock_sync.return_value = Mock(lifecycle_state="ACTIVE")
         mock_post.return_value = Mock(
             status_code=200, json=lambda: {"result": "result"}
         )

--- a/tests/unitary/with_extras/model/test_generic_model.py
+++ b/tests/unitary/with_extras/model/test_generic_model.py
@@ -1051,45 +1051,6 @@ class TestGenericModel:
 
         assert test_result == test_model
 
-    @patch.object(
-        ModelDeployment,
-        "state",
-        new_callable=PropertyMock,
-        return_value=ModelDeploymentState.FAILED,
-    )
-    @patch.object(ModelDeployment, "from_id")
-    @patch("ads.common.auth.default_signer")
-    @patch("ads.common.oci_client.OCIClientFactory")
-    def test_from_model_deployment_fail(
-        self,
-        mock_client,
-        mock_default_signer,
-        mock_from_id,
-        mock_model_deployment_state,
-    ):
-        """Tests loading model from model deployment."""
-        test_auth_config = {"signer": {"config": "value"}}
-        mock_default_signer.return_value = test_auth_config
-        test_model_deployment_id = "md_ocid"
-        test_model_id = "model_ocid"
-        md_props = ModelDeploymentProperties(model_id=test_model_id)
-        md = ModelDeployment(properties=md_props)
-        mock_from_id.return_value = md
-
-        with pytest.raises(NotActiveDeploymentError):
-            GenericModel.from_model_deployment(
-                model_deployment_id=test_model_deployment_id,
-                model_file_name="test.pkl",
-                artifact_dir="test_dir",
-                auth=test_auth_config,
-                force_overwrite=True,
-                properties=None,
-                bucket_uri="test_bucket_uri",
-                remove_existing_artifact=True,
-                compartment_id="test_compartment_id",
-            )
-            mock_from_id.assert_called_with(test_model_deployment_id)
-
     @patch.object(ModelDeployment, "update")
     @patch.object(ModelDeployment, "from_id")
     @patch("ads.common.auth.default_signer")


### PR DESCRIPTION
### Fixed model deployment failed return value

- Every time when a service error raises, log this error and return the model deployment object. The model deployment object can continue calling logging
- Raise error for model deployment that's not in `ACTIVE` state


