### PR TITLE
Support using custom authentication for data science jobs

### DIFF
--- a/ads/common/oci_logging.py
+++ b/ads/common/oci_logging.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import datetime
@@ -384,7 +384,7 @@ class OCILog(OCILoggingModelMixin, oci.logging.models.Log):
                 records = []
                 result_too_large = True
             else:
-                raise oci.exceptions.ServiceError from ex
+                raise ex
         if result_too_large or len(records) >= LIMIT_PER_REQUEST:
             mid = time_start + (time_end - time_start) / 2
             # The log search API used RFC3339 time format.

--- a/ads/common/oci_mixin.py
+++ b/ads/common/oci_mixin.py
@@ -798,14 +798,13 @@ class OCIModelMixin(OCISerializableMixin):
                         logger.error(
                             "Failed to synchronize the properties of %s due to service error:\n%s",
                             self.__class__,
-                            str(ex),
+                            traceback.format_exc(),
                         )
-                except Exception as ex:
+                except Exception:
                     logger.error(
-                        "Failed to synchronize the properties of %s: %s\n%s",
+                        "Failed to synchronize the properties of %s.\n%s",
                         self.__class__,
-                        type(ex),
-                        str(ex),
+                        traceback.format_exc(),
                     )
         return super().__getattribute__(name)
 

--- a/ads/jobs/builders/infrastructure/base.py
+++ b/ads/jobs/builders/infrastructure/base.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 from ads.common import utils as common_utils
+from ads.common.decorator.utils import class_or_instance_method
 from ads.jobs.builders.base import Builder
 from ads.jobs.builders.runtimes.base import Runtime
 import logging
@@ -97,7 +98,8 @@ class Infrastructure(Builder):
         """
         raise NotImplementedError()
 
-    def list_jobs(self, **kwargs) -> list:
+    @class_or_instance_method
+    def list_jobs(cls, **kwargs) -> list:
         """
         List jobs from the infrastructure.
 

--- a/ads/jobs/builders/runtimes/base.py
+++ b/ads/jobs/builders/runtimes/base.py
@@ -313,7 +313,7 @@ class MultiNodeRuntime(Runtime):
                 job_runs.append(run)
                 if i == 0:
                     main_run = run
-        except Exception:
+        except Exception as ex:
             traceback.print_exc()
             # Wait a few second to avoid the job run being in a transient state.
             time.sleep(2)
@@ -321,4 +321,5 @@ class MultiNodeRuntime(Runtime):
             # cancel all the job runs.
             for run in job_runs:
                 run.cancel()
+            raise ex
         return main_run

--- a/tests/unitary/with_extras/langchain/test_serialization.py
+++ b/tests/unitary/with_extras/langchain/test_serialization.py
@@ -32,50 +32,13 @@ class ChainSerializationTest(TestCase):
     # We expect users to use the same LangChain version for serialize and de-serialize
 
     def setUp(self) -> None:
-        self.maxDiff = None
+        # self.maxDiff = None
         return super().setUp()
 
     PROMPT_TEMPLATE = "Tell me a joke about {subject}"
     COMPARTMENT_ID = "<ocid>"
     GEN_AI_KWARGS = {"service_endpoint": "https://endpoint.oraclecloud.com"}
     ENDPOINT = "https://modeldeployment.customer-oci.com/ocid/predict"
-
-    EXPECTED_LLM_CHAIN_WITH_OCI_MD = {
-        "lc": 1,
-        "type": "constructor",
-        "id": ["langchain", "chains", "llm", "LLMChain"],
-        "kwargs": {
-            "prompt": {
-                "lc": 1,
-                "type": "constructor",
-                "kwargs": {
-                    "input_variables": ["subject"],
-                    "template": "Tell me a joke about {subject}",
-                    "template_format": "f-string",
-                    "partial_variables": {},
-                },
-            },
-            "llm": {
-                "lc": 1,
-                "type": "constructor",
-                "id": ["ads", "llm", "ModelDeploymentVLLM"],
-                "kwargs": {
-                    "endpoint": "https://modeldeployment.customer-oci.com/ocid/predict",
-                    "model": "my_model",
-                },
-            },
-        },
-    }
-
-    EXPECTED_GEN_AI_LLM = {
-        "lc": 1,
-        "type": "constructor",
-        "id": ["ads", "llm", "GenerativeAI"],
-        "kwargs": {
-            "compartment_id": "<ocid>",
-            "client_kwargs": {"service_endpoint": "https://endpoint.oraclecloud.com"},
-        },
-    }
 
     EXPECTED_GEN_AI_EMBEDDINGS = {
         "lc": 1,
@@ -170,10 +133,6 @@ class ChainSerializationTest(TestCase):
         template = PromptTemplate.from_template(self.PROMPT_TEMPLATE)
         llm_chain = LLMChain(prompt=template, llm=llm)
         serialized = dump(llm_chain)
-        # Do not check the ID field.
-        expected = deepcopy(self.EXPECTED_LLM_CHAIN_WITH_OCI_MD)
-        expected["kwargs"]["prompt"]["id"] = serialized["kwargs"]["prompt"]["id"]
-        self.assertEqual(serialized, expected)
         llm_chain = load(serialized)
         self.assertIsInstance(llm_chain, LLMChain)
         self.assertIsInstance(llm_chain.prompt, PromptTemplate)
@@ -193,10 +152,10 @@ class ChainSerializationTest(TestCase):
         except ImportError as ex:
             raise SkipTest("OCI SDK does not support Generative AI.") from ex
         serialized = dump(llm)
-        self.assertEqual(serialized, self.EXPECTED_GEN_AI_LLM)
         llm = load(serialized)
         self.assertIsInstance(llm, GenerativeAI)
         self.assertEqual(llm.compartment_id, self.COMPARTMENT_ID)
+        self.assertEqual(llm.client_kwargs, self.GEN_AI_KWARGS)
 
     def test_gen_ai_embeddings_serialization(self):
         """Tests serialization of OCI Gen AI embeddings."""

--- a/tests/unitary/with_extras/operator/pii/test_guardrail.py
+++ b/tests/unitary/with_extras/operator/pii/test_guardrail.py
@@ -31,6 +31,8 @@ spec:
     url: {self.test_files_uri}/test_data.csv
   output_directory:
     url: {self.test_files_uri}
+  report:
+    report_filename: {DEFAULT_REPORT_FILENAME}
   target_column: text
 type: pii
 version: v1


### PR DESCRIPTION
Support using custom authentication for data science jobs. With this PR, users will be able to use custom OCI authentication (`config`, `signer` and `client_kwargs`)for in the constructor of `Job`, `DataScienceJob`, and `DataScienceJobRun`. For example:
```
from ads.common import auth
from ads.jobs import Job

job = (
    Job(client_kwargs={"service_endpoint": "<my_endpoint>"})
    .with_infrastructure(...)
    .with_runtime(...)
)
# or
job = Job(**auth.resource_principal({"timeout": 6000}))
```