### PR TITLE
Aqua/fix/status code inconsistency

### DIFF
--- a/ads/aqua/extension/base_handler.py
+++ b/ads/aqua/extension/base_handler.py
@@ -52,12 +52,14 @@ class AquaAPIhandler(APIHandler):
         """AquaAPIhandler errors are JSON, not human pages."""
 
         self.set_header("Content-Type", "application/json")
+        reason = kwargs.get("reason")
+        self.set_status(status_code, reason=reason)
         message = responses.get(status_code, "Unknown HTTP Error")
         reply = {
             "status": status_code,
             "message": message,
             "service_payload": kwargs.get("service_payload", {}),
-            "reason": kwargs.get("reason"),
+            "reason": reason,
         }
         exc_info = kwargs.get("exc_info")
         if exc_info:

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -19,12 +19,10 @@ class AquaModelHandler(AquaAPIhandler):
             return self.list()
         return self.read(model_id)
 
-    @handle_exceptions
     def read(self, model_id):
         """Read the information of an Aqua model."""
         return self.finish(AquaModelApp().get(model_id))
 
-    @handle_exceptions
     def list(self):
         """List Aqua models."""
         compartment_id = self.get_argument("compartment_id", default=None)

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
+from tornado.web import HTTPError
+
 from ads.aqua.decorator import handle_exceptions
 from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua.model import AquaModelApp
@@ -14,7 +16,6 @@ class AquaModelHandler(AquaAPIhandler):
     @handle_exceptions
     def get(self, model_id=""):
         """Handle GET request."""
-
         if not model_id:
             return self.list()
         return self.read(model_id)


### PR DESCRIPTION
# Description
jira: https://jira.oci.oraclecorp.com/browse/ODSC-53652

Need to set_status before `finish()` . 

# After fixing
Status becomes matching.
![Screenshot 2024-02-27 at 4 41 51 PM](https://github.com/oracle/accelerated-data-science/assets/49049296/fc3bf0b2-c408-41fb-a4cf-2e691e29cc10)
