### PR TITLE
Add Telemetry module to ADS

### DIFF
--- a/ads/telemetry/base.py
+++ b/ads/telemetry/base.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+import logging
+
+from ads import set_auth
+from ads.common import oci_client as oc
+from ads.common.auth import default_signer
+from ads.config import OCI_RESOURCE_PRINCIPAL_VERSION
+
+
+logger = logging.getLogger(__name__)
+class TelemetryBase:
+    """Base class for Telemetry Client."""
+
+    def __init__(self, bucket: str, namespace: str = None) -> None:
+        """Initializes the telemetry client.
+
+        Parameters
+        ----------
+        bucket : str
+            OCI object storage bucket name storing the telemetry objects.
+        namespace : str, optional
+            Namespace of the OCI object storage bucket, by default None.
+        """
+        if OCI_RESOURCE_PRINCIPAL_VERSION:
+            set_auth("resource_principal")
+        self._auth = default_signer()
+        self.os_client = oc.OCIClientFactory(**self._auth).object_storage
+        self.bucket = bucket
+        self._namespace = namespace
+        self._service_endpoint = None
+        logger.debug(f"Initialized Telemetry. Namespace: {self.namespace}, Bucket: {self.bucket}")
+
+
+    @property
+    def namespace(self) -> str:
+        """Gets the namespace of the object storage from the tenancy.
+
+        Returns
+        -------
+        str
+            The namespace of the tenancy.
+        """
+        if not self._namespace:
+            self._namespace = self.os_client.get_namespace().data
+        return self._namespace
+
+    @property
+    def service_endpoint(self):
+        """Gets the tenancy-specific endpoint.
+
+        Returns
+        -------
+        str
+            Tenancy-specific endpoint.
+        """
+        if not self._service_endpoint:
+            self._service_endpoint = self.os_client.base_client.endpoint
+        return self._service_endpoint

--- a/ads/telemetry/base.py
+++ b/ads/telemetry/base.py
@@ -8,7 +8,7 @@ import logging
 from ads import set_auth
 from ads.common import oci_client as oc
 from ads.common.auth import default_signer
-from ads.config import OCI_RESOURCE_PRINCIPAL_VERSION
+from ads.config import OCI_ODSC_SERVICE_ENDPOINT, OCI_RESOURCE_PRINCIPAL_VERSION
 
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ class TelemetryBase:
         """
         if OCI_RESOURCE_PRINCIPAL_VERSION:
             set_auth("resource_principal")
-        self._auth = default_signer()
+        self._auth = default_signer({"service_endpoint": OCI_ODSC_SERVICE_ENDPOINT})
         self.os_client = oc.OCIClientFactory(**self._auth).object_storage
         self.bucket = bucket
         self._namespace = namespace

--- a/ads/telemetry/base.py
+++ b/ads/telemetry/base.py
@@ -8,7 +8,7 @@ import logging
 from ads import set_auth
 from ads.common import oci_client as oc
 from ads.common.auth import default_signer
-from ads.config import OCI_ODSC_SERVICE_ENDPOINT, OCI_RESOURCE_PRINCIPAL_VERSION
+from ads.config import OCI_RESOURCE_PRINCIPAL_VERSION
 
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ class TelemetryBase:
         """
         if OCI_RESOURCE_PRINCIPAL_VERSION:
             set_auth("resource_principal")
-        self._auth = default_signer({"service_endpoint": OCI_ODSC_SERVICE_ENDPOINT})
+        self._auth = default_signer()
         self.os_client = oc.OCIClientFactory(**self._auth).object_storage
         self.bucket = bucket
         self._namespace = namespace

--- a/ads/telemetry/client.py
+++ b/ads/telemetry/client.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+
+import logging
+import threading
+import urllib.parse
+
+import requests
+
+from .base import TelemetryBase
+
+
+logger = logging.getLogger(__name__)
+
+
+class TelemetryClient(TelemetryBase):
+    """Represents a telemetry python client providing functions to record an event.
+
+    Methods
+    -------
+    record_event(category: str = None, action: str = None, path: str = None, **kwargs) -> None
+        Send a head request to generate an event record.
+    record_event_async(category: str = None, action: str = None, path: str = None,  **kwargs)
+        Starts thread to send a head request to generate an event record.
+
+    Examples
+    --------
+    >>> import os
+    >>> from ads.telemetry.client import TelemetryClient
+    >>> AQUA_BUCKET = os.environ.get("AQUA_BUCKET", "service-managed-models")
+    >>> AQUA_BUCKET_NS = os.environ.get("AQUA_BUCKET_NS", "ociodscdev")
+    >>> telemetry = TelemetryClient(bucket=AQUA_BUCKET, namespace=AQUA_BUCKET_NS)
+    >>> category = "aqua/service/model"
+    >>> action = "list"
+    >>> telemetry.record_event_async(category=f"telemetry/{category}", action=action)
+    """
+
+    @staticmethod
+    def _encode_user_agent(**kwargs):
+        message = urllib.parse.urlencode(kwargs)
+        return message
+
+    def record_event(self, category: str = None, action: str = None, path: str = None, **kwargs) -> None:
+        """Send a head request to generate an event record.
+
+        Parameters
+        ----------
+        category (str)
+            Category of the event, which is also the path to the directory containing the object representing the event.
+        action (str)
+            Filename of the object representing the event.
+        path (str)
+            The path of the object representing the event, e.g. "telemetry/conda/delete".
+
+        Returns
+        -------
+        Response
+        """
+        if category and action:
+            path = f"{category}/{action}"
+        if not path:
+            raise ValueError("Please specify either the combination of category and action, or path")
+        endpoint = f"{self.service_endpoint}/n/{self.namespace}/b/{self.bucket}/o/{path}"
+        headers = {"User-Agent": self._encode_user_agent(**kwargs)}
+        logger.debug(f"Sending telemetry to endpoint: {endpoint}")
+        response = requests.head(endpoint, auth=self._auth, headers=headers)
+        logger.debug(f"Telemetry status code: {response.status_code}")
+        return response
+
+    def record_event_async(self, category: str = None, action: str = None, path: str = None, **kwargs):
+        """Send a head request to generate an event record.
+
+        Parameters
+        ----------
+        category (str)
+            Category of the event, which is also the path to the directory containing the object representing the event.
+        action (str)
+            Filename of the object representing the event.
+        path (str)
+            The path of the object representing the event, e.g. "telemetry/conda/delete".
+
+        Returns
+        -------
+        Thread
+            A started thread to send a head request to generate an event record.
+        """
+        thread = threading.Thread(
+            target=self.record_event,
+            args=(category, action, path),
+            kwargs=kwargs
+        )
+        thread.daemon = True
+        thread.start()
+        return thread

--- a/ads/telemetry/client.py
+++ b/ads/telemetry/client.py
@@ -66,7 +66,8 @@ class TelemetryClient(TelemetryBase):
         endpoint = f"{self.service_endpoint}/n/{self.namespace}/b/{self.bucket}/o/{path}"
         headers = {"User-Agent": self._encode_user_agent(**kwargs)}
         logger.debug(f"Sending telemetry to endpoint: {endpoint}")
-        response = requests.head(endpoint, auth=self._auth, headers=headers)
+        signer = self._auth["signer"]
+        response = requests.head(endpoint, auth=signer, headers=headers)
         logger.debug(f"Telemetry status code: {response.status_code}")
         return response
 

--- a/tests/unitary/default_setup/telemetry/test_telemetry_client.py
+++ b/tests/unitary/default_setup/telemetry/test_telemetry_client.py
@@ -28,7 +28,7 @@ class TestTelemetryClient:
         """
         data = {
             "cmd": "ads aqua model list",
-            "category": "telemetry/aqua/service/model",
+            "category": "aqua/service/model",
             "action": "list",
             "bucket": "test_bucket",
             "namespace": "test_namespace",
@@ -41,16 +41,13 @@ class TestTelemetryClient:
         bucket = data["bucket"]
         namespace = data["namespace"]
         value = data["value"]
-        path = f"{category}/{action}"
-        expected_endpoint = f"{self.endpoint}/n/{namespace}/b/{bucket}/o/{path}"
+        expected_endpoint = f"{self.endpoint}/n/{namespace}/b/{bucket}/o/telemetry/{category}/{action}"
 
         telemetry = TelemetryClient(bucket=bucket, namespace=namespace)
         telemetry.record_event(category=category, action=action)
-        telemetry.record_event(path=path)
-        telemetry.record_event(path=path, **value)
+        telemetry.record_event(category=category, action=action, **value)
 
         expected_headers = [
-            {'User-Agent': ''},
             {'User-Agent': ''},
             {'User-Agent': 'keyword=test_service_model_name_or_id'}
         ]

--- a/tests/unitary/default_setup/telemetry/test_telemetry_client.py
+++ b/tests/unitary/default_setup/telemetry/test_telemetry_client.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+
+from unittest.mock import patch, PropertyMock
+
+from ads.telemetry.client import TelemetryClient
+
+class TestTelemetryClient:
+    """Contains unittests for TelemetryClient."""
+
+    endpoint = "https://objectstorage.us-ashburn-1.oraclecloud.com"
+
+    def mocked_requests_head(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, status_code):
+                self.status_code = status_code
+
+        return MockResponse(200)
+
+    @patch('requests.head', side_effect=mocked_requests_head)
+    @patch('ads.telemetry.client.TelemetryClient.service_endpoint', new_callable=PropertyMock,
+           return_value=endpoint)
+    def test_telemetry_client_record_event(self, mock_endpoint, mock_head):
+        """Tests TelemetryClient.record_event() with category/action and path, respectively.
+        """
+        data = {
+            "cmd": "ads aqua model list",
+            "category": "telemetry/aqua/service/model",
+            "action": "list",
+            "bucket": "test_bucket",
+            "namespace": "test_namespace",
+            "value": {
+                "keyword": "test_service_model_name_or_id"
+            }
+        }
+        category = data["category"]
+        action = data["action"]
+        bucket = data["bucket"]
+        namespace = data["namespace"]
+        value = data["value"]
+        path = f"{category}/{action}"
+        expected_endpoint = f"{self.endpoint}/n/{namespace}/b/{bucket}/o/{path}"
+
+        telemetry = TelemetryClient(bucket=bucket, namespace=namespace)
+        telemetry.record_event(category=category, action=action)
+        telemetry.record_event(path=path)
+        telemetry.record_event(path=path, **value)
+
+        expected_headers = [
+            {'User-Agent': ''},
+            {'User-Agent': ''},
+            {'User-Agent': 'keyword=test_service_model_name_or_id'}
+        ]
+        i = 0
+        for call_args in mock_head.call_args_list:
+            args, kwargs = call_args
+            assert all(endpoint == expected_endpoint for endpoint in args)
+            assert kwargs['headers'] == expected_headers[i]
+            i += 1


### PR DESCRIPTION
### Description

First step to include telemetry to aqua module is to move telemetry module into ADS.
https://jira.oci.oraclecorp.com/browse/ODSC-53773

### What was done

- move telemetry module from odsc_cli to ADS codebase

### Validation

- builded whl
- installed it in nb-session
- run code to record event in the conda bucket (I am not sure if aqua logs created in dev)
```
from ads import set_auth
from ads.telemetry.client import TelemetryClient

set_auth("resource_principal")
AQUA_BUCKET = "service-managed-models"
AQUA_BUCKET_NS = "ociodscdev"
telemetry = TelemetryClient(bucket=AQUA_BUCKET, namespace=AQUA_BUCKET_NS)
category = "ads/telemetry/module"
action = "test"
telemetry.record_event_async(category=f"{category}", action=action)
```
- checked logs records. Saw an expected entry with. check the ticket (https://jira.oci.oraclecorp.com/browse/ODSC-53773) comment section fro a screenshot.