### PR TITLE
Aqua/fix/tag validation in list

### DIFF
--- a/ads/aqua/model.py
+++ b/ads/aqua/model.py
@@ -9,10 +9,10 @@ from enum import Enum
 from typing import List
 
 import oci
+
 from ads.aqua import logger
 from ads.aqua.base import AquaApp
 from ads.aqua.exception import AquaClientError, AquaServiceError
-from ads.common.utils import get_console_link
 from ads.aqua.utils import (
     README,
     UNKNOWN,
@@ -22,6 +22,7 @@ from ads.aqua.utils import (
 )
 from ads.common.oci_resource import SEARCH_TYPE, OCIResource
 from ads.common.serializer import DataClassSerializable
+from ads.common.utils import get_console_link
 from ads.config import COMPARTMENT_OCID, ODSC_MODEL_COMPARTMENT_OCID, TENANCY_OCID
 from ads.model.datascience_model import DataScienceModel
 
@@ -276,7 +277,7 @@ class AquaModelApp(AquaApp):
 
     def _rqs(self, compartment_id):
         """Use RQS to fetch models in the user tenancy."""
-        condition_tags = f"&& (freeformTags.key = '{Tags.AQUA_SERVICE_MODEL_TAG.value}' || freeformTags.key = '{Tags.AQUA_FINE_TUNED_MODEL_TAG.value}')"
+        condition_tags = f"&& (freeformTags.key = '{Tags.AQUA_TAG.value}' && freeformTags.key = '{Tags.AQUA_FINE_TUNED_MODEL_TAG.value}')"
         condition_lifecycle = "&& lifecycleState = 'ACTIVE'"
         query = f"query datasciencemodel resources where (compartmentId = '{compartment_id}' {condition_lifecycle} {condition_tags})"
         logger.info(query)


### PR DESCRIPTION
# Description
Based on the current workflow, `aqua_service_model` tag is no longer used to identify service model as all service models are placed in a specific compartment. 

# Changed
Changed the filter condition to remove the usage of this tag.

# Test
logging
```
INFO:ads.aqua:Fetching custom models from compartment_id=ocid1.compartment.oc1.<ocid>.
INFO:ads.aqua:query datasciencemodel resources where (compartmentId = 'ocid1.compartment.oc1..<ocid>' && lifecycleState = 'ACTIVE' && (freeformTags.key = 'OCI_AQUA' && freeformTags.key = 'aqua_fine_tuned_model'))
INFO:ads.aqua:tenant_id=ocid1.tenancy.oc1..<ocid>
INFO:ads.aqua:Fetch 3 model in compartment_id=ocid1.compartment.oc1..<ocid>.

```

invoking API 
![Screenshot 2024-02-07 at 12 44 34 PM](https://github.com/oracle/accelerated-data-science/assets/49049296/5d51523b-b6b9-4006-ac84-d3ebcde9edb8)

