### PR TITLE
Update LangChain Tests

### DIFF
--- a/ads/jobs/templates/driver_utils.py
+++ b/ads/jobs/templates/driver_utils.py
@@ -413,7 +413,7 @@ class JobRunner:
                     logger.log(level=level, msg=msg)
             # Add a small delay so that
             # outputs from the subsequent code will have different timestamp for oci logging
-            time.sleep(0.05)
+            time.sleep(0.02)
         if check and process.returncode != 0:
             # If there is an error, exit the main process with the same return code.
             sys.exit(process.returncode)

--- a/tests/unitary/with_extras/langchain/test_serializers.py
+++ b/tests/unitary/with_extras/langchain/test_serializers.py
@@ -80,8 +80,7 @@ class TestOpensearchSearchVectorSerializers(unittest.TestCase):
 
     def test_save(self):
         serialized = self.serializer.save(self.opensearch)
-        assert serialized["id"] == [
-            "langchain",
+        assert serialized["id"][-3:] == [
             "vectorstores",
             "opensearch_vector_search",
             "OpenSearchVectorSearch",


### PR DESCRIPTION
The current way of saving the original LangChain's `get_type_to_cls_dict` method is not correct.
```
cls.original_type_to_cls_dict = deepcopy(llms.get_type_to_cls_dict())
```
Because `get_type_to_cls_dict` is a function but the code is saving as a dictionary.

After running this test, the subsequent calls to `get_type_to_cls_dict` will fail with
```
TypeError: 'dict' object is not callable
```

Depending on the order when running the test, some tests may appear to fail randomly due to this issue:
https://github.com/oracle/accelerated-data-science/actions/runs/7137179363/job/19453780865#step:8:3440
https://github.com/oracle/accelerated-data-science/actions/runs/7115504771/job/19371812840

Since the embedding and LLM models in this test are for serialization only without inference. There is no need to use the "fake" one. We can use the real embedding and LLM models to avoid modifying `get_type_to_cls_dict` in LangChain.

This PR also updated the tests to skip checking ID fields in the serialization, since LangChain is updating frequently and this field might change. Users should use the same version of LangChain for serialization and de-serialization.