### PR TITLE
Replace WORLD_SIZE with NODE_COUNT in Distributed Training.

### DIFF
--- a/ads/jobs/builders/runtimes/base.py
+++ b/ads/jobs/builders/runtimes/base.py
@@ -300,7 +300,7 @@ class MultiNodeRuntime(Runtime):
                     # HuggingFace accelerate requires machine rank
                     # Here we use NODE_RANK to store the machine rank
                     envs["NODE_RANK"] = str(i)
-                    envs["WORLD_SIZE"] = str(replicas)
+                    envs["NODE_COUNT"] = str(replicas)
                     if main_run:
                         envs["MAIN_JOB_RUN_OCID"] = main_run.id
                     name = replica_kwargs.get("display_name")

--- a/tests/unitary/default_setup/jobs/test_jobs_pytorch_ddp.py
+++ b/tests/unitary/default_setup/jobs/test_jobs_pytorch_ddp.py
@@ -137,13 +137,13 @@ class PyTorchRuntimeHandlerTest(unittest.TestCase):
             [
                 {
                     "display_name": "None-0",
-                    "environment_variables": {"NODE_RANK": "0", "WORLD_SIZE": "2"},
+                    "environment_variables": {"NODE_RANK": "0", "NODE_COUNT": "2"},
                 },
                 {
                     "display_name": "None-1",
                     "environment_variables": {
                         "NODE_RANK": "1",
-                        "WORLD_SIZE": "2",
+                        "NODE_COUNT": "2",
                         "MAIN_JOB_RUN_OCID": test_ocid,
                     },
                 },


### PR DESCRIPTION
The distributed training uses environment variable to store the number nodes. Currently `WORLD_SIZE` is used. However, this is not really the conventional `WORLD_SIZE`. Usually `WORLD_SIZE` should be `number of nodes * number of GPUs per node`. It is better to rename `WORLD_SIZE` to `NODE_COUNT` to avoid potential confusion in the future.