### PR TITLE
Fixed artifact dir

### DIFF
--- a/ads/model/artifact_downloader.py
+++ b/ads/model/artifact_downloader.py
@@ -63,7 +63,7 @@ class ArtifactDownloader(ABC):
                     "Set `force_overwrite` to `True` if you wish to overwrite."
                 )
             shutil.rmtree(self.target_dir)
-            os.mkdir(self.target_dir)
+        os.makedirs(self.target_dir, exist_ok=True)
         with utils.get_progress_bar(
             ArtifactDownloader.PROGRESS_STEPS_COUNT + self.PROGRESS_STEPS_COUNT
         ) as progress:


### PR DESCRIPTION
### Notebook

- Non-existing `artifact_dir`
<img width="1153" alt="Screenshot 2024-01-09 at 4 03 15 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/cd67b658-597e-4b13-9129-a9b1b5558742">


- Empty `artifact_dir`
<img width="1165" alt="Screenshot 2024-01-09 at 4 06 28 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/5a7cdf37-9ebd-42de-af25-34012dbb23ec">


- Existing `artifact_dir` with `force_overwrite` as False
<img width="1156" alt="Screenshot 2024-01-09 at 4 03 35 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/03e2ebd1-bca9-4ef3-b9bf-396d5ecc7f06">


- Existing `artifact_dir` with `force_overwrite` as True
<img width="1165" alt="Screenshot 2024-01-09 at 4 03 51 PM" src="https://github.com/oracle/accelerated-data-science/assets/118394507/fcb7a0d4-7100-4fc2-a50c-85a9bab51514">