### PR TITLE
AQUA/FT/Update the response based on the new requirements

### DIFF
--- a/ads/aqua/data.py
+++ b/ads/aqua/data.py
@@ -3,8 +3,9 @@
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-from enum import Enum
 from dataclasses import dataclass
+from enum import Enum
+
 from ads.common.serializer import DataClassSerializable
 
 
@@ -17,6 +18,7 @@ class AquaResourceIdentifier(DataClassSerializable):
 
 class Resource(Enum):
     JOB = "jobs"
+    JOBRUN = "jobruns"
     MODEL = "models"
     MODEL_DEPLOYMENT = "modeldeployments"
     MODEL_VERSION_SET = "model-version-sets"

--- a/ads/aqua/model.py
+++ b/ads/aqua/model.py
@@ -37,6 +37,7 @@ from ads.model.datascience_model import DataScienceModel
 @dataclass(repr=False)
 class AquaFineTuningMetric(DataClassSerializable):
     name: str
+    category: str
     scores: list
 
 
@@ -70,6 +71,7 @@ class AquaModel(AquaModelSummary, DataClassSerializable):
 class AquaFineTuneModel(AquaModel, DataClassSerializable):
     """Represents an Aqua Fine Tuned Model."""
 
+    job: AquaResourceIdentifier = field(default_factory=AquaResourceIdentifier)
     source: AquaResourceIdentifier = field(default_factory=AquaResourceIdentifier)
     experiment: AquaResourceIdentifier = field(default_factory=AquaResourceIdentifier)
     shape_info: dict = field(default_factory=dict)
@@ -201,6 +203,15 @@ class AquaModelApp(AquaApp):
                 ),
                 # mock data for fine tuned model details
                 # TODO: fetch real value from custom metadata
+                job=AquaResourceIdentifier(
+                    id="ocid1.datasciencejobrun.oc1.iad.xxxx",
+                    name="Job Run Name",
+                    url=get_console_link(
+                        resource=Resource.JOBRUN.value,
+                        ocid="ocid1.datasciencejobrun.oc1.iad.xxxx",
+                        region=self.region,
+                    ),
+                ),
                 source=AquaResourceIdentifier(
                     id="ocid1.datasciencemodel.oc1.iad.xxxx",
                     name="Base Model Name",
@@ -224,6 +235,7 @@ class AquaModelApp(AquaApp):
                     AquaFineTuningMetric(
                         **{
                             "name": "validation_loss",
+                            "category": "validation",
                             "scores": [
                                 {"epoch": 2.5, "step": 12, "score": 1.1149},
                                 {"epoch": 3.5, "step": 20, "score": 1.1067},
@@ -233,13 +245,33 @@ class AquaModelApp(AquaApp):
                     ),
                     AquaFineTuningMetric(
                         **{
+                            "name": "training_loss",
+                            "category": "training",
+                            "scores": [
+                                {"epoch": 1.0, "step": 4, "score": 1.3856},
+                                {"epoch": 1.5, "step": 8, "score": 1.0992},
+                                {"epoch": 3.0, "step": 3, "score": 0.9193},
+                                {"epoch": 3.5, "step": 20, "score": 0.853},
+                            ],
+                        }
+                    ),
+                    AquaFineTuningMetric(
+                        **{
                             "name": "validation_accuracy",
+                            "category": "validation",
                             "scores": [
                                 # accuracy will be stored in "val_metrics_final"
                                 # Before we finalize the accuracy, we can use the rouge1 score as an example.
                                 # There will be only one number without epoch/step
                                 {"score": 29.1849}
                             ],
+                        }
+                    ),
+                    AquaFineTuningMetric(
+                        **{
+                            "name": "final_training_loss",
+                            "category": "training",
+                            "scores": [{"score": 1.0474}],
                         }
                     ),
                 ],


### PR DESCRIPTION
# Description
Based on the discussion, we added the following fields into response:
* jobrun's info (ocid,name,console uri)
* both val_loss and train_loss will be returned in metrics
* final_train_loss added into returning metrics 