### PR TITLE
ODSC-50649/raise ValueError when `inference_python_version` cannot be resolved

### DIFF
--- a/ads/model/artifact.py
+++ b/ads/model/artifact.py
@@ -273,7 +273,8 @@ class ModelArtifact:
             == ""
         ):
             raise ValueError(
-                "Cannot automatically detect the inference python version. `inference_python_version` must be provided."
+                "Cannot automatically detect the inference python version. "
+                "`inference_python_version` must be provided."
             )
         runtime_file_path = os.path.join(self.artifact_dir, "runtime.yaml")
         if os.path.exists(runtime_file_path) and not force_overwrite:

--- a/ads/model/artifact.py
+++ b/ads/model/artifact.py
@@ -30,13 +30,13 @@ SCORE_VERSION = "1.0"
 ADS_VERSION = __version__
 
 
-class ArtifactNestedFolderError(Exception):   # pragma: no cover
+class ArtifactNestedFolderError(Exception):  # pragma: no cover
     def __init__(self, folder: str):
         self.folder = folder
         super().__init__("The required artifact files placed in a nested folder.")
 
 
-class ArtifactRequiredFilesError(Exception):   # pragma: no cover
+class ArtifactRequiredFilesError(Exception):  # pragma: no cover
     def __init__(self, required_files: Tuple[str]):
         super().__init__(
             "Not all required files presented in artifact folder. "
@@ -44,7 +44,7 @@ class ArtifactRequiredFilesError(Exception):   # pragma: no cover
         )
 
 
-class AritfactFolderStructureError(Exception):   # pragma: no cover
+class AritfactFolderStructureError(Exception):  # pragma: no cover
     def __init__(self, required_files: Tuple[str]):
         super().__init__(
             "The artifact folder has a wrong structure. "
@@ -272,7 +272,7 @@ class ModelArtifact:
             or runtime_info.model_deployment.inference_conda_env.inference_python_version.strip()
             == ""
         ):
-            warnings.warn(
+            raise ValueError(
                 "Cannot automatically detect the inference python version. `inference_python_version` must be provided."
             )
         runtime_file_path = os.path.join(self.artifact_dir, "runtime.yaml")

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -965,17 +965,20 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
             auth=self.auth,
             local_copy_dir=self.local_copy_dir,
         )
-        self.runtime_info = self.model_artifact.prepare_runtime_yaml(
-            inference_conda_env=self.properties.inference_conda_env,
-            inference_python_version=self.properties.inference_python_version,
-            training_conda_env=self.properties.training_conda_env,
-            training_python_version=self.properties.training_python_version,
-            force_overwrite=force_overwrite,
-            namespace=namespace,
-            bucketname=DEFAULT_CONDA_BUCKET_NAME,
-            auth=self.auth,
-            ignore_conda_error=self.ignore_conda_error,
-        )
+        try:
+            self.runtime_info = self.model_artifact.prepare_runtime_yaml(
+                inference_conda_env=self.properties.inference_conda_env,
+                inference_python_version=self.properties.inference_python_version,
+                training_conda_env=self.properties.training_conda_env,
+                training_python_version=self.properties.training_python_version,
+                force_overwrite=force_overwrite,
+                namespace=namespace,
+                bucketname=DEFAULT_CONDA_BUCKET_NAME,
+                auth=self.auth,
+                ignore_conda_error=self.ignore_conda_error,
+            )
+        except ValueError as e:
+            raise e
 
         self._summary_status.update_status(
             detail="Generated runtime.yaml", status=ModelState.DONE.value

--- a/ads/model/runtime/env_info.py
+++ b/ads/model/runtime/env_info.py
@@ -106,7 +106,7 @@ class EnvInfo(ABC):
                 env_path, python_version = service_pack_slug_mapping[env_slug]
             else:
                 warnings.warn(
-                    "The {env_slug} is not a service pack. Use `from_path` method by passing in the object storage path."
+                    f"The {env_slug} is not a service pack. Use `from_path` method by passing in the object storage path."
                 )
 
         return cls._populate_env_info(
@@ -157,9 +157,13 @@ class EnvInfo(ABC):
                     ).fetch_metadata_of_object()
                     python_version = metadata_json.get("python", None)
                     env_slug = metadata_json.get("slug", None)
+                    if not python_version:
+                        raise ValueError(
+                            f"The manifest metadata of {env_path} doesn't contains inforamtion for python version."
+                        )
                 except Exception as e:
-                    logging.warning(e)
-                    logging.warning(
+                    logging.debug(e)
+                    logging.debug(
                         "python version and slug are not found from the manifest metadata."
                     )
 
@@ -227,7 +231,7 @@ class TrainingEnvInfo(EnvInfo, DataClassSerializable):
         )
 
     @classmethod
-    def _validate_dict(cls,obj_dict: Dict) -> bool:
+    def _validate_dict(cls, obj_dict: Dict) -> bool:
         """Validate the content in the dictionary format from the yaml file.
 
         Parameters


### PR DESCRIPTION
# Description
JIRA: https://jira.oci.oraclecorp.com/browse/ODSC-50649
We currently showing the requirement of `inference_python_version` as warning message during `.prepare()`. However, user might not take any action as `.prepare()` can still work. Then `.deploy()` will fail because of this missing information.

This change aims to raise ValueError in `.prepare()` when this field cannot be resolved automatically, mandating `inference_python_version`. 

In addition, changed some warning message which could lead to misunderstanding.  For example, when user passes `inference_python_version` and the manifest of given `inference_conda_env` doesn't provide python version, the warning message will show as below:
![Screenshot 2023-12-12 at 12 40 31 PM](https://github.com/oracle/accelerated-data-science/assets/49049296/0b996969-5bec-4ad7-8e7a-2fed2e4023da)
Use debug level instead.

# User Experience
* `.prepare()` without `inference_python_version` and it cannot be resolved automatically:
![Screenshot 2023-12-12 at 12 44 28 PM](https://github.com/oracle/accelerated-data-science/assets/49049296/d519d4fa-4e02-483e-b112-02fd3f4fd643)


* `.prepare()` without `inference_python_version` and it can be resolved automatically:
![Screenshot 2023-12-12 at 12 38 53 PM](https://github.com/oracle/accelerated-data-science/assets/49049296/bf1ca357-2532-4024-8097-158e2a389e76)

* `.prepare()` with `inference_python_version` 
![Screenshot 2023-12-12 at 12 45 53 PM](https://github.com/oracle/accelerated-data-science/assets/49049296/57dccfbe-f86d-4aa1-8b61-15d0150a7233)
