### PR TITLE
updating user error message

### DIFF
--- a/ads/common/decorator/runtime_dependency.py
+++ b/ads/common/decorator/runtime_dependency.py
@@ -41,9 +41,7 @@ from .utils import _get_original_func
 
 logger = logging.getLogger(__name__)
 
-MODULE_NOT_FOUND_ERROR = (
-    "The `{module}` module was not found. Please run `pip install {package}`."
-)
+MODULE_NOT_FOUND_ERROR = "The `{module}` module was not found. Please run `pip install {package}`. If this does not work, then install module `{module}` via pypi."
 IMPORT_ERROR = "Cannot import name `{object}` from `{module}`."
 
 

--- a/ads/opctl/backend/local.py
+++ b/ads/opctl/backend/local.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import copy
@@ -110,7 +110,11 @@ class LocalBackend(Backend):
                     f"Run with the --debug argument to view container logs."
                 )
 
-    @runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
+    @runtime_dependency(
+        module="docker",
+        install_from=OptionalDependency.OPCTL,
+        err_msg="The library `docker` cannot be found. Please pip install docker.",
+    )
     def init_vscode_container(self) -> None:
         """
         Create a .devcontainer.json file for development with VSCode.
@@ -415,7 +419,11 @@ class LocalBackend(Backend):
         return bind_volumes
 
     @staticmethod
-    @runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
+    @runtime_dependency(
+        module="docker",
+        install_from=OptionalDependency.OPCTL,
+        err_msg="The library `docker` cannot be found. Please pip install docker.",
+    )
     def _activate_conda_env_and_run(
         image: str, slug: str, command: List[str], bind_volumes: Dict, env_vars: Dict
     ) -> int:

--- a/ads/opctl/backend/local.py
+++ b/ads/opctl/backend/local.py
@@ -110,11 +110,7 @@ class LocalBackend(Backend):
                     f"Run with the --debug argument to view container logs."
                 )
 
-    @runtime_dependency(
-        module="docker",
-        install_from=OptionalDependency.OPCTL,
-        err_msg="The library `docker` cannot be found. Please pip install docker.",
-    )
+    @runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
     def init_vscode_container(self) -> None:
         """
         Create a .devcontainer.json file for development with VSCode.
@@ -419,11 +415,7 @@ class LocalBackend(Backend):
         return bind_volumes
 
     @staticmethod
-    @runtime_dependency(
-        module="docker",
-        install_from=OptionalDependency.OPCTL,
-        err_msg="The library `docker` cannot be found. Please pip install docker.",
-    )
+    @runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
     def _activate_conda_env_and_run(
         image: str, slug: str, command: List[str], bind_volumes: Dict, env_vars: Dict
     ) -> int:

--- a/ads/opctl/conda/cmds.py
+++ b/ads/opctl/conda/cmds.py
@@ -58,11 +58,7 @@ def _fetch_manifest_template() -> Dict:
     return manifest_template
 
 
-@runtime_dependency(
-    module="docker",
-    install_from=OptionalDependency.OPCTL,
-    err_msg="The library `docker` cannot be found. Please pip install docker.",
-)
+@runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
 def _check_job_image_exists(gpu: bool) -> None:
     if gpu:
         image = ML_JOB_GPU_IMAGE

--- a/ads/opctl/config/resolver.py
+++ b/ads/opctl/config/resolver.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import base64
@@ -121,7 +121,11 @@ class ConfigResolver(ConfigProcessor):
             "operator_name"
         ) or self.config.get("name")
 
-    @runtime_dependency(module="inflection", install_from=OptionalDependency.OPCTL)
+    @runtime_dependency(
+        module="inflection",
+        install_from=OptionalDependency.OPCTL,
+        err_msg="The library `inflection` cannot be found. Please pip install inflection.",
+    )
     def _resolve_source_folder_path(self) -> None:
         # this should be run after resolve_operator_name()
         # resolve ADS operator source folder path

--- a/ads/opctl/config/resolver.py
+++ b/ads/opctl/config/resolver.py
@@ -121,11 +121,7 @@ class ConfigResolver(ConfigProcessor):
             "operator_name"
         ) or self.config.get("name")
 
-    @runtime_dependency(
-        module="inflection",
-        install_from=OptionalDependency.OPCTL,
-        err_msg="The library `inflection` cannot be found. Please pip install inflection.",
-    )
+    @runtime_dependency(module="inflection", install_from=OptionalDependency.OPCTL)
     def _resolve_source_folder_path(self) -> None:
         # this should be run after resolve_operator_name()
         # resolve ADS operator source folder path

--- a/ads/opctl/config/utils.py
+++ b/ads/opctl/config/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2022 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import configparser
@@ -16,15 +16,15 @@ from ads.common.decorator.runtime_dependency import (
 )
 
 
-class OperatorNotFound(Exception):   # pragma: no cover
+class OperatorNotFound(Exception):  # pragma: no cover
     pass
 
 
-class CondaPackInfoNotProvided(Exception):   # pragma: no cover
+class CondaPackInfoNotProvided(Exception):  # pragma: no cover
     pass
 
 
-class NotSupportedError(Exception):   # pragma: no cover
+class NotSupportedError(Exception):  # pragma: no cover
     pass
 
 
@@ -42,8 +42,16 @@ def read_from_ini(path: str) -> configparser.ConfigParser:
     return parser
 
 
-@runtime_dependency(module="nbformat", install_from=OptionalDependency.OPCTL)
-@runtime_dependency(module="nbconvert", install_from=OptionalDependency.OPCTL)
+@runtime_dependency(
+    module="nbformat",
+    install_from=OptionalDependency.OPCTL,
+    err_msg="The library `nbformat` cannot be found. Please pip install nbformat.",
+)
+@runtime_dependency(
+    module="nbconvert",
+    install_from=OptionalDependency.OPCTL,
+    err_msg="The library `nbconvert` cannot be found. Please pip install nbconvert.",
+)
 def convert_notebook(
     input_path,
     auth,

--- a/ads/opctl/config/utils.py
+++ b/ads/opctl/config/utils.py
@@ -42,16 +42,8 @@ def read_from_ini(path: str) -> configparser.ConfigParser:
     return parser
 
 
-@runtime_dependency(
-    module="nbformat",
-    install_from=OptionalDependency.OPCTL,
-    err_msg="The library `nbformat` cannot be found. Please pip install nbformat.",
-)
-@runtime_dependency(
-    module="nbconvert",
-    install_from=OptionalDependency.OPCTL,
-    err_msg="The library `nbconvert` cannot be found. Please pip install nbconvert.",
-)
+@runtime_dependency(module="nbformat", install_from=OptionalDependency.OPCTL)
+@runtime_dependency(module="nbconvert", install_from=OptionalDependency.OPCTL)
 def convert_notebook(
     input_path,
     auth,

--- a/ads/opctl/distributed/cmds.py
+++ b/ads/opctl/distributed/cmds.py
@@ -141,11 +141,7 @@ def show_config_info(job_id, work_dir, cluster_file_name, worker_info, **kwargs)
         )
 
 
-@runtime_dependency(
-    module="docker",
-    install_from=OptionalDependency.OPCTL,
-    err_msg="The library `docker` cannot be found. Please pip install docker.",
-)
+@runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
 def verify_image(img_name):
     """
     Verify if the input image exists in OCI registry

--- a/ads/opctl/distributed/cmds.py
+++ b/ads/opctl/distributed/cmds.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import json
@@ -141,7 +141,11 @@ def show_config_info(job_id, work_dir, cluster_file_name, worker_info, **kwargs)
         )
 
 
-@runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
+@runtime_dependency(
+    module="docker",
+    install_from=OptionalDependency.OPCTL,
+    err_msg="The library `docker` cannot be found. Please pip install docker.",
+)
 def verify_image(img_name):
     """
     Verify if the input image exists in OCI registry

--- a/ads/opctl/operator/cmd.py
+++ b/ads/opctl/operator/cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*--
 
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import os
@@ -69,7 +69,11 @@ def list() -> None:
     )
 
 
-@runtime_dependency(module="rich", install_from=OptionalDependency.OPCTL)
+@runtime_dependency(
+    module="rich",
+    install_from=OptionalDependency.OPCTL,
+    err_msg="The library `rich` cannot be found. Please pip install rich.",
+)
 def info(
     type: str,
     **kwargs: Dict[str, Any],
@@ -220,7 +224,11 @@ def init(
     logger.info("#" * 50)
 
 
-@runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
+@runtime_dependency(
+    module="docker",
+    install_from=OptionalDependency.OPCTL,
+    err_msg="The library `docker` cannot be found. Please pip install docker.",
+)
 @validate_environment
 def build_image(
     type: str = None,
@@ -318,7 +326,11 @@ def build_image(
         )
 
 
-@runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
+@runtime_dependency(
+    module="docker",
+    install_from=OptionalDependency.OPCTL,
+    err_msg="The library `docker` cannot be found. Please pip install docker.",
+)
 @validate_environment
 def publish_image(
     type: str,

--- a/ads/opctl/operator/cmd.py
+++ b/ads/opctl/operator/cmd.py
@@ -69,11 +69,7 @@ def list() -> None:
     )
 
 
-@runtime_dependency(
-    module="rich",
-    install_from=OptionalDependency.OPCTL,
-    err_msg="The library `rich` cannot be found. Please pip install rich.",
-)
+@runtime_dependency(module="rich", install_from=OptionalDependency.OPCTL)
 def info(
     type: str,
     **kwargs: Dict[str, Any],
@@ -224,11 +220,7 @@ def init(
     logger.info("#" * 50)
 
 
-@runtime_dependency(
-    module="docker",
-    install_from=OptionalDependency.OPCTL,
-    err_msg="The library `docker` cannot be found. Please pip install docker.",
-)
+@runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
 @validate_environment
 def build_image(
     type: str = None,
@@ -326,11 +318,7 @@ def build_image(
         )
 
 
-@runtime_dependency(
-    module="docker",
-    install_from=OptionalDependency.OPCTL,
-    err_msg="The library `docker` cannot be found. Please pip install docker.",
-)
+@runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
 @validate_environment
 def publish_image(
     type: str,

--- a/ads/opctl/utils.py
+++ b/ads/opctl/utils.py
@@ -252,11 +252,7 @@ def suppress_traceback(debug: bool = True) -> None:
     return decorator
 
 
-@runtime_dependency(
-    module="docker",
-    install_from=OptionalDependency.OPCTL,
-    err_msg="The library `docker` cannot be found. Please pip install docker.",
-)
+@runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
 def get_docker_client() -> "docker.client.DockerClient":
     import docker
 
@@ -269,11 +265,7 @@ def get_docker_client() -> "docker.client.DockerClient":
     return docker.from_env()
 
 
-@runtime_dependency(
-    module="docker",
-    install_from=OptionalDependency.OPCTL,
-    err_msg="The library `docker` cannot be found. Please pip install docker.",
-)
+@runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
 def run_container(
     image: str,
     bind_volumes: Dict,

--- a/ads/opctl/utils.py
+++ b/ads/opctl/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 
@@ -252,7 +252,11 @@ def suppress_traceback(debug: bool = True) -> None:
     return decorator
 
 
-@runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
+@runtime_dependency(
+    module="docker",
+    install_from=OptionalDependency.OPCTL,
+    err_msg="The library `docker` cannot be found. Please pip install docker.",
+)
 def get_docker_client() -> "docker.client.DockerClient":
     import docker
 
@@ -265,7 +269,11 @@ def get_docker_client() -> "docker.client.DockerClient":
     return docker.from_env()
 
 
-@runtime_dependency(module="docker", install_from=OptionalDependency.OPCTL)
+@runtime_dependency(
+    module="docker",
+    install_from=OptionalDependency.OPCTL,
+    err_msg="The library `docker` cannot be found. Please pip install docker.",
+)
 def run_container(
     image: str,
     bind_volumes: Dict,


### PR DESCRIPTION
A few users have come across an issue when trying to use ads opctl. They get the error message "Please run `pip install oracle-ads[opctl]` to install the required dependencies for ADS CLI", which is too vague. Some customers don't have internet access to re-install the library, or are working on a version of the library that isn't installable through pypi for one reason or another.

This is a small PR to update the error messages