### PR TITLE
Keep active models by default

### DIFF
--- a/ads/aqua/model.py
+++ b/ads/aqua/model.py
@@ -32,6 +32,7 @@ from ads.config import (
     TENANCY_OCID,
 )
 from ads.model.datascience_model import DataScienceModel
+from oci.data_science.models import Model
 
 
 @dataclass(repr=False)
@@ -314,9 +315,14 @@ class AquaModelApp(AquaApp):
             logger.info(
                 f"Fetching service models from compartment_id={ODSC_MODEL_COMPARTMENT_OCID}"
             )
+            lifecycle_state = kwargs.pop(
+                "lifecycle_state", Model.LIFECYCLE_STATE_ACTIVE
+            )
+
             models = self.list_resource(
                 self.ds_client.list_models,
                 compartment_id=ODSC_MODEL_COMPARTMENT_OCID,
+                lifecycle_state=lifecycle_state,
                 **kwargs,
             )
 


### PR DESCRIPTION
### Description

model list call would load all the available models in the compartment, but we want to see only active models by default. Added a check to show active models only if lifecycle_state is not set via params.

### Test

logs for when list API is called for service compartment:
```
INFO:ads.aqua:Fetch 10 model in compartment_id=ocid1.compartment.oc1..<OCID>
```

logs for when list API is called for service compartment after 2 models are deactivated
```
INFO:ads.aqua:Fetch 8 model in compartment_id=ocid1.compartment.oc1..<OCID>
```

### Unit Test
```
============================= test session starts ==============================
collecting ... collected 1 item

test_model.py::TestAquaModel::test_list_service_models 

============================== 1 passed in 1.74s ===============================
PASSED            [100%]############ Expected Response ############
```