### PR TITLE
Update Copyright Check for 2024 and Fix LangChain tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,52 +1,52 @@
 repos:
-# Standard hooks
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
-    hooks:
-    -   id: check-ast
-        exclude: ^docs/
-    -   id: check-docstring-first
-        exclude: ^(docs/|tests/)
-    -   id: check-json
-    -   id: check-merge-conflict
-    -   id: check-yaml
-        exclude: feature_store_*.yaml
-        args: ['--allow-multiple-documents']
-    -   id: detect-private-key
-    -   id: end-of-file-fixer
-        exclude: '\.ipynb?$'
-    -   id: pretty-format-json
-        args: ['--autofix']
-    -   id: trailing-whitespace
-        args: [--markdown-linebreak-ext=md]
-        exclude: ^docs/
-# Black, the code formatter, natively supports pre-commit
--   repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-    -   id: black
-        exclude: ^docs/
-# Regex based rst files common mistakes detector
--   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
-    hooks:
-    -   id: rst-backticks
-        files: ^docs/
-    -   id: rst-inline-touching-normal
-        files: ^docs/
-# Hardcoded secrets and ocids detector
--   repo: https://github.com/gitleaks/gitleaks
-    rev: v8.17.0
-    hooks:
-    -   id: gitleaks
-        exclude: .github/workflows/reusable-actions/set-dummy-conf.yml
-# Oracle copyright checker
--   repo: https://github.com/oracle-samples/oci-data-science-ai-samples/
-    rev: cbe0136f7aaffe463b31ddf3f34b0e16b4b124ff
-    hooks:
-    -   id: check-copyright
-        name: check-copyright
-        entry: .pre-commit-scripts/check-copyright.py
-        language: script
-        types_or: ['python', 'shell', 'bash']
-        exclude: ^docs/
+    # Standard hooks
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.4.0
+      hooks:
+          - id: check-ast
+            exclude: ^docs/
+          - id: check-docstring-first
+            exclude: ^(docs/|tests/)
+          - id: check-json
+          - id: check-merge-conflict
+          - id: check-yaml
+            exclude: feature_store_*.yaml
+            args: ["--allow-multiple-documents"]
+          - id: detect-private-key
+          - id: end-of-file-fixer
+            exclude: '\.ipynb?$'
+          - id: pretty-format-json
+            args: ["--autofix"]
+          - id: trailing-whitespace
+            args: [--markdown-linebreak-ext=md]
+            exclude: ^docs/
+    # Black, the code formatter, natively supports pre-commit
+    - repo: https://github.com/psf/black
+      rev: 23.3.0
+      hooks:
+          - id: black
+            exclude: ^docs/
+    # Regex based rst files common mistakes detector
+    - repo: https://github.com/pre-commit/pygrep-hooks
+      rev: v1.10.0
+      hooks:
+          - id: rst-backticks
+            files: ^docs/
+          - id: rst-inline-touching-normal
+            files: ^docs/
+    # Hardcoded secrets and ocids detector
+    - repo: https://github.com/gitleaks/gitleaks
+      rev: v8.17.0
+      hooks:
+          - id: gitleaks
+            exclude: .github/workflows/reusable-actions/set-dummy-conf.yml
+    # Oracle copyright checker
+    - repo: https://github.com/oracle-samples/oci-data-science-ai-samples/
+      rev: 1bc5270a443b791c62f634233c0f4966dfcc0dd6
+      hooks:
+          - id: check-copyright
+            name: check-copyright
+            entry: .pre-commit-scripts/check-copyright.py
+            language: script
+            types_or: ["python", "shell", "bash"]
+            exclude: ^docs/

--- a/ads/llm/chain.py
+++ b/ads/llm/chain.py
@@ -261,12 +261,8 @@ class GuardrailSequence(RunnableSequence):
         from ads.llm.serialize import load
 
         chain_spec = chain_dict[SPEC_CHAIN]
-        chain = cls()
-        for config in chain_spec:
-            step = load(config, **kwargs)
-            # Chain the step
-            chain |= step
-        return chain
+        steps = [load(config, **kwargs) for config in chain_spec]
+        return cls(*steps)
 
     def __str__(self) -> str:
         return "\n".join([str(step.__class__) for step in self.steps])

--- a/tests/unitary/with_extras/langchain/test_guardrails.py
+++ b/tests/unitary/with_extras/langchain/test_guardrails.py
@@ -175,10 +175,6 @@ class GuardrailSequenceTests(GuardrailTestsBase):
 
         self.assert_before_and_after_serialization(test_fn, chain)
 
-    def test_empty_sequence(self):
-        """Tests empty sequence."""
-        seq = GuardrailSequence()
-        self.assertEqual(seq.steps, [])
 
     def test_save_to_file(self):
         """Tests saving to file."""


### PR DESCRIPTION
- Use new [version](https://github.com/oracle-samples/oci-data-science-ai-samples/commit/1bc5270a443b791c62f634233c0f4966dfcc0dd6) of copyright checking script.
- Formatted the `.pre-commit-config.yaml` with black.
- Update LangChain serialization test to be less dependent on the LangChain version (Recent updates on LangChain added new fields).
- Update GuardrailSequence to be compatible with LangChain 0.0.353