### PR TITLE
Fixed model deployment progress bar.

### DIFF
--- a/ads/model/service/oci_datascience_model_deployment.py
+++ b/ads/model/service/oci_datascience_model_deployment.py
@@ -20,10 +20,6 @@ from oci.data_science.models import (
 
 DEFAULT_WAIT_TIME = 1200
 DEFAULT_POLL_INTERVAL = 10
-DEACTIVATE_WORKFLOW_STEPS = 2
-DELETE_WORKFLOW_STEPS = 2
-ACTIVATE_WORKFLOW_STEPS = 6
-CREATE_WORKFLOW_STEPS = 6
 ALLOWED_STATUS = [
     State.ACTIVE.name,
     State.CREATING.name,
@@ -203,7 +199,6 @@ class OCIDataScienceModelDeployment(
                 try:
                     self.wait_for_progress(
                         self.workflow_req_id, 
-                        ACTIVATE_WORKFLOW_STEPS, 
                         max_wait_time, 
                         poll_interval
                     )
@@ -254,7 +249,6 @@ class OCIDataScienceModelDeployment(
             try:
                 self.wait_for_progress(
                     self.workflow_req_id, 
-                    CREATE_WORKFLOW_STEPS, 
                     max_wait_time, 
                     poll_interval
                 )
@@ -317,7 +311,6 @@ class OCIDataScienceModelDeployment(
                 try:
                     self.wait_for_progress(
                         self.workflow_req_id, 
-                        DEACTIVATE_WORKFLOW_STEPS, 
                         max_wait_time, 
                         poll_interval
                     )
@@ -387,7 +380,6 @@ class OCIDataScienceModelDeployment(
             try:
                 self.wait_for_progress(
                     self.workflow_req_id, 
-                    DELETE_WORKFLOW_STEPS, 
                     max_wait_time, 
                     poll_interval
                 )

--- a/tests/unitary/default_setup/model_deployment/test_oci_datascience_model_deployment.py
+++ b/tests/unitary/default_setup/model_deployment/test_oci_datascience_model_deployment.py
@@ -15,10 +15,6 @@ from ads.common.oci_datascience import OCIDataScienceMixin
 from ads.common.oci_mixin import OCIModelMixin, OCIWorkRequestMixin
 
 from ads.model.service.oci_datascience_model_deployment import (
-    ACTIVATE_WORKFLOW_STEPS,
-    CREATE_WORKFLOW_STEPS,
-    DEACTIVATE_WORKFLOW_STEPS,
-    DELETE_WORKFLOW_STEPS,
     OCIDataScienceModelDeployment,
 )
 
@@ -163,7 +159,6 @@ class TestOCIDataScienceModelDeployment:
                     mock_activate.assert_called_with(self.mock_model_deployment.id)
                     mock_wait.assert_called_with(
                         "test",
-                        ACTIVATE_WORKFLOW_STEPS,
                         1,
                         1,
                     )
@@ -248,7 +243,6 @@ class TestOCIDataScienceModelDeployment:
                     )
                     mock_wait.assert_called_with(
                         "test",
-                        DEACTIVATE_WORKFLOW_STEPS,
                         1,
                         1,
                     )
@@ -330,7 +324,6 @@ class TestOCIDataScienceModelDeployment:
                                 mock_update_from_oci_model.assert_called()
                                 mock_wait.assert_called_with(
                                     "test",
-                                    CREATE_WORKFLOW_STEPS,                                    
                                     1,
                                     1,
                                 )
@@ -468,7 +461,6 @@ class TestOCIDataScienceModelDeployment:
                         mock_delete.assert_called_with(self.mock_model_deployment.id)
                         mock_wait.assert_called_with(
                             "test",
-                            DELETE_WORKFLOW_STEPS,
                             1,
                             1,
                         )


### PR DESCRIPTION
### Fixed model deployment progress bar.

- Change the progress bar steps to 100 as 100 percent
- Use the `work_request.percent_complete` for evaluation in the progress bar

## Notebook
<img width="1163" alt="Screenshot 2023-11-30 at 10 44 07 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/e0a4a925-c8e8-42f0-85ee-372eb5c4bcd3">
<img width="1170" alt="Screenshot 2023-11-30 at 10 44 25 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/9992b015-96d2-4826-a4a1-81918fb6679c">
<img width="1160" alt="Screenshot 2023-11-30 at 10 46 46 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/98fde1ec-13dc-4948-b1ee-f275b0ffbfdc">
<img width="1166" alt="Screenshot 2023-11-30 at 11 59 31 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/91f1d6c1-8623-45d5-9f7a-c68c40ad0099">
