### PR TITLE
Updated default web concurrency value to be none

### DIFF
--- a/ads/model/deployment/model_deployment_infrastructure.py
+++ b/ads/model/deployment/model_deployment_infrastructure.py
@@ -20,7 +20,6 @@ MODEL_DEPLOYMENT_INFRASTRUCTURE_TYPE = "datascienceModelDeployment"
 MODEL_DEPLOYMENT_INFRASTRUCTURE_KIND = "infrastructure"
 
 DEFAULT_BANDWIDTH_MBPS = 10
-DEFAULT_WEB_CONCURRENCY = 10
 DEFAULT_REPLICA = 1
 DEFAULT_SHAPE_NAME = "VM.Standard.E4.Flex"
 DEFAULT_OCPUS = 1
@@ -219,7 +218,6 @@ class ModelDeploymentInfrastructure(Builder):
             defaults[self.CONST_PROJECT_ID] = PROJECT_OCID
 
         defaults[self.CONST_BANDWIDTH_MBPS] = DEFAULT_BANDWIDTH_MBPS
-        defaults[self.CONST_WEB_CONCURRENCY] = DEFAULT_WEB_CONCURRENCY
         defaults[self.CONST_REPLICA] = DEFAULT_REPLICA
 
         if NB_SESSION_OCID:
@@ -628,7 +626,6 @@ class ModelDeploymentInfrastructure(Builder):
             .with_compartment_id(self.compartment_id or "{Provide a compartment OCID}")
             .with_project_id(self.project_id or "{Provide a project OCID}")
             .with_bandwidth_mbps(self.bandwidth_mbps or DEFAULT_BANDWIDTH_MBPS)
-            .with_web_concurrency(self.web_concurrency or DEFAULT_WEB_CONCURRENCY)
             .with_replica(self.replica or DEFAULT_REPLICA)
             .with_shape_name(self.shape_name or DEFAULT_SHAPE_NAME)
             .with_shape_config_details(

--- a/docs/source/user_guide/cli/opctl/configure.rst
+++ b/docs/source/user_guide/cli/opctl/configure.rst
@@ -97,7 +97,6 @@ This will prompt you to setup default ADS CLI configurations for each OCI profil
     project_id = oci.xxxx.<project_ocid>
     bandwidth_mbps = 10
     replica = 1
-    web_concurrency = 10
 
     [ANOTHERPROF]
     compartment_id = ocid1.compartment.oc1..<unique_ID>

--- a/tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py
+++ b/tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py
@@ -373,7 +373,6 @@ spec:
                 "ocpus": 10.0,
                 "memory_in_gbs": 36.0,
             },
-            ModelDeploymentInfrastructure.CONST_WEB_CONCURRENCY: 10,
             ModelDeploymentInfrastructure.CONST_REPLICA: 1,
         }
 


### PR DESCRIPTION
### Updated default web concurrency value to be none

- The `WEB_CONCURRENCY` is an optional parameter for model deployment service and there is no service default value for it as this value is calculated based on user's shape memory and model size.
- User can either set `WEB_CONCURRENCY` through the `with_env` in `runtime` or call `with_web_concurrency` in `infrastructure`. The latter will override the former if both methods are called.