### PR TITLE
Bugfix/ODSC-50785/auth passed in GenericModel.save cannot be used by OCIDataScienceMixin 

### DIFF
--- a/ads/common/oci_mixin.py
+++ b/ads/common/oci_mixin.py
@@ -969,7 +969,8 @@ class OCIWorkRequestMixin:
                 logger.error(f"Max wait time ({max_wait_time} seconds) exceeded.")
             previous_percent_complete = 0
             while not exceed_max_time and (
-                not work_request_logs or previous_percent_complete <= WORK_REQUEST_PERCENTAGE
+                not work_request_logs
+                or previous_percent_complete <= WORK_REQUEST_PERCENTAGE
             ):
                 time.sleep(poll_interval)
                 new_work_request_logs = []
@@ -986,7 +987,9 @@ class OCIWorkRequestMixin:
                     work_request_logs[i:] if work_request_logs else []
                 )
 
-                percent_change = work_request.percent_complete - previous_percent_complete
+                percent_change = (
+                    work_request.percent_complete - previous_percent_complete
+                )
                 previous_percent_complete = work_request.percent_complete
 
                 if len(new_work_request_logs) > 0:

--- a/ads/common/oci_mixin.py
+++ b/ads/common/oci_mixin.py
@@ -274,7 +274,7 @@ class OCISerializableMixin(OCIClientMixin):
         else:
             return cls.__deserialize_model(data, to_cls)
 
-    @classmethod
+    @class_or_instance_method
     def __deserialize_model(cls, data, to_cls):
         """De-serializes list or dict to model."""
         if isinstance(data, to_cls):

--- a/ads/model/artifact.py
+++ b/ads/model/artifact.py
@@ -30,13 +30,13 @@ SCORE_VERSION = "1.0"
 ADS_VERSION = __version__
 
 
-class ArtifactNestedFolderError(Exception):   # pragma: no cover
+class ArtifactNestedFolderError(Exception):  # pragma: no cover
     def __init__(self, folder: str):
         self.folder = folder
         super().__init__("The required artifact files placed in a nested folder.")
 
 
-class ArtifactRequiredFilesError(Exception):   # pragma: no cover
+class ArtifactRequiredFilesError(Exception):  # pragma: no cover
     def __init__(self, required_files: Tuple[str]):
         super().__init__(
             "Not all required files presented in artifact folder. "
@@ -44,7 +44,7 @@ class ArtifactRequiredFilesError(Exception):   # pragma: no cover
         )
 
 
-class AritfactFolderStructureError(Exception):   # pragma: no cover
+class AritfactFolderStructureError(Exception):  # pragma: no cover
     def __init__(self, required_files: Tuple[str]):
         super().__init__(
             "The artifact folder has a wrong structure. "
@@ -225,7 +225,8 @@ class ModelArtifact:
         Raises
         ------
         ValueError
-            If neither slug or conda_env_uri is provided.
+            If inference_python_version is not provided.
+            If runtime.yaml already exists.
 
         Returns
         -------

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -216,6 +216,7 @@ class DataScienceModel(Builder):
             - provenance_metadata: Union[ModelProvenanceMetadata, Dict]
             - artifact: str
         """
+        self.auth = kwargs.pop("auth", None)
         super().__init__(spec=spec, **deepcopy(kwargs))
         # Reinitiate complex attributes
         self._init_complex_attributes()
@@ -972,7 +973,7 @@ class DataScienceModel(Builder):
                 dsc_spec[dsc_attr] = value
 
         dsc_spec.update(**kwargs)
-        return OCIDataScienceModel(**dsc_spec)
+        return OCIDataScienceModel(**dsc_spec, **self.auth)
 
     def _update_from_oci_dsc_model(
         self, dsc_model: OCIDataScienceModel

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -216,7 +216,7 @@ class DataScienceModel(Builder):
             - provenance_metadata: Union[ModelProvenanceMetadata, Dict]
             - artifact: str
         """
-        self.auth = kwargs.pop("auth", None)
+        self.auth = kwargs.pop("auth", {})
         super().__init__(spec=spec, **deepcopy(kwargs))
         # Reinitiate complex attributes
         self._init_complex_attributes()

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -216,7 +216,6 @@ class DataScienceModel(Builder):
             - provenance_metadata: Union[ModelProvenanceMetadata, Dict]
             - artifact: str
         """
-        self.auth = kwargs.pop("auth", {})
         super().__init__(spec=spec, **deepcopy(kwargs))
         # Reinitiate complex attributes
         self._init_complex_attributes()
@@ -971,9 +970,9 @@ class DataScienceModel(Builder):
                 )()
             else:
                 dsc_spec[dsc_attr] = value
-
+        auth = kwargs.pop("auth", {})
         dsc_spec.update(**kwargs)
-        return OCIDataScienceModel(**dsc_spec, **self.auth)
+        return OCIDataScienceModel(**dsc_spec, **auth)
 
     def _update_from_oci_dsc_model(
         self, dsc_model: OCIDataScienceModel

--- a/ads/model/deployment/model_deployment.py
+++ b/ads/model/deployment/model_deployment.py
@@ -286,7 +286,6 @@ class ModelDeployment(Builder):
         kwargs:
             Keyword arguments for initializing `ModelDeploymentProperties` or `ModelDeployment`.
         """
-
         if spec and properties:
             raise ValueError(
                 "You can only pass in either `spec` or `properties` to initialize model deployment instance."
@@ -953,7 +952,9 @@ class ModelDeployment(Builder):
         except oci.exceptions.ServiceError as ex:
             # When bandwidth exceeds the allocated value, TooManyRequests error (429) will be raised by oci backend.
             if ex.status == 429:
-                bandwidth_mbps = self.infrastructure.bandwidth_mbps or DEFAULT_BANDWIDTH_MBPS
+                bandwidth_mbps = (
+                    self.infrastructure.bandwidth_mbps or DEFAULT_BANDWIDTH_MBPS
+                )
                 utils.get_logger().warning(
                     f"Load balancer bandwidth exceeds the allocated {bandwidth_mbps} Mbps."
                     "To estimate the actual bandwidth, use formula: (payload size in KB) * (estimated requests per second) * 8 / 1024."

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -368,7 +368,7 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         self.estimator = estimator
         self.auth = auth or authutil.default_signer()
         self.dsc_model = (
-            DataScienceModel()
+            DataScienceModel(auth=self.auth)
             .with_custom_metadata_list(ModelCustomMetadata())
             .with_provenance_metadata(ModelProvenanceMetadata())
             .with_defined_metadata_list(ModelTaxonomyMetadata())

--- a/ads/model/generic_model.py
+++ b/ads/model/generic_model.py
@@ -368,7 +368,7 @@ class GenericModel(MetadataMixin, Introspectable, EvaluatorMixin):
         self.estimator = estimator
         self.auth = auth or authutil.default_signer()
         self.dsc_model = (
-            DataScienceModel(auth=self.auth)
+            DataScienceModel()
             .with_custom_metadata_list(ModelCustomMetadata())
             .with_provenance_metadata(ModelProvenanceMetadata())
             .with_defined_metadata_list(ModelTaxonomyMetadata())

--- a/tests/unitary/with_extras/model/test_generic_model.py
+++ b/tests/unitary/with_extras/model/test_generic_model.py
@@ -1137,6 +1137,7 @@ class TestGenericModel:
     def test_update_deployment_instance_level_with_id(
         self, mock_client, mock_signer, mock_update
     ):
+        mock_signer.return_value = {}
         test_model_deployment_id = "xxxx.datasciencemodeldeployment.xxxx"
         md_props = ModelDeploymentProperties(model_id=test_model_deployment_id)
         md = ModelDeployment(properties=md_props)
@@ -1144,8 +1145,7 @@ class TestGenericModel:
         test_model = MagicMock(model_deployment=md, _summary_status=SummaryStatus())
         mock_update.return_value = test_model
 
-        generic_model = GenericModel(estimator=TestEstimator())
-        test_result = generic_model.update_deployment(
+        test_result = self.generic_model.update_deployment(
             model_deployment_id=test_model_deployment_id,
             properties=None,
             wait_for_completion=True,
@@ -1281,11 +1281,10 @@ class TestGenericModel:
         test_model_deployment_id = "xxxx.datasciencemodeldeployment.xxxx"
         md_props = ModelDeploymentProperties(model_id=test_model_deployment_id)
         md = ModelDeployment(properties=md_props)
-        generic_model = GenericModel(estimator=TestEstimator())
-        generic_model.model_deployment = md
+        self.generic_model.model_deployment = md
         mock_deactivate.return_value = md
         mock_activate.return_value = md
-        generic_model.restart_deployment(max_wait_time=2000, poll_interval=50)
+        self.generic_model.restart_deployment(max_wait_time=2000, poll_interval=50)
         mock_deactivate.assert_called_with(max_wait_time=2000, poll_interval=50)
         mock_activate.assert_called_with(max_wait_time=2000, poll_interval=50)
 


### PR DESCRIPTION
# Description
JIRA: https://jira.oci.oraclecorp.com/browse/ODSC-50785
`GenericModel` has auth attribute but `auth` passed at the time of initialization of `GenericModel` doesn’t apply when interacting with service. The resources are still created by default auth set through `ads.set_auth`.  To be able to override service endpoint for a specific service and not change any other service endpoint, we have two options:
1. add auth properties into DataScienceModel 
2. passing auth at the time of invoking the service, i.e. `save()`.

This PR now go with option 2 for the following reasons:
1. `save()` is expecting to accept auth currently and it should pass the accepting auth into [DataScienceModel.create()](https://github.com/oracle/accelerated-data-science/blob/main/ads/model/datascience_model.py#L564), the reason it not work now because of some bugs, which have been fixed in this PR.
2. Similar to 1, [DataScienceModel.create()](https://github.com/oracle/accelerated-data-science/blob/main/ads/model/datascience_model.py#L564) is designed to accept auth. 
3. Avoid being inconsistent with other resources creations in ads. We still want to have option to override service endpoint, this will be handled in a separate task as it requires redesign of our Builder.

# User experience for option 2
```
# Use resource_principal in general use case by default
ads.set_auth("resource_principal")

# Use default auth in other client
...

generic_model = GenericModel(artifact_dir="./test_model")
generic_model.prepare()

# Saving model to specific service_endpoint
my_auth = ads.common.auth.resource_principal(client_kwargs={"service_endpoint":"https://datascience-int.us-ashburn-1.oci.oc-test.com/xxx"})
generic_model.save(auth=my_auth)
```

![Screenshot 2023-12-19 at 4 43 34 PM](https://github.com/oracle/accelerated-data-science/assets/49049296/43e851f0-6264-4759-a805-6487adcc9b35)
![Screenshot 2023-12-19 at 4 48 24 PM](https://github.com/oracle/accelerated-data-science/assets/49049296/ff1c2d38-014f-41eb-9c96-de2ba3366d3a)



# Discussion on adding `auth` property into `DataScienceModel`
Before continuing to add `auth` property into `DataScienceModel` class, noticing deprecation message in [ModelDeployment class](https://github.com/oracle/accelerated-data-science/blob/main/ads/model/deployment/model_deployment.py#L303). 
```
Parameter `config` was deprecated in 2.8.2 from ModelDeployment constructor and will be removed in 3.0.0. Please use `ads.set_auth()` to config the auth information.
```
Looks like it is expected to use `set_auth()` to set authentication instead of passing `auth` parameter. However, If we only want to override datascience service endpoint and not change any other service endpoint,  we need to call `set_auth` back and forth.

See discussion in comments https://github.com/oracle/accelerated-data-science/pull/502#issuecomment-1863521734.