### PR TITLE
Fix version of lightgbm to be <4.0.0

### DIFF
--- a/.github/workflows/run-unittests-py38-cov-report.yml
+++ b/.github/workflows/run-unittests-py38-cov-report.yml
@@ -39,8 +39,8 @@ jobs:
             # `model` tests running in "slow_tests",
             # `feature_store` tests has its own test suite
             ignore-path: |
-              --ignore tests/unitary/with_extras/model
-              --ignore tests/unitary/with_extras/feature_store
+              --ignore tests/unitary/with_extras/model \
+              --ignore tests/unitary/with_extras/feature_store \
               --ignore tests/unitary/with_extras/hpo
           - name: "slow_tests"
             test-path: "tests/unitary/with_extras/model"

--- a/.github/workflows/run-unittests-py38-cov-report.yml
+++ b/.github/workflows/run-unittests-py38-cov-report.yml
@@ -87,7 +87,7 @@ jobs:
           ln -s ../ads ads
           ln -s ../.coveragerc .coveragerc
 
-          "Run hpo tests, which hangs if run together with all unitary tests"
+          # Run hpo tests, which hangs if run together with all unitary tests
           if [[ ${{ matrix.name }} ==  "unitary" ]]; then
             python -m pytest -v -p no:warnings -n auto --dist loadfile \
             --cov-append --cov=ads --cov-report=xml --cov-report=html \

--- a/.github/workflows/run-unittests-py38-cov-report.yml
+++ b/.github/workflows/run-unittests-py38-cov-report.yml
@@ -32,13 +32,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-path: ["tests/unitary/with_extras tests/unitary/default_setup", "tests/unitary/with_extras/model"]
+        name: ["unitary", "slow_tests"]
         include:
-          - test-path: "tests/unitary/with_extras tests/unitary/default_setup"
-            ignore-path: "--ignore tests/unitary/with_extras/model --ignore tests/unitary/with_extras/feature_store"
-            name: "unitary"
-          - test-path: "tests/unitary/with_extras/model"
-            name: "model"
+          - name: "unitary"
+            test-path: "tests/unitary"
+            # `model` tests running in "slow_tests",
+            # `feature_store` tests has its own test suite
+            ignore-path: |
+              --ignore tests/unitary/with_extras/model
+              --ignore tests/unitary/with_extras/feature_store
+              --ignore tests/unitary/with_extras/hpo
+          - name: "slow_tests"
+            test-path: "tests/unitary/with_extras/model"
 
     steps:
       - uses: actions/checkout@v3
@@ -68,7 +73,7 @@ jobs:
           pip install -e ".[forecast]"
 
       - name: "Run unitary tests folder with maximum ADS dependencies"
-        timeout-minutes: 60
+        timeout-minutes: 40
         shell: bash
         env:
           CONDA_PREFIX: /usr/share/miniconda
@@ -82,9 +87,17 @@ jobs:
           ln -s ../ads ads
           ln -s ../.coveragerc .coveragerc
 
+          "Run hpo tests, which hangs if run together with all unitary tests"
+          if [[ ${{ matrix.name ==  "unitary" }} ]]; then
+            python -m pytest -v -p no:warnings -n auto --dist loadfile \
+            --cov-append --cov=ads --cov-report=xml --cov-report=html \
+            tests/unitary/with_extras/hpo
+          fi
+
           # Run tests
           python -m pytest -v -p no:warnings --durations=5 \
-          -n auto --dist loadfile --cov=ads --cov-report=xml --cov-report=html \
+          -n auto --dist loadfile \
+          --cov-append --cov=ads --cov-report=xml --cov-report=html \
           ${{ matrix.test-path }} ${{ matrix.ignore-path }}
 
       - name: "Save coverage files"
@@ -123,11 +136,11 @@ jobs:
           # Prepare file paths to .coverage files
           # Filenames taken from job.test last step with name - "Save coverage files"
           FILE_UNITARY="cov-reports-unitary/.coverage"; [[ ! -f $FILE_UNITARY ]] && FILE_UNITARY=""
-          FILE_MODEL="cov-reports-model/.coverage"; [[ ! -f $FILE_MODEL ]] && FILE_MODEL=""
+          FILE_SLOW="cov-reports-slow_tests/.coverage"; [[ ! -f $FILE_SLOW ]] && FILE_SLOW=""
 
           # Combine coverage files
           pip install coverage
-          coverage combine $FILE_UNITARY $FILE_MODEL
+          coverage combine $FILE_UNITARY $FILE_SLOW
 
           # Make html report
           coverage html
@@ -151,7 +164,7 @@ jobs:
           # Prepare file paths to coverage xml files
           # Filenames taken from job.test last step with name - "Save coverage files"
           FILE1="cov-reports-unitary/coverage.xml"; [[ ! -f $FILE1 ]] && FILE1=""
-          FILE2="cov-reports-model/coverage.xml"; [[ ! -f $FILE2 ]] && FILE2=""
+          FILE2="cov-reports-slow_tests/coverage.xml"; [[ ! -f $FILE2 ]] && FILE2=""
           echo "FILE1=$FILE1" >> $GITHUB_ENV
           echo "FILE2=$FILE2" >> $GITHUB_ENV
 

--- a/.github/workflows/run-unittests-py38-cov-report.yml
+++ b/.github/workflows/run-unittests-py38-cov-report.yml
@@ -88,7 +88,7 @@ jobs:
           ln -s ../.coveragerc .coveragerc
 
           "Run hpo tests, which hangs if run together with all unitary tests"
-          if [[ ${{ matrix.name ==  "unitary" }} ]]; then
+          if [[ ${{ matrix.name }} ==  "unitary" ]]; then
             python -m pytest -v -p no:warnings -n auto --dist loadfile \
             --cov-append --cov=ads --cov-report=xml --cov-report=html \
             tests/unitary/with_extras/hpo

--- a/.github/workflows/run-unittests-py39-py310.yml
+++ b/.github/workflows/run-unittests-py39-py310.yml
@@ -33,13 +33,21 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10"]
-        test-path: ["tests/unitary/with_extras tests/unitary/default_setup", "tests/unitary/with_extras/model"]
+        name: ["unitary", "slow_tests"]
         include:
-          - test-path: "tests/unitary/with_extras tests/unitary/default_setup"
-            ignore-path: "--ignore tests/unitary/with_extras/model --ignore tests/unitary/with_extras/feature_store --ignore tests/unitary/with_extras/operator/forecast"
-            name: "unitary"
-          - test-path: "tests/unitary/with_extras/model"
-            name: "model"
+          - name: "unitary"
+            test-path: "tests/unitary"
+            # `model` tests running in "slow_tests",
+            # `feature_store` tests has its own test suite
+            # `forecast` tests not supported in python 3.9,3.10 (automlx dependency). Tests are running in python3.8 test env, see run-unittests-py38-cov-report.yml
+            # 'hpo' tests hangs if run together with all unitary tests. Tests running in separate command before running all unitary
+            ignore-path: |
+              --ignore tests/unitary/with_extras/model
+              --ignore tests/unitary/with_extras/feature_store
+              --ignore tests/unitary/with_extras/operator/forecast
+              --ignore tests/unitary/with_extras/hpo
+          - name: "slow_tests"
+            test-path: "tests/unitary/with_extras/model"
 
     steps:
       - uses: actions/checkout@v3
@@ -62,8 +70,19 @@ jobs:
         name: "Test env setup"
         timeout-minutes: 20
 
+      - name: "Run hpo tests"
+        description: "Run hpo tests, which hangs if run together with all unitary tests"
+        timeout-minutes: 10
+        shell: bash
+        if: ${{ matrix.name }} == "unitary"
+        run: |
+          set -x # print commands that are executed
+
+          python -m pytest -v -p no:warnings -n auto --dist loadfile \
+          tests/unitary/with_extras/hpo
+
       - name: "Run unitary tests folder with maximum ADS dependencies"
-        timeout-minutes: 60
+        timeout-minutes: 30
         shell: bash
         env:
           CONDA_PREFIX: /usr/share/miniconda

--- a/.github/workflows/run-unittests-py39-py310.yml
+++ b/.github/workflows/run-unittests-py39-py310.yml
@@ -71,13 +71,13 @@ jobs:
         timeout-minutes: 20
 
       - name: "Run hpo tests"
-        description: "Run hpo tests, which hangs if run together with all unitary tests"
         timeout-minutes: 10
         shell: bash
         if: ${{ matrix.name }} == "unitary"
         run: |
           set -x # print commands that are executed
 
+          # Run hpo tests, which hangs if run together with all unitary tests
           python -m pytest -v -p no:warnings -n auto --dist loadfile \
           tests/unitary/with_extras/hpo
 

--- a/.github/workflows/run-unittests-py39-py310.yml
+++ b/.github/workflows/run-unittests-py39-py310.yml
@@ -42,9 +42,9 @@ jobs:
             # `forecast` tests not supported in python 3.9,3.10 (automlx dependency). Tests are running in python3.8 test env, see run-unittests-py38-cov-report.yml
             # 'hpo' tests hangs if run together with all unitary tests. Tests running in separate command before running all unitary
             ignore-path: |
-              --ignore tests/unitary/with_extras/model
-              --ignore tests/unitary/with_extras/feature_store
-              --ignore tests/unitary/with_extras/operator/forecast
+              --ignore tests/unitary/with_extras/model \
+              --ignore tests/unitary/with_extras/feature_store \
+              --ignore tests/unitary/with_extras/operator/forecast \
               --ignore tests/unitary/with_extras/hpo
           - name: "slow_tests"
             test-path: "tests/unitary/with_extras/model"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ bds = [
   "sqlalchemy",
 ]
 boosted = [
-  "lightgbm",
+  "lightgbm<4.0.0",  # relax when the official releases of skl2onnx (v1.16.0) and onnxmltools (1.11.3), https://github.com/sdpython/mlprodict/issues/488
   "xgboost",
 ]
 data = [
@@ -106,8 +106,8 @@ notebook = [
   "ipywidgets~=7.6.3",
 ]
 onnx = [
-  "lightgbm",
-  "onnx>=1.12.0,<1.15.0",  # v1.15.0 introduced ValueError: `initial_types` can not be detected.
+  "lightgbm<4.0.0",  # relax when the official releases of skl2onnx (v1.16.0) and onnxmltools (1.11.3), https://github.com/sdpython/mlprodict/issues/488
+  "onnx>=1.12.0",
   "onnxmltools>=1.10.0",
   "onnxruntime>=1.10.0,<1.16",  # v1.16 introduced issues https://github.com/microsoft/onnxruntime/issues/17631, revealed by unit tests
   "oracle_ads[viz]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,9 +107,9 @@ notebook = [
 ]
 onnx = [
   "lightgbm",
-  "onnx>=1.12.0",
+  "onnx>=1.12.0,<1.15.0",  # v1.15.0 introduced ValueError: `initial_types` can not be detected.
   "onnxmltools>=1.10.0",
-  "onnxruntime>=1.10.0,<1.16",  # v1.16 introduced issues https://github.com/microsoft/onnxruntime/issues/17631, revealedd by unit tests
+  "onnxruntime>=1.10.0,<1.16",  # v1.16 introduced issues https://github.com/microsoft/onnxruntime/issues/17631, revealed by unit tests
   "oracle_ads[viz]",
   "protobuf<=3.20",
   "skl2onnx>=1.10.4",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,7 @@ faker
 mock
 pip
 pytest
-pytest-codecov
+pytest-cov
 pytest-xdist
 # darts
 # docker

--- a/tests/unitary/default_setup/telemetry/test_agent.py
+++ b/tests/unitary/default_setup/telemetry/test_agent.py
@@ -8,7 +8,6 @@ import oci
 from unittest.mock import patch
 
 import pytest
-# from pytest import MonkeyPatch
 
 import ads
 from ads.telemetry.telemetry import (
@@ -35,7 +34,10 @@ class TestUserAgent:
 
     @patch("oci.config.validate_config")
     @patch("oci.signer.Signer")
-    def test_user_agent_api_keys_using_test_profile(self, mock_signer, mock_validate_config):
+    def test_user_agent_api_keys_using_test_profile(
+        self, mock_signer, mock_validate_config, monkeypatch
+    ):
+        monkeypatch.delenv(EXTRA_USER_AGENT_INFO, raising=False)
         with patch("oci.config.from_file", return_value=self.test_config):
             auth_info = ads.auth.api_keys("test_path", "TEST_PROFILE")
             assert (
@@ -46,6 +48,7 @@ class TestUserAgent:
     @patch("oci.auth.signers.get_resource_principals_signer")
     def test_user_agent_rp(self, mock_signer, monkeypatch):
         monkeypatch.delenv("OCI_RESOURCE_PRINCIPAL_VERSION", raising=False)
+        monkeypatch.delenv(EXTRA_USER_AGENT_INFO, raising=False)
         importlib.reload(ads.config)
         importlib.reload(ads.telemetry)
         auth_info = ads.auth.resource_principal()
@@ -56,9 +59,12 @@ class TestUserAgent:
 
     @patch("oci.config.validate_config")
     @patch("oci.signer.load_private_key_from_file")
-    def test_user_agent_default_signer(self, mock_load_key_file, mock_validate_config, monkeypatch):
+    def test_user_agent_default_signer(
+        self, mock_load_key_file, mock_validate_config, monkeypatch
+    ):
         # monkeypatch = MonkeyPatch()
         monkeypatch.delenv("OCI_RESOURCE_PRINCIPAL_VERSION", raising=False)
+        monkeypatch.delenv(EXTRA_USER_AGENT_INFO, raising=False)
         importlib.reload(ads.config)
         with patch("oci.config.from_file", return_value=self.test_config):
             auth_info = ads.auth.default_signer()
@@ -106,11 +112,17 @@ class TestUserAgent:
     @patch("oci.config.validate_config")
     @patch("oci.signer.load_private_key_from_file")
     def test_user_agent_default_signer_known_resources(
-        self,mock_load_key_file, mock_validate_config, monkeypatch, INPUT_DATA, EXPECTED_RESULT
+        self,
+        mock_load_key_file,
+        mock_validate_config,
+        monkeypatch,
+        INPUT_DATA,
+        EXPECTED_RESULT,
     ):
         # monkeypatch = MonkeyPatch()
         monkeypatch.setenv("OCI_RESOURCE_PRINCIPAL_VERSION", "1.1")
         monkeypatch.setenv(INPUT_DATA["RESOURCE_KEY"], "1234")
+        monkeypatch.delenv(EXTRA_USER_AGENT_INFO, raising=False)
         if INPUT_DATA[EXTRA_USER_AGENT_INFO] is not None:
             monkeypatch.setenv(EXTRA_USER_AGENT_INFO, INPUT_DATA[EXTRA_USER_AGENT_INFO])
 
@@ -138,6 +150,7 @@ class TestUserAgent:
         monkeypatch,
     ):
         monkeypatch.setenv("OCI_RESOURCE_PRINCIPAL_VERSION", "1.1")
+        monkeypatch.delenv(EXTRA_USER_AGENT_INFO, raising=False)
 
         importlib.reload(ads.config)
         importlib.reload(ads.telemetry)


### PR DESCRIPTION
### Description

This PR fixes several issues:
1. `ValueError: initial_types can not be detected. Please directly pass initial_types.` This error observed in model/test_model_framework_sklearn_model.py and model/test_model_framework_lightgbm_model.py. Issue is coming from https://github.com/sdpython/mlprodict/issues/488. Suggesting to fix lightgbm version <4.0.0 and relax it later when when the official releases of skl2onnx (v1.16.0) and onnxmltools (1.11.3).
2. tests hang on 99% of completion and never ends. This issue is coming from hpo tests, when they run together with whole unitary folder, tests hangs. To fix - reorganizing for tests made to run hpo tests first, and then all other
3. Some operators tests leaving behind config values, which are messing up with default values for telemetry, which running after operators tests. Fix for the removing env variable EXTRA_USER_AGENT_INFO before running telemetry tests. Here is error:
```
FAILED tests/unitary/default_setup/telemetry/test_agent.py::TestUserAgent::test_user_agent_api_keys_using_test_profile - AssertionError: assert 'Oracle-ads/version=2.9.0#surface=WORKSTATION#api=Operator' == 'Oracle-ads/version=2.9.0#surface=WORKSTATION#api=UNKNOWN'
  - Oracle-ads/version=2.9.0#surface=WORKSTATION#api=UNKNOWN
  ?                                                  ---- ^^
  + Oracle-ads/version=2.9.0#surface=WORKSTATION#api=Operator
  ?                                                   ^^^^^^^
```

### What was done

- updated tests workflow ymls so that hpo tests runs first and after all other
- added limit for version of lightgbm < 4.0.0
- fixed telemetry tests removing EXTRA_USER_AGENT_INFO env variable before running them
