### PR TITLE
[ODSC-51508] : Fix/forecast v2 for tmp folder

### DIFF
--- a/ads/opctl/operator/lowcode/forecast/model/base_model.py
+++ b/ads/opctl/operator/lowcode/forecast/model/base_model.py
@@ -435,6 +435,8 @@ class ForecastOperatorBaseModel(ABC):
 
         if self.spec.output_directory:
             output_dir = self.spec.output_directory.url
+            # set the unique directory path as the requested path by the user
+            unique_output_dir = output_dir
         else:
             output_dir = "results"
 


### PR DESCRIPTION
[ODSC-51508](https://jira.oci.oraclecorp.com/browse/ODSC-51508)

- Change the default output directory from "tmp_fc_operator_result" to "results"
- If the results directory already exists append by _1 & so to obtain a unique directory.
Sample run:
![image](https://github.com/oracle/accelerated-data-science/assets/17523722/d0355e98-5a3d-4828-ba24-86d42a44880b)
