### PR TITLE
Renames "runtime" on the "backend" in the operator merged specification

### DIFF
--- a/ads/opctl/operator/cmd.py
+++ b/ads/opctl/operator/cmd.py
@@ -32,6 +32,7 @@ from ads.opctl.operator.common.const import (
     OPERATOR_BASE_DOCKER_GPU_FILE,
     OPERATOR_BASE_GPU_IMAGE,
     OPERATOR_BASE_IMAGE,
+    OPERATOR_BACKEND_SECTION_NAME
 )
 from ads.opctl.operator.common.operator_loader import OperatorInfo, OperatorLoader
 from ads.opctl.utils import publish_image as publish_image_cmd
@@ -204,7 +205,7 @@ def init(
     ).items():
         tmp_config = value
         if merge_config and operator_config:
-            tmp_config = {**operator_config, "runtime": value}
+            tmp_config = {**operator_config, OPERATOR_BACKEND_SECTION_NAME: value}
 
         with fsspec.open(
             os.path.join(

--- a/ads/opctl/operator/common/backend_factory.py
+++ b/ads/opctl/operator/common/backend_factory.py
@@ -28,7 +28,7 @@ from ads.opctl.constants import (
     RESOURCE_TYPE,
     RUNTIME_TYPE,
 )
-from ads.opctl.operator.common.const import PACK_TYPE
+from ads.opctl.operator.common.const import PACK_TYPE, OPERATOR_BACKEND_SECTION_NAME
 from ads.opctl.operator.common.dictionary_merger import DictionaryMerger
 from ads.opctl.operator.common.operator_loader import OperatorInfo, OperatorLoader
 
@@ -124,14 +124,14 @@ class BackendFactory:
                 f"The `type` attribute must be specified in the operator's config."
             )
 
-        if not backend and not config.config.get("runtime"):
+        if not backend and not config.config.get(OPERATOR_BACKEND_SECTION_NAME):
             logger.info(
                 f"Backend config is not provided, the {BACKEND_NAME.LOCAL.value} "
                 "will be used by default. "
             )
             backend = BACKEND_NAME.LOCAL.value
         elif not backend:
-            backend = config.config.get("runtime")
+            backend = config.config.get(OPERATOR_BACKEND_SECTION_NAME)
 
         # extracting details about the operator
         operator_info = OperatorLoader.from_uri(uri=operator_type).load()
@@ -211,9 +211,9 @@ class BackendFactory:
         config.config["infrastructure"] = p_backend.config["infrastructure"]
         config.config["execution"] = p_backend.config["execution"]
 
-        return cls.BACKEND_MAP[p_backend.config["execution"]["backend"].lower()](
-            config=config.config, operator_info=operator_info
-        )
+        return cls.BACKEND_MAP[
+            p_backend.config["execution"][OPERATOR_BACKEND_SECTION_NAME].lower()
+        ](config=config.config, operator_info=operator_info)
 
     @classmethod
     def _extract_backend(

--- a/ads/opctl/operator/common/const.py
+++ b/ads/opctl/operator/common/const.py
@@ -15,6 +15,7 @@ OPERATOR_BASE_GPU_IMAGE = "ads-operator-gpu-base"
 OPERATOR_BASE_DOCKER_FILE = "Dockerfile"
 OPERATOR_BASE_DOCKER_GPU_FILE = "Dockerfile.gpu"
 
+OPERATOR_BACKEND_SECTION_NAME = "backend"
 
 class PACK_TYPE(str, metaclass=ExtendedEnumMeta):
     SERVICE = "service"

--- a/ads/opctl/operator/common/operator_config.py
+++ b/ads/opctl/operator/common/operator_config.py
@@ -30,15 +30,15 @@ class OperatorConfig(DataClassSerializable):
         The version of the operator.
     spec: object
         The operator specification details.
-    runtime: dict
-        The runtime details of the operator.
+    backend: dict
+        The operator's backend details.
     """
 
     kind: str = "operator"
     type: str = None
     version: str = None
     spec: Any = None
-    runtime: Dict = None
+    backend: Dict = None
 
     @classmethod
     def _validate_dict(cls, obj_dict: Dict) -> bool:


### PR DESCRIPTION
## Description

Currently, when the merged config is generated for the operator, it contains a 'runtime' section, which can be confusing, as 'runtime' itself has its own 'runtime' section. See the example below. This PR replaces the 'runtime' section with the 'backend' section in the merged config. The resulting merged config can be used to execute operators with the `ads opctl run` command. 

The merged config enables the combination of the operator's specification and the backend configuration into a single specification file.

**Current Implementation:**

```
kind: operator
spec:
  datetime_column:
    name: Date
  historical_data:
    url: data.csv
  model: auto
  target_category_columns:
  - Column1
  target_column: target
type: forecast
version: v1
runtime:
  kind: job
  spec:
    infrastructure:
      kind: infrastructure
      spec:
        blockStorageSize: 512
        compartmentId: '{Provide a compartment OCID}'
        jobInfrastructureType: ME_STANDALONE
        jobType: DEFAULT
        projectId: '{Provide a project OCID}'
        shapeConfigDetails:
          memoryInGBs: 512
          ocpus: 32
        shapeName: VM.Standard.E4.Flex
        subnetId: '{Provide a subnet OCID or remove this field if you use a default
          networking}'
      type: dataScienceJob
    name: '{Job name. For MLflow and Operator will be auto generated}'
    runtime:
      kind: runtime
      spec:
        args: []
        cmd: '{Container CMD. For MLflow and Operator will be auto generated}'
        entrypoint:
        - bash
        - --login
        - -c
        freeformTags:
          operator: forecast:v1
        image: /forecast:v1
      type: container
```

**Incoming Changes:** 

```
kind: operator
spec:
  datetime_column:
    name: Date
  historical_data:
    url: data.csv
  model: auto
  target_category_columns:
  - Column1
  target_column: target
type: forecast
version: v1
backend:
  kind: job
  spec:
    infrastructure:
      kind: infrastructure
      spec:
        blockStorageSize: 512
        compartmentId: '{Provide a compartment OCID}'
        jobInfrastructureType: ME_STANDALONE
        jobType: DEFAULT
        projectId: '{Provide a project OCID}'
        shapeConfigDetails:
          memoryInGBs: 512
          ocpus: 32
        shapeName: VM.Standard.E4.Flex
        subnetId: '{Provide a subnet OCID or remove this field if you use a default
          networking}'
      type: dataScienceJob
    name: '{Job name. For MLflow and Operator will be auto generated}'
    runtime:
      kind: runtime
      spec:
        args: []
        cmd: '{Container CMD. For MLflow and Operator will be auto generated}'
        entrypoint:
        - bash
        - --login
        - -c
        freeformTags:
          operator: forecast:v1
        image: /forecast:v1
      type: container
```

## Usage

#### Generating merged config
```
ads operator init -t forecast --merged
```

#### Running operator
```
ads operator run -f forecast.yaml
```
OR
```
ads opctl run -f forecast.yaml
```
