### PR TITLE
odsc-52392/list model api improvement

### DIFF
--- a/ads/aqua/base.py
+++ b/ads/aqua/base.py
@@ -2,18 +2,12 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
-
-
-from typing import List
-
-import logging
 import oci
+from oci.exceptions import ClientError, ServiceError
+
+from ads.aqua.exception import AquaClientError, AquaServiceError
 from ads.common.auth import default_signer
 from ads.common.utils import extract_region
-from ads.aqua.exception import AquaServiceError, AquaClientError
-from oci.exceptions import ServiceError, ClientError
-
-logger = logging.getLogger(__name__)
 
 
 class AquaApp:
@@ -28,7 +22,7 @@ class AquaApp:
         self,
         list_func_ref,
         **kwargs,
-    ) -> List[dict]:
+    ) -> list:
         """Generic method to list OCI Data Science resources.
 
         Parameters

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -3,9 +3,14 @@
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
+import os
+
+from ads.aqua.exception import exception_handler
 from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua.model import AquaModelApp
-from ads.aqua.exception import exception_handler
+
+# TODO: move all the environment variable keys (or constants) into one common place
+AQUA_MODEL_COMPARTMENT = "AQUA_MODEL_COMPARTMENT"
 
 
 class AquaModelHandler(AquaAPIhandler):
@@ -29,10 +34,18 @@ class AquaModelHandler(AquaAPIhandler):
         """List Aqua models."""
         # If default is not specified,
         # jupyterlab will raise 400 error when argument is not provided by the HTTP request.
-        compartment_id = self.get_argument("compartment_id")
+        compartment_id = self.get_argument(
+            "compartment_id", default=os.environ.get(AQUA_MODEL_COMPARTMENT)
+        )
         # project_id is optional.
         project_id = self.get_argument("project_id", default=None)
         return self.finish(AquaModelApp().list(compartment_id, project_id))
 
 
+__handlers__ = [("model/?([^/]*)", AquaModelHandler)]
+
+__handlers__ = [("model/?([^/]*)", AquaModelHandler)]
+
+__handlers__ = [("model/?([^/]*)", AquaModelHandler)]
+__handlers__ = [("model/?([^/]*)", AquaModelHandler)]
 __handlers__ = [("model/?([^/]*)", AquaModelHandler)]

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -29,7 +29,7 @@ class AquaModelHandler(AquaAPIhandler):
         """Read the information of an Aqua model."""
         return self.finish(AquaModelApp().get(model_id))
 
-    @exception_handler
+    # @exception_handler
     def list(self):
         """List Aqua models."""
         # If default is not specified,
@@ -42,10 +42,4 @@ class AquaModelHandler(AquaAPIhandler):
         return self.finish(AquaModelApp().list(compartment_id, project_id))
 
 
-__handlers__ = [("model/?([^/]*)", AquaModelHandler)]
-
-__handlers__ = [("model/?([^/]*)", AquaModelHandler)]
-
-__handlers__ = [("model/?([^/]*)", AquaModelHandler)]
-__handlers__ = [("model/?([^/]*)", AquaModelHandler)]
 __handlers__ = [("model/?([^/]*)", AquaModelHandler)]

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -29,7 +29,7 @@ class AquaModelHandler(AquaAPIhandler):
         """Read the information of an Aqua model."""
         return self.finish(AquaModelApp().get(model_id))
 
-    # @exception_handler
+    @exception_handler
     def list(self):
         """List Aqua models."""
         # If default is not specified,

--- a/ads/aqua/model.py
+++ b/ads/aqua/model.py
@@ -193,6 +193,21 @@ class AquaModelApp(AquaApp):
 
         return aqua_models
 
+    def _if_show(self, model: "ModelSummary") -> bool:
+        """Determine if the given model should be return by `list`."""
+        TARGET_TAGS = model.freeform_tags.keys()
+        if not Tags.AQUA_TAG.value in TARGET_TAGS:
+            return False
+
+        return (
+            True
+            if (
+                Tags.AQUA_SERVICE_MODEL_TAG.value in TARGET_TAGS
+                or Tags.AQUA_FINE_TUNED_MODEL_TAG.value in TARGET_TAGS
+            )
+            else False
+        )
+
     def _get_artifact_path(self, custom_metadata_list: List) -> str:
         """Get the artifact path from the custom metadata list of model.
 

--- a/ads/aqua/model.py
+++ b/ads/aqua/model.py
@@ -19,7 +19,7 @@ from ads.config import COMPARTMENT_OCID
 
 ICON_FILE_NAME = "icon.txt"
 README = "README.md"
-UNKNOWN = "Unknown"
+UNKNOWN = ""
 
 
 class Tags(Enum):
@@ -179,7 +179,7 @@ class AquaModelApp(AquaApp):
                 license=model.freeform_tags.get(Tags.LICENSE.value, UNKNOWN),
                 name=model.display_name,
                 organization=model.freeform_tags.get(Tags.ORGANIZATION.value, UNKNOWN),
-                project_id=project_id,
+                project_id=project_id or "",
                 task=model.freeform_tags.get(Tags.TASK.value, UNKNOWN),
                 time_created=model.time_created,
                 is_fine_tuned_model=True

--- a/ads/aqua/model.py
+++ b/ads/aqua/model.py
@@ -13,7 +13,7 @@ from ads.aqua import logger
 from ads.aqua.base import AquaApp
 from ads.aqua.exception import AquaClientError, AquaServiceError
 from ads.aqua.utils import create_word_icon
-from ads.common.oci_resource import OCIResource
+from ads.common.oci_resource import SEARCH_TYPE, OCIResource
 from ads.common.serializer import DataClassSerializable
 from ads.config import COMPARTMENT_OCID
 
@@ -146,7 +146,7 @@ class AquaModelApp(AquaApp):
         try:
             models = OCIResource.search(
                 query,
-                type="Structured",
+                type=SEARCH_TYPE.STRUCTURED,
             )
         except Exception as se:
             # TODO: adjust error raising

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+"""AQUA utils and constants."""
+import logging
+import sys
+import base64
+import random
+import sys
+import re
+from string import Template
+
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+logger = logging.getLogger("ODSC_AQUA")
+
+
+def get_logger():
+    return logger
+
+
+def random_color_generator(word: str):
+    seed = sum([ord(c) for c in word]) % 13
+    random.seed(seed)
+    r = random.randint(10, 245)
+    g = random.randint(10, 245)
+    b = random.randint(10, 245)
+
+    text_color = "black" if (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.5 else "white"
+
+    return f"#{r:02x}{g:02x}{b:02x}", text_color
+
+
+def svg_to_base64_datauri(svg_contents: str):
+    base64_encoded_svg_contents = base64.b64encode(svg_contents.encode())
+    return "data:image/svg+xml;base64," + base64_encoded_svg_contents.decode()
+
+
+def create_word_icon(label: str, width: int = 150, return_as_datauri=True):
+    match = re.findall(r"(^[a-zA-Z]{1}).*?(\d+[a-z]?)", label)
+    icon_text = "".join(match[0] if match else [label[0]])
+    icon_color, text_color = random_color_generator(label)
+    cx = width / 2
+    cy = width / 2
+    r = width / 2
+    fs = int(r / 25)
+
+    t = Template(
+        """
+        <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="${width}" height="${width}">
+
+            <style>
+                text {
+                    font-size: ${fs}em;
+                    font-family: lucida console, Fira Mono, monospace;
+                    text-anchor: middle;
+                    stroke-width: 1px;
+                    font-weight: bold;
+                    alignment-baseline: central;
+                }
+
+            </style>
+
+            <circle cx="${cx}" cy="${cy}" r="${r}" fill="${icon_color}" />
+            <text x="50%" y="50%" fill="${text_color}">${icon_text}</text>
+        </svg>
+    """.strip()
+    )
+
+    icon_svg = t.substitute(**locals())
+    if return_as_datauri:
+        return svg_to_base64_datauri(icon_svg)
+    else:
+        return icon_svg

--- a/ads/config.py
+++ b/ads/config.py
@@ -172,5 +172,3 @@ def open(
         # Saving config if it necessary
         if mode == Mode.WRITE:
             config.save(force_overwrite=True)
-            config.save(force_overwrite=True)
-            config.save(force_overwrite=True)

--- a/ads/config.py
+++ b/ads/config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import contextlib
@@ -46,6 +46,8 @@ RESOURCE_OCID = (
 )
 NO_CONTAINER = os.environ.get("NO_CONTAINER")
 TMPDIR = os.environ.get("TMPDIR")
+
+ODSC_MODEL_COMPARTMENT_OCID = os.environ.get("ODSC_MODEL_COMPARTMENT_OCID")
 
 
 def export(
@@ -169,4 +171,6 @@ def open(
 
         # Saving config if it necessary
         if mode == Mode.WRITE:
+            config.save(force_overwrite=True)
+            config.save(force_overwrite=True)
             config.save(force_overwrite=True)

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -9,8 +9,6 @@ from collections import namedtuple
 from dataclasses import asdict
 from unittest.mock import ANY, MagicMock, patch
 
-from oci.data_science.models import ModelSummary
-
 from ads.aqua.model import AquaModelApp, AquaModelSummary
 
 
@@ -18,88 +16,7 @@ class TestDataset:
     Response = namedtuple("Response", ["data", "status"])
     DataList = namedtuple("DataList", ["objects"])
 
-    model_summary_objects = [
-        {
-            "compartment_id": "ocid1.compartment.oc1..<OCID>",
-            "created_by": "ocid1.datasciencenotebooksession.oc1.iad.<OCID>",
-            "defined_tags": {},
-            "display_name": "Model1-Fine-Tuned",
-            "freeform_tags": {
-                "OCI_AQUA": "",
-                "aqua_fine_tuned_model": "ocid1.datasciencemodel.oc1.iad.<OCID>#Model1",
-                "license": "UPL",
-                "organization": "Oracle AI",
-                "task": "text_generation",
-            },
-            "id": "ocid1.datasciencemodel.oc1.iad.<OCID>",
-            "lifecycle_state": "ACTIVE",
-            "project_id": "ocid1.datascienceproject.oc1.iad.<OCID>",
-            "time_created": "2024-01-19T19:33:58.078000+00:00",
-        },
-        {
-            "compartment_id": "ocid1.compartment.oc1..<OCID>",
-            "created_by": "ocid1.datasciencenotebooksession.oc1.iad.<OCID>",
-            "defined_tags": {},
-            "display_name": "Model1-Copy",
-            "freeform_tags": {
-                "OCI_AQUA": "",
-                "license": "UPL",
-                "organization": "Oracle AI",
-                "task": "text_generation",
-            },
-            "id": "ocid1.datasciencemodel.oc1.iad.<OCID>",
-            "lifecycle_state": "ACTIVE",
-            "project_id": "ocid1.datascienceproject.oc1.iad.<OCID>",
-            "time_created": "2024-01-19T19:30:39.452000+00:00",
-        },
-        {
-            "compartment_id": "ocid1.compartment.oc1..<OCID>",
-            "created_by": "ocid1.datasciencenotebooksession.oc1.iad.<OCID>",
-            "defined_tags": {},
-            "display_name": "Model1",
-            "freeform_tags": {
-                "OCI_AQUA": "",
-                "aqua_service_model": "ocid1.datasciencemodel.oc1.iad.<OCID>#Model1",
-                "license": "UPL",
-                "organization": "Oracle AI",
-                "task": "text_generation",
-            },
-            "id": "ocid1.datasciencemodel.oc1.iad.<OCID>",
-            "lifecycle_state": "ACTIVE",
-            "project_id": "ocid1.datascienceproject.oc1.iad.<OCID>",
-            "time_created": "2024-01-19T17:57:39.158000+00:00",
-        },
-    ]
-
-    model_object = {
-        "compartment_id": "ocid1.compartment.oc1.<OCID>",
-        "created_by": "ocid1.datasciencenotebooksession.oc1.iad.<OCID>",
-        "custom_metadata_list": [
-            {
-                "category": "other",
-                "description": "model by reference storage path",
-                "key": "Object Storage Path",
-                "value": "oci://mybucket@mytenancy/prefix/artifact",
-            },
-            {
-                "category": "other",
-                "description": "The model file name.",
-                "key": "ModelFileName",
-                "value": "model.pkl",
-            },
-        ],
-        "display_name": "Model1-Fine-Tuned",
-        "freeform_tags": {
-            "OCI_AQUA": "",
-            "aqua_fine_tuned_model": "ocid1.datasciencemodel.oc1.iad.<OCID>#Model1",
-            "license": "UPL",
-            "organization": "Oracle AI",
-            "task": "text_generation",
-        },
-        "id": "ocid1.datasciencemodel.oc1.iad.<OCID>",
-        "project_id": "ocid1.datascienceproject.<OCID>",
-        "time_created": "2024-01-19T19:33:58.078000+00:00",
-    }
+    resource_summary_objects = []
 
     COMPARTMENT_ID = "ocid1.compartment.oc1..<OCID>"
     MOCK_ICON = "data:image/svg+xml;base64,########"
@@ -108,24 +25,10 @@ class TestDataset:
 class TestAquaModel(unittest.TestCase):
     """Contains unittests for AquaModelApp."""
 
-    def setUp(self):
-        self.app = AquaModelApp()  # Replace with actual instantiation
-
-    @patch("ads.common.auth.default_signer")
-    def test_list(self, mock_auth):
+    def test_list(self):
         """Tests list models succesfully."""
-        self.app.list_resource = MagicMock(
-            return_value=[
-                ModelSummary(**item) for item in TestDataset.model_summary_objects
-            ]
-        )
+        pass
 
-        results = self.app.list(TestDataset.COMPARTMENT_ID)
-
-        assert len(results) == 2
-
-        attributes = AquaModelSummary.__annotations__.keys()
-        for r in results:
-            rdict = asdict(r)
-            for attr in attributes:
-                assert rdict.get(attr) is not None
+    def test_list_failed(self):
+        """Tests list models succesfully."""
+        pass

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -4,8 +4,128 @@
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-from unittest import TestCase
+import unittest
+from collections import namedtuple
+from dataclasses import asdict
+from unittest.mock import ANY, MagicMock, patch
+
+from oci.data_science.models import ModelSummary
+
+from ads.aqua.model import AquaModelApp, AquaModelSummary
 
 
-class TestAquaModel(TestCase):
-    pass
+class TestDataset:
+    Response = namedtuple("Response", ["data", "status"])
+    DataList = namedtuple("DataList", ["objects"])
+
+    model_summary_objects = [
+        {
+            "compartment_id": "ocid1.compartment.oc1..<OCID>",
+            "created_by": "ocid1.datasciencenotebooksession.oc1.iad.<OCID>",
+            "defined_tags": {},
+            "display_name": "Model1-Fine-Tuned",
+            "freeform_tags": {
+                "OCI_AQUA": "",
+                "aqua_fine_tuned_model": "ocid1.datasciencemodel.oc1.iad.<OCID>#Model1",
+                "license": "UPL",
+                "organization": "Oracle AI",
+                "task": "text_generation",
+            },
+            "id": "ocid1.datasciencemodel.oc1.iad.<OCID>",
+            "lifecycle_state": "ACTIVE",
+            "project_id": "ocid1.datascienceproject.oc1.iad.<OCID>",
+            "time_created": "2024-01-19T19:33:58.078000+00:00",
+        },
+        {
+            "compartment_id": "ocid1.compartment.oc1..<OCID>",
+            "created_by": "ocid1.datasciencenotebooksession.oc1.iad.<OCID>",
+            "defined_tags": {},
+            "display_name": "Model1-Copy",
+            "freeform_tags": {
+                "OCI_AQUA": "",
+                "license": "UPL",
+                "organization": "Oracle AI",
+                "task": "text_generation",
+            },
+            "id": "ocid1.datasciencemodel.oc1.iad.<OCID>",
+            "lifecycle_state": "ACTIVE",
+            "project_id": "ocid1.datascienceproject.oc1.iad.<OCID>",
+            "time_created": "2024-01-19T19:30:39.452000+00:00",
+        },
+        {
+            "compartment_id": "ocid1.compartment.oc1..<OCID>",
+            "created_by": "ocid1.datasciencenotebooksession.oc1.iad.<OCID>",
+            "defined_tags": {},
+            "display_name": "Model1",
+            "freeform_tags": {
+                "OCI_AQUA": "",
+                "aqua_service_model": "ocid1.datasciencemodel.oc1.iad.<OCID>#Model1",
+                "license": "UPL",
+                "organization": "Oracle AI",
+                "task": "text_generation",
+            },
+            "id": "ocid1.datasciencemodel.oc1.iad.<OCID>",
+            "lifecycle_state": "ACTIVE",
+            "project_id": "ocid1.datascienceproject.oc1.iad.<OCID>",
+            "time_created": "2024-01-19T17:57:39.158000+00:00",
+        },
+    ]
+
+    model_object = {
+        "compartment_id": "ocid1.compartment.oc1.<OCID>",
+        "created_by": "ocid1.datasciencenotebooksession.oc1.iad.<OCID>",
+        "custom_metadata_list": [
+            {
+                "category": "other",
+                "description": "model by reference storage path",
+                "key": "Object Storage Path",
+                "value": "oci://mybucket@mytenancy/prefix/artifact",
+            },
+            {
+                "category": "other",
+                "description": "The model file name.",
+                "key": "ModelFileName",
+                "value": "model.pkl",
+            },
+        ],
+        "display_name": "Model1-Fine-Tuned",
+        "freeform_tags": {
+            "OCI_AQUA": "",
+            "aqua_fine_tuned_model": "ocid1.datasciencemodel.oc1.iad.<OCID>#Model1",
+            "license": "UPL",
+            "organization": "Oracle AI",
+            "task": "text_generation",
+        },
+        "id": "ocid1.datasciencemodel.oc1.iad.<OCID>",
+        "project_id": "ocid1.datascienceproject.<OCID>",
+        "time_created": "2024-01-19T19:33:58.078000+00:00",
+    }
+
+    COMPARTMENT_ID = "ocid1.compartment.oc1..<OCID>"
+    MOCK_ICON = "data:image/svg+xml;base64,########"
+
+
+class TestAquaModel(unittest.TestCase):
+    """Contains unittests for AquaModelApp."""
+
+    def setUp(self):
+        self.app = AquaModelApp()  # Replace with actual instantiation
+
+    @patch("ads.common.auth.default_signer")
+    def test_list(self, mock_auth):
+        """Tests list models succesfully."""
+        self.app.list_resource = MagicMock(
+            return_value=[
+                ModelSummary(**item) for item in TestDataset.model_summary_objects
+            ]
+        )
+
+        results = self.app.list(TestDataset.COMPARTMENT_ID)
+
+        assert len(results) == 2
+
+        attributes = AquaModelSummary.__annotations__.keys()
+        for r in results:
+            rdict = asdict(r)
+            for attr in attributes:
+                assert rdict.get(attr) is not None


### PR DESCRIPTION
# Description
Use query service to get models list from given compartment.

# User Experience
## URL invoking
```aqua/model/?compartment_id=<OCID>```

Sample response:
```
{
  "data": [
    {
      "name": "Mistral-7B-Instruct-v0.1-Fine-Tuned",
      "id": "<OCID>",
      "compartment_id": "<OCID>",
      "project_id": "",
      "time_created": "2024-01-19 19:33:58.078000+00:00",
      "icon": "data:image/svg+xml;base64,xxxx",
      "task": "text_generation",
      "license": "Apache",
      "organization": "Mistral AI",
      "is_fine_tuned_model": true,
      "tags": {...},
    },
    {
      "name": "Llama-2-13b",
      "id": "<OCID>",
      "compartment_id": "<OCID>",
      "project_id": "",
      "time_created": "2024-01-19 17:57:39.158000+00:00",
      "icon": "data:image/svg+xml;base64,xxxxx",
      "task": "text_generation",
      "license": "Meta license",
      "tags": {...},
      "organization": "Meta AI",
      "is_fine_tuned_model": false
    },
  ]
}
```

## CLI
```
ads aqua model list --compartment_id "ocid1.compartment.oc1..xxx" 
```


# TODO:
* Error handling will be improved in the separate PR
* Implement caching by generate `index.json` locally.
* Add more test cases.