### PR TITLE
ODSC-50486/print out model deployment id when calling predict

### DIFF
--- a/ads/model/service/oci_datascience_model_deployment.py
+++ b/ads/model/service/oci_datascience_model_deployment.py
@@ -67,11 +67,11 @@ def check_for_model_deployment_id(msg: str = MODEL_DEPLOYMENT_NEEDS_TO_BE_DEPLOY
     return decorator
 
 
-class MissingModelDeploymentIdError(Exception):   # pragma: no cover
+class MissingModelDeploymentIdError(Exception):  # pragma: no cover
     pass
 
 
-class MissingModelDeploymentWorkflowIdError(Exception):   # pragma: no cover
+class MissingModelDeploymentWorkflowIdError(Exception):  # pragma: no cover
     pass
 
 
@@ -175,32 +175,23 @@ class OCIDataScienceModelDeployment(
             The `OCIDataScienceModelDeployment` instance (self).
         """
         dsc_model_deployment = OCIDataScienceModelDeployment.from_id(self.id)
-        if (
-            dsc_model_deployment.lifecycle_state
-            == self.LIFECYCLE_STATE_ACTIVE
-        ):
+        if dsc_model_deployment.lifecycle_state == self.LIFECYCLE_STATE_ACTIVE:
             raise Exception(
                 f"Model deployment {dsc_model_deployment.id} is already in active state."
             )
 
-        if (
-            dsc_model_deployment.lifecycle_state
-            == self.LIFECYCLE_STATE_INACTIVE
-        ):
+        if dsc_model_deployment.lifecycle_state == self.LIFECYCLE_STATE_INACTIVE:
             logger.info(f"Activating model deployment `{self.id}`.")
             response = self.client.activate_model_deployment(
                 self.id,
             )
 
             if wait_for_completion:
-
                 self.workflow_req_id = response.headers.get("opc-work-request-id", None)
 
                 try:
                     self.wait_for_progress(
-                        self.workflow_req_id, 
-                        max_wait_time, 
-                        poll_interval
+                        self.workflow_req_id, max_wait_time, poll_interval
                     )
                 except Exception as e:
                     logger.error(
@@ -241,21 +232,17 @@ class OCIDataScienceModelDeployment(
         response = self.client.create_model_deployment(create_model_deployment_details)
         self.update_from_oci_model(response.data)
         logger.info(f"Creating model deployment `{self.id}`.")
+        print(f"Model Deployment OCID: {self.id}")
 
         if wait_for_completion:
-
             self.workflow_req_id = response.headers.get("opc-work-request-id", None)
 
             try:
                 self.wait_for_progress(
-                    self.workflow_req_id, 
-                    max_wait_time, 
-                    poll_interval
+                    self.workflow_req_id, max_wait_time, poll_interval
                 )
             except Exception as e:
-                logger.error(
-                    "Error while trying to create model deployment: " + str(e)
-                )
+                logger.error("Error while trying to create model deployment: " + str(e))
 
         return self.sync()
 
@@ -287,32 +274,23 @@ class OCIDataScienceModelDeployment(
             The `OCIDataScienceModelDeployment` instance (self).
         """
         dsc_model_deployment = OCIDataScienceModelDeployment.from_id(self.id)
-        if (
-            dsc_model_deployment.lifecycle_state
-            == self.LIFECYCLE_STATE_INACTIVE
-        ):
+        if dsc_model_deployment.lifecycle_state == self.LIFECYCLE_STATE_INACTIVE:
             raise Exception(
                 f"Model deployment {dsc_model_deployment.id} is already in inactive state."
             )
 
-        if (
-            dsc_model_deployment.lifecycle_state
-            == self.LIFECYCLE_STATE_ACTIVE
-        ):
+        if dsc_model_deployment.lifecycle_state == self.LIFECYCLE_STATE_ACTIVE:
             logger.info(f"Deactivating model deployment `{self.id}`.")
             response = self.client.deactivate_model_deployment(
                 self.id,
             )
 
             if wait_for_completion:
-
                 self.workflow_req_id = response.headers.get("opc-work-request-id", None)
 
                 try:
                     self.wait_for_progress(
-                        self.workflow_req_id, 
-                        max_wait_time, 
-                        poll_interval
+                        self.workflow_req_id, max_wait_time, poll_interval
                     )
                 except Exception as e:
                     logger.error(
@@ -355,7 +333,7 @@ class OCIDataScienceModelDeployment(
         dsc_model_deployment = OCIDataScienceModelDeployment.from_id(self.id)
         if dsc_model_deployment.lifecycle_state in [
             self.LIFECYCLE_STATE_DELETED,
-            self.LIFECYCLE_STATE_DELETING
+            self.LIFECYCLE_STATE_DELETING,
         ]:
             raise Exception(
                 f"Model deployment {dsc_model_deployment.id} is either deleted or being deleted."
@@ -374,19 +352,14 @@ class OCIDataScienceModelDeployment(
         )
 
         if wait_for_completion:
-
             self.workflow_req_id = response.headers.get("opc-work-request-id", None)
 
             try:
                 self.wait_for_progress(
-                    self.workflow_req_id, 
-                    max_wait_time, 
-                    poll_interval
+                    self.workflow_req_id, max_wait_time, poll_interval
                 )
             except Exception as e:
-                logger.error(
-                    "Error while trying to delete model deployment: " + str(e)
-                )
+                logger.error("Error while trying to delete model deployment: " + str(e))
 
         return self.sync()
 
@@ -440,9 +413,7 @@ class OCIDataScienceModelDeployment(
             )
             self.workflow_req_id = response.headers.get("opc-work-request-id", None)
         except Exception as e:
-            logger.error(
-                "Error while trying to update model deployment: " + str(e)
-            )
+            logger.error("Error while trying to update model deployment: " + str(e))
 
         return self.sync()
 


### PR DESCRIPTION
# Description
Jira: https://jira.oci.oraclecorp.com/browse/ODSC-50486
Currently, the model deployment OCID shows in log when `deploy()` has been invoke. We want to print out the model deployment OCID in the notebook cell when deploy is called.


# User experience
![Screenshot 2023-12-08 at 4 08 10 PM](https://github.com/oracle/accelerated-data-science/assets/49049296/272ca864-768d-4ab8-b045-b30b78d5b037)

