### PR TITLE
aqua/add fire as aqua dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ pii = [
   "spacy==3.6.1",
 ]
 llm = ["langchain>=0.0.295", "evaluate>=0.4.0"]
-aqua = ["sqlalchemy>=2.0.25"]
+aqua = ["fire"]
 
 [project.urls]
 "Github" = "https://github.com/oracle/accelerated-data-science"


### PR DESCRIPTION
# Description
Add `fire` to aqua dependency to support Aqua CLI.

# Package Details
https://github.com/google/python-fire