### PR TITLE
Relax fsspec version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
   "asteval>=0.9.25",
   "cerberus>=1.3.4",
   "cloudpickle>=1.6.0",
-  "fsspec>=0.8.7,!=2023.9.1",  # v2.9.1 introduced issues, revealed by unit tests
+  "fsspec>=0.8.7",
   "gitpython>=3.1.2",
   "jinja2>=2.11.2",
   "matplotlib>=3.1.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
   "asteval>=0.9.25",
   "cerberus>=1.3.4",
   "cloudpickle>=1.6.0",
-  "fsspec>=0.8.7,<2023.9.1",  # v2.9.1 introduced issues, revealed by unit tests
+  "fsspec>=0.8.7,!=2023.9.1",  # v2.9.1 introduced issues, revealed by unit tests
   "gitpython>=3.1.2",
   "jinja2>=2.11.2",
   "matplotlib>=3.1.3",


### PR DESCRIPTION
### Description

In September unit tests failed on fsspec version 2023.9.1 (link to failed test https://github.com/oracle/accelerated-data-science/actions/runs/6228575725/job/16905571454). Fix was to pin version fsspec <2023.9.1. Now we want to relax it.

Jira: https://jira.oci.oraclecorp.com/browse/ODSC-50780

### Validation

unit tests should pass