### PR TITLE
Uptake bokeh and fix ADS BokehHeatMap

### DIFF
--- a/ads/dataset/correlation_plot.py
+++ b/ads/dataset/correlation_plot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import os
@@ -26,7 +26,6 @@ class BokehHeatMap(object):
 
     @runtime_dependency(module="bokeh", install_from=OptionalDependency.VIZ)
     def __init__(self, ds):
-
         from bokeh.io import output_notebook
         from bokeh.palettes import BuPu
 
@@ -120,8 +119,8 @@ class BokehHeatMap(object):
             y_range=yrange,
             toolbar_location="below",
             toolbar_sticky=False,
-            plot_width=600,
-            plot_height=600,
+            width=600,
+            height=600,
         )
 
         p.rect(
@@ -196,8 +195,8 @@ class BokehHeatMap(object):
             y_range=(0, len(matrix["Y"]) + 1),
             toolbar_location="below",
             toolbar_sticky=False,
-            plot_width=600,
-            plot_height=600,
+            width=600,
+            height=600,
         )
 
         p.hbar(
@@ -229,7 +228,6 @@ class BokehHeatMap(object):
             level="glyph",
             y_offset=-5,
             source=source,
-            render_mode="canvas",
         )
 
         p.add_layout(color_bar, "right")
@@ -264,7 +262,7 @@ class BokehHeatMap(object):
         from bokeh.plotting import figure
 
         if len(corr_matrix) == 0:
-            tab = bokeh.models.Panel(
+            tab = bokeh.models.TabPanel(
                 child=figure(title=msg + ", nothing to display"),
                 title=title,
             )
@@ -286,7 +284,7 @@ class BokehHeatMap(object):
             tool_tips=[("X", "@x"), ("Y", "@y"), ("Corr", "@corr")],
         )
 
-        tab = bokeh.models.Panel(child=p, title=title)
+        tab = bokeh.models.TabPanel(child=p, title=title)
         return tab
 
     @runtime_dependency(module="bokeh", install_from=OptionalDependency.VIZ)
@@ -323,7 +321,7 @@ class BokehHeatMap(object):
         from bokeh.plotting import figure
 
         if len(corr_matrix) == 0:
-            tab = bokeh.models.Panel(
+            tab = bokeh.models.TabPanel(
                 child=figure(title=msg + ", nothing to display"),
                 title=title,
             )
@@ -333,7 +331,7 @@ class BokehHeatMap(object):
 
         assert correlation_target, "Correlation target is required for this plot"
         if correlation_target not in corr_matrix.columns:
-            tab = bokeh.models.Panel(
+            tab = bokeh.models.TabPanel(
                 child=figure(title="No Data to display"), title=title
             )
             return tab
@@ -382,7 +380,7 @@ class BokehHeatMap(object):
             column_name=correlation_target,
         )
 
-        tab = bokeh.models.Panel(child=p, title=title)
+        tab = bokeh.models.TabPanel(child=p, title=title)
         return tab
 
     @runtime_dependency(module="bokeh", install_from=OptionalDependency.VIZ)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ torch = [
   "torchvision",
 ]
 viz = [
-  "bokeh>=2.3.0, <=2.4.3",
+  "bokeh>=3.0.0, <3.2.0",  # starting 3.2.0 bokeh not supporting python3.8; relax after ADS will drop py3.8 support
   "folium>=0.12.1",
   "graphviz<0.17",
   "scipy>=1.5.4",

--- a/tests/unitary/default_setup/telemetry/test_agent.py
+++ b/tests/unitary/default_setup/telemetry/test_agent.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2022, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import importlib
@@ -50,7 +50,6 @@ class TestUserAgent:
         monkeypatch.delenv("OCI_RESOURCE_PRINCIPAL_VERSION", raising=False)
         monkeypatch.delenv(EXTRA_USER_AGENT_INFO, raising=False)
         importlib.reload(ads.config)
-        importlib.reload(ads.telemetry)
         auth_info = ads.auth.resource_principal()
         assert (
             auth_info["config"].get("additional_user_agent")
@@ -125,12 +124,7 @@ class TestUserAgent:
         monkeypatch.delenv(EXTRA_USER_AGENT_INFO, raising=False)
         if INPUT_DATA[EXTRA_USER_AGENT_INFO] is not None:
             monkeypatch.setenv(EXTRA_USER_AGENT_INFO, INPUT_DATA[EXTRA_USER_AGENT_INFO])
-
         importlib.reload(ads.config)
-        importlib.reload(ads)
-        importlib.reload(ads.auth)
-        importlib.reload(ads.telemetry)
-
         with patch("oci.config.from_file", return_value=self.test_config):
             auth_info = ads.auth.default_signer()
             assert (
@@ -151,10 +145,7 @@ class TestUserAgent:
     ):
         monkeypatch.setenv("OCI_RESOURCE_PRINCIPAL_VERSION", "1.1")
         monkeypatch.delenv(EXTRA_USER_AGENT_INFO, raising=False)
-
         importlib.reload(ads.config)
-        importlib.reload(ads.telemetry)
-
         with patch("oci.config.from_file", return_value=self.test_config):
             auth_info = ads.auth.default_signer()
             assert (

--- a/tests/unitary/with_extras/dataset/test_dataset_correlation_plot.py
+++ b/tests/unitary/with_extras/dataset/test_dataset_correlation_plot.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+import os
+
+import pandas as pd
+import pytest
+import unittest
+
+from ads.dataset.correlation_plot import BokehHeatMap
+from ads.dataset.dataset import ADSDataset
+from ads.dataset.exception import ValidationError
+
+
+class TestBokehHeatMap(unittest.TestCase):
+    dataset = pd.DataFrame(
+        columns=[
+            "one",
+            "two",
+            "three",
+            "four",
+            "five",
+        ],
+        data=[
+            [
+                3.4,
+                999,
+                1,
+                None,
+                95354,
+            ],
+            [
+                3,
+                999,
+                5,
+                None,
+                90421,
+            ],
+            [
+                2,
+                999,
+                1,
+                15,
+                89352,
+            ],
+            [
+                3,
+                999,
+                6,
+                11,
+                89427,
+            ],
+            [
+                2,
+                999,
+                1,
+                46,
+                94342,
+            ],
+        ],
+    )
+    bokeh_heatmap = BokehHeatMap(dataset)
+    corr_matrix = dataset.corr()
+
+    def test_plot_heat_map(self):
+        p = self.bokeh_heatmap.plot_heat_map(
+            self.corr_matrix,
+            xrange=self.corr_matrix.index.values.tolist(),
+            yrange=self.corr_matrix.columns.values.tolist(),
+            title="heat_map",
+        )
+
+        self.assertEqual(str(type(p)), "<class 'bokeh.plotting._figure.figure'>")
+        assert p.width == 600
+        assert p.height == 600
+        assert p.xaxis.major_label_orientation == "vertical"
+        assert len(p.yaxis) == 1
+        assert p.title.text == "heat_map"
+
+    def test_plot_hbar(self):
+        rows = self.corr_matrix.index.values.tolist()
+        columns = self.corr_matrix.columns
+        corr_flatten = pd.DataFrame(
+            [(r, c, self.corr_matrix[r][c]) for c in columns for r in rows],
+            columns=["X", "Y", "corr"],
+        )
+        p = self.bokeh_heatmap.plot_hbar(
+            corr_flatten, title="plot_hbar", column_name="name in title"
+        )
+
+        self.assertEqual(str(type(p)), "<class 'bokeh.plotting._figure.figure'>")
+        assert p.width == 600
+        assert p.height == 600
+        assert p.toolbar_location == "below"
+        assert p.title.text == "plot_hbar (name in title)"
+
+    def test_generate_heatmap(self):
+        tabs = self.bokeh_heatmap.generate_heatmap(
+            self.corr_matrix, title="heatmap", msg="", correlation_threshold=-1
+        )
+
+        self.assertEqual(str(type(tabs)), "<class 'bokeh.models.layouts.TabPanel'>")
+        self.assertEqual(
+            str(type(tabs.child)), "<class 'bokeh.plotting._figure.figure'>"
+        )
+        assert tabs.child.width == 600
+        assert tabs.child.height == 600
+        assert len(tabs.child.yaxis) == 1
+        assert tabs.title == "heatmap"
+
+    def test_generate_target_heatmap(self):
+        tabs = self.bokeh_heatmap.generate_target_heatmap(
+            self.corr_matrix,
+            title="target_heatmap",
+            correlation_target="one",
+            msg="",
+            correlation_threshold=-1,
+        )
+
+        self.assertEqual(str(type(tabs)), "<class 'bokeh.models.layouts.TabPanel'>")
+        self.assertEqual(
+            str(type(tabs.child)), "<class 'bokeh.plotting._figure.figure'>"
+        )
+        assert tabs.child.width == 600
+        assert tabs.child.height == 600
+        assert tabs.child.toolbar_location == "below"
+        assert tabs.title == "target_heatmap"
+
+    def test_plot_correlation_heatmap(self):
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        data_file = os.path.join(current_dir, "data", "orcl_attrition.csv")
+        df = pd.read_csv(data_file)
+        ds = ADSDataset.from_dataframe(df)
+        bokeh_heatmap = BokehHeatMap(ds)
+
+        with pytest.raises(ValidationError):
+            bokeh_heatmap.plot_correlation_heatmap(
+                ds=ds, correlation_methods="wrong_correlation_methods"
+            )
+
+        bokeh_heatmap.plot_correlation_heatmap(ds=ds, correlation_methods="pearson")
+        bokeh_heatmap.plot_correlation_heatmap(ds=ds, correlation_methods="cramers v")
+        bokeh_heatmap.plot_correlation_heatmap(
+            ds=ds, correlation_methods="correlation ratio"
+        )
+
+        with pytest.raises(ValueError):
+            bokeh_heatmap.plot_correlation_heatmap(ds=ds, plot_type="wrong_plot_type")


### PR DESCRIPTION
### Description

The [Bokeh](https://pypi.org/project/bokeh/) stopped supporting a python 3.7 and published a new version (3.0.0) of the package which broke ADS BokehHeatMap API.

Jira: https://jira.oci.oraclecorp.com/browse/ODSC-35230

### What was done

- added new unittests to cover BokehHeatMap class (coverage was 16% for correlation_plot.py)
- updated bokeh >=3.0.0, <3.2.0
- changed deprecated Panel model in 3.0.0 to new model - TabPanel
- removed deprecated in 3.0.0 version attribute 'render_mode' in LabelSet model
- changed deprecated attributes plot_width, plot_height to width, height

Note: removed reload of ads (it is redundant) form failed telemetry agent test. Details why in comments in Jira ticket of this bug.

### Pre-commit
```
check python ast.........................................................Passed
check docstring is first.................................................Passed
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check yaml...........................................(no files to check)Skipped
detect private key.......................................................Passed
fix end of files.........................................................Passed
pretty format json...................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
black....................................................................Passed
rst ``code`` is two backticks........................(no files to check)Skipped
rst ``inline code`` next to normal text..............(no files to check)Skipped
Detect hardcoded secrets.................................................Passed
check-copyright..........................................................Passed
[ODSC-35230/uptake_bokeh f2b6a600] ODSC-35230. Fix ADS BokehHeatMap with new version of Bokeh.
 3 files changed, 161 insertions(+), 13 deletions(-)
```
