### PR TITLE
Fix UnboundLocalError when saving model to model catalog

### DIFF
--- a/ads/catalog/model.py
+++ b/ads/catalog/model.py
@@ -82,11 +82,11 @@ _MAX_ARTIFACT_SIZE_IN_BYTES = 2147483648  # 2GB
 _WORK_REQUEST_INTERVAL_IN_SEC = 3
 
 
-class ModelWithActiveDeploymentError(Exception):   # pragma: no cover
+class ModelWithActiveDeploymentError(Exception):  # pragma: no cover
     pass
 
 
-class ModelArtifactSizeError(Exception):   # pragma: no cover
+class ModelArtifactSizeError(Exception):  # pragma: no cover
     def __init__(self, max_artifact_size: str):
         super().__init__(
             f"The model artifacts size is greater than `{max_artifact_size}`. "
@@ -391,7 +391,6 @@ class Model:
             Nothing.
         """
         if display_format == "dataframe":
-
             from IPython.core.display import display
 
             display(self.to_dataframe())
@@ -1560,9 +1559,9 @@ class ModelCatalog:
                 if work_request_logs:
                     new_work_request_logs = work_request_logs[i:]
 
-                for wr_item in new_work_request_logs:
-                    progress.update(wr_item.message)
-                    i += 1
+                    for wr_item in new_work_request_logs:
+                        progress.update(wr_item.message)
+                        i += 1
 
                 if work_request.data.status in STOP_STATE:
                     if work_request.data.status != WorkRequest.STATUS_SUCCEEDED:


### PR DESCRIPTION
When saving model to model catalog using artifacts from object storage bucket, the `UnboundLocalError` may happen if the service did not create the work request in 3 second. This could be due to a networking delay. The error is caused by local variable `new_work_request_logs` being used before assignment. This PR fixes the issue by using it only it work request logs exist.