### PR TITLE
ODSC-50786/GenericModel: add reload options to `ModelArtifact.from_uri`

### DIFF
--- a/ads/model/artifact.py
+++ b/ads/model/artifact.py
@@ -171,22 +171,17 @@ class ModelArtifact:
         self.ignore_conda_error = ignore_conda_error
         self.model = None
         self.auth = auth or authutil.default_signer()
-        try:
-            if reload and not ignore_conda_error:
-                self.reload()
-                # Extracts the model_file_name from the score.py.
-                if (
-                    not self.model_file_name
-                    and self.score
-                    and hasattr(self.score, "model_name")
-                    and self.score.model_name
-                ):
-                    self.model_file_name = self.score.model_name
-        except:
-            logger.error(
-                "Failing to load model into environemnt. Please set `reload=False` or `ignore_conda_error=True`."
-            )
-            raise
+
+        if reload and not ignore_conda_error:
+            self.reload()
+            # Extracts the model_file_name from the score.py.
+            if (
+                not self.model_file_name
+                and self.score
+                and hasattr(self.score, "model_name")
+                and self.score.model_name
+            ):
+                self.model_file_name = self.score.model_name
 
     def prepare_runtime_yaml(
         self,
@@ -422,7 +417,7 @@ class ModelArtifact:
         force_overwrite: Optional[bool] = False,
         ignore_conda_error: Optional[bool] = False,
         model_file_name: Optional[str] = None,
-        reload: Optional[bool] = True,
+        reload: Optional[bool] = False,
     ):
         """Constructs a ModelArtifact object from the existing model artifacts.
 
@@ -445,8 +440,8 @@ class ModelArtifact:
             Parameter to ignore error when collecting conda information.
         model_file_name: (str, optional). Defaults to `None`
             The file name of the serialized model.
-        reload: (bool, optional). Defaults to True.
-            Determine whether will reload the Model into the env.
+        reload: (bool, optional). Defaults to False.
+            Whether to reload the Model into the environment.
 
         Returns
         -------

--- a/ads/model/artifact.py
+++ b/ads/model/artifact.py
@@ -498,6 +498,8 @@ class ModelArtifact:
                     utils.copy_from_uri(
                         uri=temp_dir, to_path=to_path, force_overwrite=True
                     )
+            except ArtifactRequiredFilesError as ex:
+                logger.warning(ex)
 
         if ObjectStorageDetails.is_oci_path(artifact_dir):
             for root, dirs, files in os.walk(to_path):

--- a/ads/model/artifact.py
+++ b/ads/model/artifact.py
@@ -30,13 +30,13 @@ SCORE_VERSION = "1.0"
 ADS_VERSION = __version__
 
 
-class ArtifactNestedFolderError(Exception):   # pragma: no cover
+class ArtifactNestedFolderError(Exception):  # pragma: no cover
     def __init__(self, folder: str):
         self.folder = folder
         super().__init__("The required artifact files placed in a nested folder.")
 
 
-class ArtifactRequiredFilesError(Exception):   # pragma: no cover
+class ArtifactRequiredFilesError(Exception):  # pragma: no cover
     def __init__(self, required_files: Tuple[str]):
         super().__init__(
             "Not all required files presented in artifact folder. "
@@ -44,7 +44,7 @@ class ArtifactRequiredFilesError(Exception):   # pragma: no cover
         )
 
 
-class AritfactFolderStructureError(Exception):   # pragma: no cover
+class AritfactFolderStructureError(Exception):  # pragma: no cover
     def __init__(self, required_files: Tuple[str]):
         super().__init__(
             "The artifact folder has a wrong structure. "
@@ -171,16 +171,22 @@ class ModelArtifact:
         self.ignore_conda_error = ignore_conda_error
         self.model = None
         self.auth = auth or authutil.default_signer()
-        if reload and not ignore_conda_error:
-            self.reload()
-            # Extracts the model_file_name from the score.py.
-            if (
-                not self.model_file_name
-                and self.score
-                and hasattr(self.score, "model_name")
-                and self.score.model_name
-            ):
-                self.model_file_name = self.score.model_name
+        try:
+            if reload and not ignore_conda_error:
+                self.reload()
+                # Extracts the model_file_name from the score.py.
+                if (
+                    not self.model_file_name
+                    and self.score
+                    and hasattr(self.score, "model_name")
+                    and self.score.model_name
+                ):
+                    self.model_file_name = self.score.model_name
+        except:
+            logger.error(
+                "Failing to load model into environemnt. Please set `reload=False` or `ignore_conda_error=True`."
+            )
+            raise
 
     def prepare_runtime_yaml(
         self,
@@ -412,10 +418,11 @@ class ModelArtifact:
         cls,
         uri: str,
         artifact_dir: str,
-        model_file_name: str = None,
-        force_overwrite: Optional[bool] = False,
         auth: Optional[Dict] = None,
+        force_overwrite: Optional[bool] = False,
         ignore_conda_error: Optional[bool] = False,
+        model_file_name: Optional[str] = None,
+        reload: Optional[bool] = True,
     ):
         """Constructs a ModelArtifact object from the existing model artifacts.
 
@@ -426,16 +433,20 @@ class ModelArtifact:
             OCI object storage URI.
         artifact_dir: str
             The local artifact folder to store the files needed for deployment.
-        model_file_name: (str, optional). Defaults to `None`
-            The file name of the serialized model.
-        force_overwrite: (bool, optional). Defaults to False.
-            Whether to overwrite existing files or not.
         auth: (Dict, optional). Defaults to None.
             The default authetication is set using `ads.set_auth` API.
             If you need to override the default, use the `ads.common.auth.api_keys`
             or `ads.common.auth.resource_principal` to create appropriate
             authentication signer and kwargs required to instantiate
             IdentityClient object.
+        force_overwrite: (bool, optional). Defaults to False.
+            Whether to overwrite existing files or not.
+        ignore_conda_error: (bool, optional). Defaults to False.
+            Parameter to ignore error when collecting conda information.
+        model_file_name: (str, optional). Defaults to `None`
+            The file name of the serialized model.
+        reload: (bool, optional). Defaults to True.
+            Determine whether will reload the Model into the env.
 
         Returns
         -------
@@ -507,10 +518,10 @@ class ModelArtifact:
 
         return cls(
             artifact_dir=artifact_dir,
-            model_file_name=model_file_name,
-            reload=True,
             ignore_conda_error=ignore_conda_error,
             local_copy_dir=to_path,
+            model_file_name=model_file_name,
+            reload=reload,
         )
 
     def __getattr__(self, item):

--- a/ads/model/artifact.py
+++ b/ads/model/artifact.py
@@ -413,10 +413,10 @@ class ModelArtifact:
         cls,
         uri: str,
         artifact_dir: str,
-        auth: Optional[Dict] = None,
+        model_file_name: str = None,
         force_overwrite: Optional[bool] = False,
+        auth: Optional[Dict] = None,
         ignore_conda_error: Optional[bool] = False,
-        model_file_name: Optional[str] = None,
         reload: Optional[bool] = False,
     ):
         """Constructs a ModelArtifact object from the existing model artifacts.

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -3,7 +3,7 @@
 
 # Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
-
+from ads.common.decorator.utils import class_or_instance_method
 import cgi
 import logging
 from copy import deepcopy
@@ -849,7 +849,7 @@ class DataScienceModel(Builder):
         self.dsc_model.delete(delete_associated_model_deployment)
         return self.sync()
 
-    @classmethod
+    @class_or_instance_method
     def list(
         cls, compartment_id: str = None, project_id: str = None, **kwargs
     ) -> List["DataScienceModel"]:
@@ -876,7 +876,7 @@ class DataScienceModel(Builder):
             )
         ]
 
-    @classmethod
+    @class_or_instance_method
     def list_df(
         cls, compartment_id: str = None, project_id: str = None, **kwargs
     ) -> "pandas.DataFrame":
@@ -914,7 +914,7 @@ class DataScienceModel(Builder):
             )
         return pandas.DataFrame.from_records(records)
 
-    @classmethod
+    @class_or_instance_method
     def from_id(cls, id: str) -> "DataScienceModel":
         """Gets an existing model by OCID.
 
@@ -972,6 +972,18 @@ class DataScienceModel(Builder):
                 dsc_spec[dsc_attr] = value
 
         dsc_spec.update(**kwargs)
+        # TODO: dsc_spec doesn't have auth info
+        # from ads.common import auth
+
+        # dsc_spec.update(
+        #     **auth.api_keys(
+        #         client_kwargs={
+        #             "service_endpoint": "https://datascience-int.us-ashburn-1.oci.oc-test.com/20190101"
+        #         }
+        #     )
+        # )
+        # print("dsc_spec")
+        # print(dsc_spec)
         return OCIDataScienceModel(**dsc_spec)
 
     def _update_from_oci_dsc_model(
@@ -1046,7 +1058,7 @@ class DataScienceModel(Builder):
             "spec": utils.batch_convert_case(spec, "camel"),
         }
 
-    @classmethod
+    @class_or_instance_method
     def from_dict(cls, config: Dict) -> "DataScienceModel":
         """Loads model instance from a dictionary of configurations.
 

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -3,7 +3,7 @@
 
 # Copyright (c) 2022, 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
-from ads.common.decorator.utils import class_or_instance_method
+
 import cgi
 import logging
 from copy import deepcopy
@@ -849,7 +849,7 @@ class DataScienceModel(Builder):
         self.dsc_model.delete(delete_associated_model_deployment)
         return self.sync()
 
-    @class_or_instance_method
+    @classmethod
     def list(
         cls, compartment_id: str = None, project_id: str = None, **kwargs
     ) -> List["DataScienceModel"]:
@@ -876,7 +876,7 @@ class DataScienceModel(Builder):
             )
         ]
 
-    @class_or_instance_method
+    @classmethod
     def list_df(
         cls, compartment_id: str = None, project_id: str = None, **kwargs
     ) -> "pandas.DataFrame":
@@ -914,7 +914,7 @@ class DataScienceModel(Builder):
             )
         return pandas.DataFrame.from_records(records)
 
-    @class_or_instance_method
+    @classmethod
     def from_id(cls, id: str) -> "DataScienceModel":
         """Gets an existing model by OCID.
 
@@ -972,18 +972,6 @@ class DataScienceModel(Builder):
                 dsc_spec[dsc_attr] = value
 
         dsc_spec.update(**kwargs)
-        # TODO: dsc_spec doesn't have auth info
-        # from ads.common import auth
-
-        # dsc_spec.update(
-        #     **auth.api_keys(
-        #         client_kwargs={
-        #             "service_endpoint": "https://datascience-int.us-ashburn-1.oci.oc-test.com/20190101"
-        #         }
-        #     )
-        # )
-        # print("dsc_spec")
-        # print(dsc_spec)
         return OCIDataScienceModel(**dsc_spec)
 
     def _update_from_oci_dsc_model(
@@ -1058,7 +1046,7 @@ class DataScienceModel(Builder):
             "spec": utils.batch_convert_case(spec, "camel"),
         }
 
-    @class_or_instance_method
+    @classmethod
     def from_dict(cls, config: Dict) -> "DataScienceModel":
         """Loads model instance from a dictionary of configurations.
 

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -1372,21 +1372,29 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
 
         if reload:
             model.reload_runtime_info()
-            model._summary_status.update_status(
-                detail="Generated score.py",
-                status=ModelState.DONE.value,
-            )
-            model._summary_status.update_status(
-                detail="Generated runtime.yaml",
-                status=ModelState.DONE.value,
-            )
-            model._summary_status.update_status(
-                detail="Serialized model", status=ModelState.DONE.value
-            )
             model._summary_status.update_action(
                 detail="Populated metadata(Custom, Taxonomy and Provenance)",
-                action=f"Call .populate_metadata() to populate metadata.",
+                action="Call .populate_metadata() to populate metadata.",
             )
+
+        model._summary_status.update_status(
+            detail="Generated score.py",
+            status=ModelState.NOTAPPLICABLE.value,
+        )
+        model._summary_status.update_status(
+            detail="Generated runtime.yaml",
+            status=ModelState.NOTAPPLICABLE.value,
+        )
+        model._summary_status.update_status(
+            detail="Serialized model",
+            status=ModelState.NOTAPPLICABLE.value,
+        )
+        model._summary_status.update_status(
+            detail="Populated metadata(Custom, Taxonomy and Provenance)",
+            status=ModelState.AVAILABLE.value
+            if reload
+            else ModelState.NOTAPPLICABLE.value,
+        )
 
         return model
 
@@ -3038,6 +3046,7 @@ class ModelState(Enum):
     AVAILABLE = "Available"
     NOTAVAILABLE = "Not Available"
     NEEDSACTION = "Needs Action"
+    NOTAPPLICABLE = "Not Applicable"
 
 
 class SummaryStatus:

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -1355,7 +1355,7 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
             force_overwrite=force_overwrite,
             ignore_conda_error=ignore_conda_error,
             model_file_name=model_file_name,
-            reload=kwargs.pop("reload", None),
+            reload=kwargs.pop("reload", False),
         )
         model = cls(
             estimator=model_artifact.model,

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -1351,10 +1351,11 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         model_artifact = ModelArtifact.from_uri(
             uri=uri,
             artifact_dir=artifact_dir,
-            model_file_name=model_file_name,
-            force_overwrite=force_overwrite,
             auth=auth,
+            force_overwrite=force_overwrite,
             ignore_conda_error=ignore_conda_error,
+            model_file_name=model_file_name,
+            reload=kwargs.pop("reload", None),
         )
         model = cls(
             estimator=model_artifact.model,

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -1348,6 +1348,7 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         properties.with_dict(local_vars)
         auth = auth or authutil.default_signer()
         artifact_dir = _prepare_artifact_dir(artifact_dir)
+        reload = kwargs.pop("reload", False)
         model_artifact = ModelArtifact.from_uri(
             uri=uri,
             artifact_dir=artifact_dir,
@@ -1355,7 +1356,7 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
             force_overwrite=force_overwrite,
             ignore_conda_error=ignore_conda_error,
             model_file_name=model_file_name,
-            reload=kwargs.pop("reload", False),
+            reload=reload,
         )
         model = cls(
             estimator=model_artifact.model,
@@ -1368,22 +1369,25 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         model.local_copy_dir = model_artifact.local_copy_dir
         model.model_artifact = model_artifact
         model.ignore_conda_error = ignore_conda_error
-        model.reload_runtime_info()
-        model._summary_status.update_status(
-            detail="Generated score.py",
-            status=ModelState.DONE.value,
-        )
-        model._summary_status.update_status(
-            detail="Generated runtime.yaml",
-            status=ModelState.DONE.value,
-        )
-        model._summary_status.update_status(
-            detail="Serialized model", status=ModelState.DONE.value
-        )
-        model._summary_status.update_action(
-            detail="Populated metadata(Custom, Taxonomy and Provenance)",
-            action=f"Call .populate_metadata() to populate metadata.",
-        )
+
+        if reload:
+            model.reload_runtime_info()
+            model._summary_status.update_status(
+                detail="Generated score.py",
+                status=ModelState.DONE.value,
+            )
+            model._summary_status.update_status(
+                detail="Generated runtime.yaml",
+                status=ModelState.DONE.value,
+            )
+            model._summary_status.update_status(
+                detail="Serialized model", status=ModelState.DONE.value
+            )
+            model._summary_status.update_action(
+                detail="Populated metadata(Custom, Taxonomy and Provenance)",
+                action=f"Call .populate_metadata() to populate metadata.",
+            )
+
         return model
 
     @classmethod

--- a/tests/unitary/with_extras/model/test_generic_model.py
+++ b/tests/unitary/with_extras/model/test_generic_model.py
@@ -807,7 +807,6 @@ class TestGenericModel:
                 # )
                 assert test_result == {"result": "result"}
 
-    # @pytest.mark.skip(reason="need to fix later.")
     @pytest.mark.parametrize(
         "test_args",
         [
@@ -849,6 +848,7 @@ class TestGenericModel:
                 "uri": "src/folder",
                 "force_overwrite": True,
                 "auth": {"config": "value"},
+                "reload": True,
             },
         ],
     )
@@ -882,6 +882,7 @@ class TestGenericModel:
             auth=test_args.get("auth", {"config": "value"}),
             model_file_name=test_args.get("model_file_name"),
             ignore_conda_error=False,
+            reload=test_args.get("reload", False),
         )
 
         if not test_args.get("as_onnx"):
@@ -899,8 +900,10 @@ class TestGenericModel:
                 properties=ModelProperties(),
                 as_onnx=True,
             )
-
-        mock_reload_runtime_info.assert_called()
+        if test_args.get("reload", False):
+            mock_reload_runtime_info.assert_called()
+        else:
+            mock_reload_runtime_info.assert_not_called()
         assert test_result == None
 
     @patch("ads.common.auth.default_signer")


### PR DESCRIPTION
# Description
JIRA: https://jira.oci.oraclecorp.com/browse/ODSC-50786
The current working environment might not fit for the model it trying to loading from MD or MC. reload's failure will crash the call.  In the case of loading MD using container runtime, the message to remind user to set `ignore_conda_error=True` appears after long waiting time for loading model artifacts. 

In fact, user don't need to load the model into environment if they're not going to invoke model locally.

# Change
Not load model into environment when calling `GenericModel.from_id` by default. This will not break current user experience as when user trying to invoke model locally by `verify()`, the `reload_artifact` parameter in `verify()` is True by default. So it will reload at the time of need.

# User Experience
Check out [here](https://confluence.oci.oraclecorp.com/x/TKqP2Q) for more details.
* By default, not reload model into environment
```
model = GenericModel.from_id(md_ocid)

# load model into environment when invoking verify()
model.verify()
```

* User wants to reload model into environment at the time of `from_id`
```
# load model into environment when invoking from_id with reload=True
model = GenericModel.from_id(md_ocid, reload=True)
```



