### PR TITLE
Anomaly: Added support for >1 target category columns

### DIFF
--- a/ads/opctl/operator/lowcode/anomaly/model/automlx.py
+++ b/ads/opctl/operator/lowcode/anomaly/model/automlx.py
@@ -42,11 +42,11 @@ class AutoMLXOperatorModel(AnomalyOperatorBaseModel):
             anomaly = pd.DataFrame({
                 date_column: df[date_column],
                 OutputColumns.ANOMALY_COL: y_pred
-            })
+            }).reset_index(drop=True)
             score = pd.DataFrame({
                 date_column: df[date_column],
                 OutputColumns.SCORE_COL: [item[1] for item in scores]
-            })
+            }).reset_index(drop=True)
             anomaly_output.add_output(target, anomaly, score)
 
         return anomaly_output

--- a/ads/opctl/operator/lowcode/anomaly/model/autots.py
+++ b/ads/opctl/operator/lowcode/anomaly/model/autots.py
@@ -54,9 +54,6 @@ class AutoTSOperatorModel(AnomalyOperatorBaseModel):
         for target, df in full_data_dict.items():
             data = df.set_index(date_column)
 
-            if self.spec.target_category_columns is not None:
-                data = data.drop(self.spec.target_category_columns[0], axis=1)
-
             (anomaly, score) = model.detect(data)
 
             if len(anomaly.columns) == 1:
@@ -64,7 +61,7 @@ class AutoTSOperatorModel(AnomalyOperatorBaseModel):
                     columns={score.columns.values[0]: OutputColumns.SCORE_COL},
                     inplace=True,
                 )
-                score = 1-score
+                score = 1 - score
                 score = score.reset_index(drop=False)
 
                 col = anomaly.columns.values[0]

--- a/ads/opctl/operator/lowcode/anomaly/model/tods.py
+++ b/ads/opctl/operator/lowcode/anomaly/model/tods.py
@@ -80,17 +80,6 @@ class TODSOperatorModel(AnomalyOperatorBaseModel):
 
             # Store the model and predictions in dictionaries
             models[target] = model
-            if self.spec.target_category_columns is None:
-                dataset.data[OutputColumns.ANOMALY_COL] = predictions_train[target]
-            else:
-                dataset.data.loc[
-                    dataset.data[self.spec.target_category_columns[0]] == target,
-                    OutputColumns.ANOMALY_COL,
-                ] = predictions_train[target]
-
-            self.datasets.full_data_dict[target][
-                OutputColumns.ANOMALY_COL
-            ] = predictions_train[target]
 
             anomaly = pd.DataFrame({
                 date_column: df[date_column],


### PR DESCRIPTION
[ODSC-52180](https://jira.oci.oraclecorp.com/browse/ODSC-52180)

Right now anomaly operator supports only one target category column. Added code to support more than 1. 

Screenshots:


<img width="525" alt="image" src="https://github.com/oracle/accelerated-data-science/assets/138288858/198c34f1-b434-4088-b4d8-ed9824f8ddec">
<img width="465" alt="image" src="https://github.com/oracle/accelerated-data-science/assets/138288858/a86d7097-b6a6-431f-9684-da24795a3ffb">
<img width="562" alt="image" src="https://github.com/oracle/accelerated-data-science/assets/138288858/97d277b9-7725-4c63-8997-4e191f40d4a5">
<img width="1306" alt="image" src="https://github.com/oracle/accelerated-data-science/assets/138288858/ad3ec39a-f3de-437a-ad79-314527a0b839">
<img width="1293" alt="image" src="https://github.com/oracle/accelerated-data-science/assets/138288858/2b992244-da6c-4d01-8de1-5bfc7c5e0c02">
<img width="1315" alt="image" src="https://github.com/oracle/accelerated-data-science/assets/138288858/a4cce5e1-a2cb-4d96-aa55-d378289485e2">



