### PR TITLE
Modified Watch in Model Deployment

### DIFF
--- a/ads/model/deployment/model_deployment.py
+++ b/ads/model/deployment/model_deployment.py
@@ -64,7 +64,7 @@ DEFAULT_WORKFLOW_STEPS = 6
 DELETE_WORKFLOW_STEPS = 2
 DEACTIVATE_WORKFLOW_STEPS = 2
 DEFAULT_RETRYING_REQUEST_ATTEMPTS = 3
-TERMINAL_STATES = [State.ACTIVE, State.FAILED, State.DELETED, State.INACTIVE]
+TERMINAL_STATES = [State.FAILED, State.DELETED, State.INACTIVE]
 
 MODEL_DEPLOYMENT_KIND = "deployment"
 MODEL_DEPLOYMENT_TYPE = "modelDeployment"
@@ -720,7 +720,7 @@ class ModelDeployment(Builder):
 
     def watch(
         self,
-        log_type: str = ModelDeploymentLogType.ACCESS,
+        log_type: str = None,
         time_start: datetime = None,
         interval: int = LOG_INTERVAL,
         log_filter: str = None,
@@ -731,7 +731,7 @@ class ModelDeployment(Builder):
         ----------
         log_type: str, optional
             The log type. Can be `access`, `predict` or None.
-            Defaults to access.
+            Defaults to None.
         time_start : datetime.datetime, optional
             Starting time for the log query.
             Defaults to None.
@@ -748,7 +748,12 @@ class ModelDeployment(Builder):
             The instance of ModelDeployment.
         """
         status = ""
-        while not self._stop_condition():
+        while self.state not in [
+            State.ACTIVE, 
+            State.FAILED, 
+            State.DELETED, 
+            State.INACTIVE
+        ]:
             status = self._check_and_print_status(status)
             time.sleep(interval)
 

--- a/ads/model/deployment/model_deployment.py
+++ b/ads/model/deployment/model_deployment.py
@@ -64,7 +64,8 @@ DEFAULT_WORKFLOW_STEPS = 6
 DELETE_WORKFLOW_STEPS = 2
 DEACTIVATE_WORKFLOW_STEPS = 2
 DEFAULT_RETRYING_REQUEST_ATTEMPTS = 3
-TERMINAL_STATES = [State.FAILED, State.DELETED, State.INACTIVE]
+TERMINAL_STATES = [State.ACTIVE, State.FAILED, State.DELETED, State.INACTIVE]
+WATCH_TERMINAL_STATES = [State.FAILED, State.DELETED, State.INACTIVE]
 
 MODEL_DEPLOYMENT_KIND = "deployment"
 MODEL_DEPLOYMENT_TYPE = "modelDeployment"
@@ -748,12 +749,7 @@ class ModelDeployment(Builder):
             The instance of ModelDeployment.
         """
         status = ""
-        while self.state not in [
-            State.ACTIVE, 
-            State.FAILED, 
-            State.DELETED, 
-            State.INACTIVE
-        ]:
+        while self.state not in TERMINAL_STATES:
             status = self._check_and_print_status(status)
             time.sleep(interval)
 
@@ -777,8 +773,8 @@ class ModelDeployment(Builder):
             pass
 
     def _stop_condition(self):
-        """Stops the sync once the model deployment is in a terminal state."""
-        return self.state in TERMINAL_STATES
+        """Stops the watch sync once the model deployment is in a terminal state."""
+        return self.state in WATCH_TERMINAL_STATES
 
     def _check_and_print_status(self, prev_status) -> str:
         """Check and print the next status.

--- a/tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py
+++ b/tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py
@@ -1286,7 +1286,7 @@ spec:
         mock_stream.assert_called_with(
             source=model_deployment.model_deployment_id,
             time_start=time_start,
-            stop_condition=model_deployment._stop_condition,
+            stop_condition=model_deployment._stream_stop_condition,
             interval=10,
             log_filter="test_filter",
         )


### PR DESCRIPTION
### Modified Watch in Model Deployment

- Set default logs to be both `access` and `predict` logs
- Kept streaming logs while model deployment is in `ACTIVE` state.

## Notebook
<img width="926" alt="Screenshot 2023-12-07 at 10 48 55 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/e49a9a54-87f1-4641-af03-8125baf05a2b">
<img width="820" alt="Screenshot 2023-12-07 at 10 49 05 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/449bfd8d-05e7-4e09-8014-f65da118d78a">
