### PR TITLE
Cancel & Delete Evaluation

### DIFF
--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -933,7 +933,7 @@ class AquaEvaluationApp(AquaApp):
 
         return report
 
-    def cancel_evaluation(self, eval_id) -> dict:
+    def cancel(self, eval_id) -> dict:
         """Cancels the job run for the given evaluation id.
         Parameters
         ----------
@@ -984,7 +984,7 @@ class AquaEvaluationApp(AquaApp):
             )
         return status
 
-    def delete_evaluation(self, eval_id):
+    def delete(self, eval_id):
         """Deletes the job and the associated model for the given evaluation id.
         Parameters
         ----------

--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -34,7 +34,7 @@ from ads.common.object_storage_details import ObjectStorageDetails
 from ads.common.serializer import DataClassSerializable
 from ads.common.utils import get_console_link, get_files
 from ads.config import COMPARTMENT_OCID, PROJECT_OCID
-from ads.jobs.ads_job import Job
+from ads.jobs.ads_job import Job, DataScienceJobRun
 from ads.jobs.builders.infrastructure.dsc_job import DataScienceJob
 from ads.jobs.builders.runtimes.base import Runtime
 from ads.jobs.builders.runtimes.python_runtime import PythonRuntime
@@ -742,6 +742,18 @@ class AquaEvaluationApp(AquaApp):
         self._report_cache.__setitem__(key=eval_id, value=report)
 
         return report
+
+    def cancel_evaluation(self, eval_id) -> dict:
+        run = DataScienceJobRun.from_ocid(eval_id)
+        try:
+            if run.status not in run.TERMINAL_STATES:
+                run.cancel(wait_for_completion=False)
+                logger.info("Cancelled Job Run: %s", eval_id)
+        except oci.exceptions.ServiceError as ex:
+            error = ex.message
+
+    def delete_evaluation(self, eval_id) -> dict:
+        pass
 
     def _get_attribute_from_model_metadata(
         self,

--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -754,7 +754,7 @@ class AquaEvaluationApp(AquaApp):
 
         Returns
         -------
-            dict containing evaluation_id, status and time_accepted
+            dict containing id, status and time_accepted
 
         Raises
         ------
@@ -774,7 +774,7 @@ class AquaEvaluationApp(AquaApp):
                 "Model provenance is missing job run training_id key"
             )
 
-        status = dict(evaluation_id=eval_id, status=UNKNOWN, time_accepted="")
+        status = dict(id=eval_id, status=UNKNOWN, time_accepted="")
         run = DataScienceJobRun.from_ocid(job_run_id)
         try:
             if run.lifecycle_state not in run.TERMINAL_STATES:
@@ -782,9 +782,9 @@ class AquaEvaluationApp(AquaApp):
                 run.cancel()
                 logger.info(f"Canceling Job Run: {job_run_id} for evaluation {eval_id}")
                 status = dict(
-                    evaluation_id=eval_id,
+                    id=eval_id,
                     lifecycle_state="CANCELING",
-                    time_accepted=datetime.now().strftime("%Y%m%d-%H%M"),
+                    time_accepted=datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f%z"),
                 )
         except oci.exceptions.ServiceError as ex:
             logger.error(
@@ -802,7 +802,7 @@ class AquaEvaluationApp(AquaApp):
 
         Returns
         -------
-            dict containing evaluation_id, status and time_accepted
+            dict containing id, status and time_accepted
 
         Raises
         ------
@@ -827,7 +827,7 @@ class AquaEvaluationApp(AquaApp):
                 f"Custom metadata is missing {EvaluationCustomMetadata.EVALUATION_JOB_ID.value} key"
             )
 
-        status = dict(evaluation_id=eval_id, status=UNKNOWN, time_accepted="")
+        status = dict(id=eval_id, status=UNKNOWN, time_accepted="")
         job = DataScienceJob.from_id(job_id)
         try:
             job.delete()
@@ -837,9 +837,9 @@ class AquaEvaluationApp(AquaApp):
             logger.info(f"Deleting evaluation: {eval_id}")
 
             status = dict(
-                evaluation_id=eval_id,
+                id=eval_id,
                 lifecycle_state="DELETING",
-                time_accepted=datetime.now().strftime("%Y%m%d-%H%M"),
+                time_accepted=datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f%z"),
             )
         except oci.exceptions.ServiceError as ex:
             logger.error(

--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -780,16 +780,11 @@ class AquaEvaluationApp(AquaApp):
             if run.lifecycle_state not in run.TERMINAL_STATES:
                 # todo: check if we want to return directly before waiting for completion
                 run.cancel()
-                while (
-                    run.lifecycle_state
-                    != oci.data_science.models.JobRun.LIFECYCLE_STATE_CANCELING
-                ):
-                    time.sleep(3)
                 logger.info(f"Canceling Job Run: {job_run_id} for evaluation {eval_id}")
                 status = dict(
                     evaluation_id=eval_id,
-                    lifecycle_state=run.lifecycle_state,
-                    time_accepted=run.time_accepted,
+                    lifecycle_state="CANCELING",
+                    time_accepted=datetime.now().strftime("%Y%m%d-%H%M"),
                 )
         except oci.exceptions.ServiceError as ex:
             logger.error(

--- a/ads/aqua/extension/evaluation_handler.py
+++ b/ads/aqua/extension/evaluation_handler.py
@@ -64,23 +64,26 @@ class AquaEvaluationHandler(AquaAPIhandler):
     @handle_exceptions
     def put(self, eval_id):
         """Handles PUT request for the evaluation APIs"""
-        self.finish(
-            {
-                "evaluation_id": eval_id,
-                "status": "CANCELLED",
-                "time_accepted": "2024-02-15 20:18:34.225000+00:00",
-            }
-        )
+        eval_id = eval_id.split("/")[0]
+        return self.finish(AquaEvaluationApp().cancel_evaluation(eval_id))
+        # self.finish(
+        #     {
+        #         "evaluation_id": eval_id,
+        #         "status": "CANCELLED",
+        #         "time_accepted": "2024-02-15 20:18:34.225000+00:00",
+        #     }
+        # )
 
     @handle_exceptions
     def delete(self, eval_id):
-        self.finish(
-            {
-                "evaluation_id": eval_id,
-                "status": "DELETING",
-                "time_accepted": "2024-02-15 20:18:34.225000+00:00",
-            }
-        )
+        return self.finish(AquaEvaluationApp().delete_evaluation(eval_id))
+        # self.finish(
+        #     {
+        #         "evaluation_id": eval_id,
+        #         "status": "DELETING",
+        #         "time_accepted": "2024-02-15 20:18:34.225000+00:00",
+        #     }
+        # )
 
     def read(self, eval_id):
         """Read the information of an Aqua model."""

--- a/ads/aqua/extension/evaluation_handler.py
+++ b/ads/aqua/extension/evaluation_handler.py
@@ -65,11 +65,11 @@ class AquaEvaluationHandler(AquaAPIhandler):
     def put(self, eval_id):
         """Handles PUT request for the evaluation APIs"""
         eval_id = eval_id.split("/")[0]
-        return self.finish(AquaEvaluationApp().cancel_evaluation(eval_id))
+        return self.finish(AquaEvaluationApp().cancel(eval_id))
 
     @handle_exceptions
     def delete(self, eval_id):
-        return self.finish(AquaEvaluationApp().delete_evaluation(eval_id))
+        return self.finish(AquaEvaluationApp().delete(eval_id))
 
     def read(self, eval_id):
         """Read the information of an Aqua model."""

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -13,6 +13,8 @@ from enum import Enum
 from pathlib import Path
 from string import Template
 from typing import List
+from functools import wraps
+import asyncio
 
 import fsspec
 from oci.data_science.models import JobRun, Model
@@ -386,3 +388,13 @@ def upload_file_to_os(
         auth=auth,
         force_overwrite=force_overwrite,
     )
+
+
+def fire_and_forget(func):
+    """Decorator to push execution of methods to the background."""
+
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        return asyncio.get_event_loop().run_in_executor(None, func, *args, *kwargs)
+
+    return wrapped

--- a/ads/jobs/builders/infrastructure/dsc_job.py
+++ b/ads/jobs/builders/infrastructure/dsc_job.py
@@ -374,7 +374,7 @@ class DSCJob(OCIDataScienceMixin, oci.data_science.models.Job):
         """
         runs = self.run_list()
         for run in runs:
-            if run in [
+            if run.lifecycle_state in [
                 DataScienceJobRun.LIFECYCLE_STATE_ACCEPTED,
                 DataScienceJobRun.LIFECYCLE_STATE_IN_PROGRESS,
                 DataScienceJobRun.LIFECYCLE_STATE_NEEDS_ATTENTION,

--- a/tests/unitary/with_extras/aqua/test_evaluation.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation.py
@@ -329,7 +329,7 @@ class TestAquaModel(unittest.TestCase):
         )
         mock_dsc_model_delete.return_value = None
 
-        result = self.app.delete_evaluation(TestDataset.EVAL_ID)
+        result = self.app.delete(TestDataset.EVAL_ID)
 
         assert result["id"] == TestDataset.EVAL_ID
         assert result["lifecycle_state"] == "DELETING"
@@ -350,7 +350,7 @@ class TestAquaModel(unittest.TestCase):
             lifecycle_state="ACCEPTED", cancel=mock_dsc_job_run_cancel
         )
 
-        result = self.app.cancel_evaluation(TestDataset.EVAL_ID)
+        result = self.app.cancel(TestDataset.EVAL_ID)
 
         assert result["id"] == TestDataset.EVAL_ID
         assert result["lifecycle_state"] == "CANCELING"

--- a/tests/unitary/with_extras/aqua/test_evaluation.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation.py
@@ -315,27 +315,22 @@ class TestAquaModel(unittest.TestCase):
 
     @patch.object(DataScienceModel, "from_id")
     @patch.object(DataScienceJob, "from_id")
-    def test_delete_evaluation(self, mock_dsc_job, mock_dsc_model_from_id):
-        mock_dsc_model_delete = MagicMock()
+    @patch.object(AquaEvaluationApp, "_delete_job_and_model")
+    def test_delete_evaluation(
+        self, mock_del_job_func, mock_dsc_job, mock_dsc_model_from_id
+    ):
         mock_dsc_model_from_id.return_value = MagicMock(
             provenance_data={
                 "training_id": TestDataset.model_provenance_object.get("training_id"),
-            },
-            delete=mock_dsc_model_delete,
+            }
         )
-        mock_dsc_job_delete = MagicMock()
-        mock_dsc_job.return_value = MagicMock(
-            lifecycle_state="ACCEPTED", delete=mock_dsc_job_delete
-        )
-        mock_dsc_model_delete.return_value = None
-
+        mock_dsc_job.return_value = MagicMock(lifecycle_state="ACCEPTED")
+        mock_del_job_func.return_value = None
         result = self.app.delete(TestDataset.EVAL_ID)
-
         assert result["id"] == TestDataset.EVAL_ID
         assert result["lifecycle_state"] == "DELETING"
 
-        mock_dsc_job_delete.assert_called_once()
-        mock_dsc_model_delete.assert_called_once()
+        mock_del_job_func.assert_called_once()
 
     @patch.object(DataScienceModel, "from_id")
     @patch.object(DataScienceJobRun, "from_ocid")

--- a/tests/unitary/with_extras/aqua/test_evaluation.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation.py
@@ -317,7 +317,7 @@ class TestAquaModel(unittest.TestCase):
     @patch.object(DataScienceJob, "from_id")
     @patch.object(AquaEvaluationApp, "_delete_job_and_model")
     def test_delete_evaluation(
-        self, mock_del_job_func, mock_dsc_job, mock_dsc_model_from_id
+        self, mock_del_job_model_func, mock_dsc_job, mock_dsc_model_from_id
     ):
         mock_dsc_model_from_id.return_value = MagicMock(
             provenance_data={
@@ -325,31 +325,32 @@ class TestAquaModel(unittest.TestCase):
             }
         )
         mock_dsc_job.return_value = MagicMock(lifecycle_state="ACCEPTED")
-        mock_del_job_func.return_value = None
+        mock_del_job_model_func.return_value = None
         result = self.app.delete(TestDataset.EVAL_ID)
         assert result["id"] == TestDataset.EVAL_ID
         assert result["lifecycle_state"] == "DELETING"
 
-        mock_del_job_func.assert_called_once()
+        mock_del_job_model_func.assert_called_once()
 
     @patch.object(DataScienceModel, "from_id")
     @patch.object(DataScienceJobRun, "from_ocid")
-    def test_cancel_evaluation(self, mock_dsc_job_run, mock_dsc_model_from_id):
+    @patch.object(AquaEvaluationApp, "_cancel_job_run")
+    def test_cancel_evaluation(
+        self, mock_cancel_jr_func, mock_dsc_job_run, mock_dsc_model_from_id
+    ):
         mock_dsc_model_from_id.return_value = MagicMock(
             provenance_data={
                 "training_id": TestDataset.model_provenance_object.get("training_id")
             }
         )
-        mock_dsc_job_run_cancel = MagicMock()
-        mock_dsc_job_run.return_value = MagicMock(
-            lifecycle_state="ACCEPTED", cancel=mock_dsc_job_run_cancel
-        )
+        mock_dsc_job_run.return_value = MagicMock(lifecycle_state="ACCEPTED")
+        mock_cancel_jr_func.return_value = None
 
         result = self.app.cancel(TestDataset.EVAL_ID)
 
         assert result["id"] == TestDataset.EVAL_ID
         assert result["lifecycle_state"] == "CANCELING"
-        mock_dsc_job_run_cancel.assert_called_once()
+        mock_cancel_jr_func.assert_called_once()
 
     @patch.object(DataScienceModel, "download_artifact")
     @patch.object(DataScienceModel, "from_id")


### PR DESCRIPTION
### Description

This PR takes care of deleting and canceling evaluations. For cancel, only the evaluation job is canceled. For delete, first we delete the job and then we delete the associated model for evaluation.

Tested deleting a job can with active Job run, that would not work with this setup. If we need to delete the job, then we should cancel the jobs run first, and then delete the job. 

- Cancel API
```
ads aqua evaluation cancel --eval_id "ocid1.datasciencemodel.oc1.iad.<OCID>"
```
Response:
```
id:              ocid1.datasciencemodel.oc1.iad.<OCID>
lifecycle_state: CANCELING
time_accepted:   2024-03-04 16:58:54.229819
INFO:ads.aqua:Canceling Job Run: ocid1.datasciencejobrun.oc1.iad.<OCID> for evaluation ocid1.datasciencemodel.oc1.iad.<OCID>
```

- Delete API
```
ads aqua evaluation delete --eval_id "ocid1.datasciencemodel.oc1.iad.<OCID>"
```

Response:
```
id:              ocid1.datasciencemodel.oc1.iad.<OCID>
lifecycle_state: DELETING
time_accepted:   2024-03-04 17:01:07.564414
INFO:ads.aqua:Deleting Job: ocid1.datasciencejob.oc1.iad.<OCID> for evaluation ocid1.datasciencemodel.oc1.iad.<OCID>
INFO:ads.aqua:Deleting evaluation: ocid1.datasciencemodel.oc1.iad.<OCID>
```


The API requests would look like:
- Cancel : `PUT http://localhost:8888/aqua/evaluation/<OCID>/cancel`
- Delete: `DELETE http://localhost:8888/aqua/evaluation/<OCID>`