### PR TITLE
Fixed horizon while generating forecast.yaml

### DIFF
--- a/ads/opctl/operator/lowcode/forecast/schema.yaml
+++ b/ads/opctl/operator/lowcode/forecast/schema.yaml
@@ -279,6 +279,7 @@ spec:
     horizon:
       required: true
       type: integer
+      default: 1
 
     model:
       type: string


### PR DESCRIPTION
When we run `ads operator init -t forecast` today the resulting yaml file does not include "horizon". 
[ODSC-51509](https://jira.oci.oraclecorp.com/browse/ODSC-51509)

<img width="1439" alt="Screenshot 2024-01-22 at 11 57 16 AM" src="https://github.com/oracle/accelerated-data-science/assets/16145348/70f81738-e2bc-4d36-b587-3057cb6c293c">
