### PR TITLE
Updated download artifact path

### DIFF
--- a/ads/config.py
+++ b/ads/config.py
@@ -45,6 +45,7 @@ RESOURCE_OCID = (
     NB_SESSION_OCID or JOB_RUN_OCID or MD_OCID or PIPELINE_RUN_OCID or DATAFLOW_RUN_OCID
 )
 NO_CONTAINER = os.environ.get("NO_CONTAINER")
+TMPDIR = os.environ.get("TMPDIR")
 
 
 def export(

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -31,6 +31,7 @@ from ads.config import (
     NB_SESSION_OCID,
     PIPELINE_RUN_COMPARTMENT_OCID,
     PROJECT_OCID,
+    TMPDIR,
 )
 from ads.evaluations import EvaluatorMixin
 from ads.feature_engineering import ADSImage
@@ -183,7 +184,7 @@ def _prepare_artifact_dir(artifact_dir: str = None) -> str:
     if artifact_dir and isinstance(artifact_dir, str):
         return os.path.abspath(os.path.expanduser(artifact_dir))
 
-    artifact_dir = tempfile.mkdtemp()
+    artifact_dir = TMPDIR or tempfile.mkdtemp()
     logger.info(
         f"The `artifact_dir` was not provided and "
         f"automatically set to: {artifact_dir}"

--- a/tests/unitary/default_setup/model/test_artifact_downloader.py
+++ b/tests/unitary/default_setup/model/test_artifact_downloader.py
@@ -100,20 +100,19 @@ class TestArtifactDownloader:
             expected_artifact_bytes_content
         )
         with tempfile.TemporaryDirectory() as tmp_dir:
-            target_dir = os.path.join(tmp_dir, "model_artifacts/")
             SmallArtifactDownloader(
                 dsc_model=self.mock_dsc_model,
-                target_dir=target_dir,
+                target_dir=tmp_dir,
                 force_overwrite=True,
             ).download()
 
             self.mock_dsc_model.get_model_artifact_content.assert_called()
 
             test_files = list(
-                glob.iglob(os.path.join(target_dir, "**"), recursive=True)
+                glob.iglob(os.path.join(tmp_dir, "**"), recursive=True)
             )
             expected_files = [
-                os.path.join(target_dir, file_name)
+                os.path.join(tmp_dir, file_name)
                 for file_name in ["", "runtime.yaml", "score.py"]
             ]
             assert sorted(test_files) == sorted(expected_files)


### PR DESCRIPTION
### Updated Model Download Artifact Path

- Respected `TMPDIR` when `artifact_dir` is not provided
- Saved model artifacts directly inside the `target_dir` folder

## Notebook

<img width="459" alt="Screenshot 2023-12-08 at 12 03 34 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/70f9bd70-ab66-46e2-8815-71dbeac4c174">
<img width="545" alt="Screenshot 2023-12-08 at 12 26 31 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/068106ba-94f8-4f2b-a412-00824cbc24fc">
