### PR TITLE
Model by reference for Multiple Models

### DIFF
--- a/ads/common/object_storage_details.py
+++ b/ads/common/object_storage_details.py
@@ -259,7 +259,7 @@ class ObjectStorageDetails:
             object_name=path.filepath,
             version_id=path.version,
         )
-        local_filepath = os.path.join(target_dir, path.filepath)
+        local_filepath = os.path.join(target_dir, path.bucket, path.filepath)
         os.makedirs(os.path.dirname(local_filepath), exist_ok=True)
 
         with open(local_filepath, "wb") as _file:

--- a/ads/model/artifact_downloader.py
+++ b/ads/model/artifact_downloader.py
@@ -171,14 +171,12 @@ class LargeArtifactDownloader(ArtifactDownloader):
         """Downloads model artifacts."""
         self.progress.update(f"Importing model artifacts from catalog")
 
-        bucket_uri = self.bucket_uri
-
         if self.dsc_model.is_model_by_reference() and self.model_file_description:
-            message = f"Copying model artifacts by reference from {bucket_uri} to {self.target_dir}"
-            self.progress.update(message)
             self.download_from_model_file_description()
             self.progress.update()
             return
+
+        bucket_uri = self.bucket_uri
 
         if not os.path.basename(bucket_uri):
             bucket_uri = os.path.join(bucket_uri, f"{self.dsc_model.id}.zip")
@@ -220,6 +218,10 @@ class LargeArtifactDownloader(ArtifactDownloader):
                 model["prefix"],
             )
             bucket_uri = f"oci://{bucket_name}@{namespace}/{prefix}"
+
+            message = f"Copying model artifacts by reference from {bucket_uri} to {self.target_dir}"
+            self.progress.update(message)
+
             objects = model["objects"]
             os_details_list = list()
 

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -1274,7 +1274,7 @@ class DataScienceModel(Builder):
 
         bucket_uri = self.artifact
         if isinstance(bucket_uri, str):
-            bucket_uri = (bucket_uri,)
+            bucket_uri = list(bucket_uri)
 
         for uri in bucket_uri:
             if not ObjectStorageDetails.from_path(uri).is_bucket_versioned():

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -1388,7 +1388,7 @@ class DataScienceModel(Builder):
         model_file_desc_dict = self.model_file_description
         models = model_file_desc_dict["models"]
 
-        bucket_uri = ()
+        bucket_uri = list()
         artifact_size = 0
         for model in models:
             namespace = model["namespace"]
@@ -1397,6 +1397,6 @@ class DataScienceModel(Builder):
             objects = model["objects"]
             uri = f"oci://{bucket_name}@{namespace}/{prefix}"
             artifact_size += sum([obj["sizeInBytes"] for obj in objects])
-            bucket_uri += (uri,)
+            bucket_uri.append(uri)
 
         return bucket_uri[0] if len(bucket_uri) == 1 else bucket_uri, artifact_size

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -548,7 +548,7 @@ class DataScienceModel(Builder):
     def artifact(self) -> Union[str, list]:
         return self.get_spec(self.CONST_ARTIFACT)
 
-    def with_artifact(self, *uri: str):
+    def with_artifact(self, uri: str, *args):
         """Sets the artifact location. Can be a local.
 
         Parameters
@@ -565,9 +565,8 @@ class DataScienceModel(Builder):
         >>> .with_artifact(uri="./model1.zip")
         >>> .with_artifact("./model1", "./model2")
         """
-        return self.set_spec(
-            self.CONST_ARTIFACT, uri[0] if len(uri) == 1 else list(uri)
-        )
+
+        return self.set_spec(self.CONST_ARTIFACT, [uri] + list(args) if args else uri)
 
     @property
     def model_version_set_id(self) -> str:
@@ -1287,7 +1286,7 @@ class DataScienceModel(Builder):
 
         bucket_uri = self.artifact
         if isinstance(bucket_uri, str):
-            bucket_uri = list(bucket_uri)
+            bucket_uri = [bucket_uri]
 
         for uri in bucket_uri:
             if not ObjectStorageDetails.from_path(uri).is_bucket_versioned():

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -11,7 +11,7 @@ import os
 import shutil
 import tempfile
 from copy import deepcopy
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Tuple
 
 import pandas
 from jsonschema import ValidationError, validate
@@ -67,6 +67,10 @@ class BucketNotVersionedError(Exception):  # pragma: no cover
 class ModelFileDescriptionError(Exception):  # pragma: no cover
     def __init__(self, msg="Model File Description file is not set up."):
         super().__init__(msg)
+
+
+class InvalidArtifactType(Exception):  # pragma: no cover
+    pass
 
 
 class DataScienceModel(Builder):
@@ -154,8 +158,9 @@ class DataScienceModel(Builder):
         Sets model custom metadata.
     with_provenance_metadata(self, metadata: Union[ModelProvenanceMetadata, Dict]) -> "DataScienceModel"
         Sets model provenance metadata.
-    with_artifact(self, uri: str)
-        Sets the artifact location. Can be a local.
+    with_artifact(self, *uri: str)
+        Sets the artifact location. Can be a local. For models created by reference, uri can take in single arg or multiple args in case
+        of a fine-tuned or multimodel setting.
     with_model_version_set_id(self, model_version_set_id: str):
         Sets the model version set ID.
     with_version_label(self, version_label: str):
@@ -527,10 +532,10 @@ class DataScienceModel(Builder):
         return self.set_spec(self.CONST_PROVENANCE_METADATA, metadata)
 
     @property
-    def artifact(self) -> str:
+    def artifact(self) -> Union[str, list]:
         return self.get_spec(self.CONST_ARTIFACT)
 
-    def with_artifact(self, uri: str):
+    def with_artifact(self, *uri: str):
         """Sets the artifact location. Can be a local.
 
         Parameters
@@ -539,13 +544,17 @@ class DataScienceModel(Builder):
             Path to artifact directory or to the ZIP archive.
             It could contain a serialized model(required) as well as any files needed for deployment.
             The content of the source folder will be zipped and uploaded to the model catalog.
-
+            For models created by reference, uri can take in single arg or multiple args in case of a fine-tuned or
+            multimodel setting.
         Examples
         --------
         >>> .with_artifact(uri="./model1/")
         >>> .with_artifact(uri="./model1.zip")
+        >>> .with_artifact("./model1", "./model2")
         """
-        return self.set_spec(self.CONST_ARTIFACT, uri)
+        return self.set_spec(
+            self.CONST_ARTIFACT, uri[0] if len(uri) == 1 else list(uri)
+        )
 
     @property
     def model_version_set_id(self) -> str:
@@ -800,15 +809,20 @@ class DataScienceModel(Builder):
                 "timeout": timeout,
             }
 
-        if ObjectStorageDetails.is_oci_path(self.artifact):
-            if bucket_uri and bucket_uri != self.artifact:
-                logger.warn(
-                    "The `bucket_uri` will be ignored and the value of `self.artifact` will be used instead."
+        if model_by_reference:
+            self._validate_prepare_file_description_artifact()
+        else:
+            if isinstance(self.artifact, list):
+                raise InvalidArtifactType(
+                    "Multiple artifacts are only allowed for models created by reference."
                 )
-            bucket_uri = self.artifact
 
-            if model_by_reference:
-                self._validate_prepare_file_description_artifact(bucket_uri)
+            if ObjectStorageDetails.is_oci_path(self.artifact):
+                if bucket_uri and bucket_uri != self.artifact:
+                    logger.warn(
+                        "The `bucket_uri` will be ignored and the value of `self.artifact` will be used instead."
+                    )
+                bucket_uri = self.artifact
 
         if not model_by_reference and (
             bucket_uri or utils.folder_size(self.artifact) > _MAX_ARTIFACT_SIZE_IN_BYTES
@@ -911,18 +925,26 @@ class DataScienceModel(Builder):
             model_by_reference = False
 
         if model_by_reference:
-            bucket_uri, artifact_size = self._download_file_description_artifact()
+            _, artifact_size = self._download_file_description_artifact()
             logging.warning(
                 f"Model {self.dsc_model.id} was created by reference, artifacts will be downloaded from the bucket {bucket_uri}"
             )
+            # artifacts will be downloaded from model_file_description
+            bucket_uri = None
         else:
             artifact_info = self.dsc_model.get_artifact_info()
             artifact_size = int(artifact_info.get("content-length"))
 
-        if not bucket_uri and artifact_size > _MAX_ARTIFACT_SIZE_IN_BYTES:
-            raise ModelArtifactSizeError(utils.human_size(_MAX_ARTIFACT_SIZE_IN_BYTES))
+            if not bucket_uri and artifact_size > _MAX_ARTIFACT_SIZE_IN_BYTES:
+                raise ModelArtifactSizeError(
+                    utils.human_size(_MAX_ARTIFACT_SIZE_IN_BYTES)
+                )
 
-        if artifact_size > _MAX_ARTIFACT_SIZE_IN_BYTES or bucket_uri:
+        if (
+            artifact_size > _MAX_ARTIFACT_SIZE_IN_BYTES
+            or bucket_uri
+            or model_by_reference
+        ):
             artifact_downloader = LargeArtifactDownloader(
                 dsc_model=self.dsc_model,
                 target_dir=target_dir,
@@ -1245,14 +1267,23 @@ class DataScienceModel(Builder):
             return self.get_spec(item)
         raise AttributeError(f"Attribute {item} not found.")
 
-    def _validate_prepare_file_description_artifact(self, bucket_uri: str):
-        if not ObjectStorageDetails.from_path(bucket_uri).is_bucket_versioned():
-            message = f"Model artifact bucket {bucket_uri} is not versioned. Enable versioning on the bucket to proceed with model creation by reference."
-            logger.error(message)
-            raise BucketNotVersionedError(message)
+    def _validate_prepare_file_description_artifact(self):
+        """This helper method validates the path to check if the buckets are versioned and if the OSS location and
+        the files exist. Next, it creates a json dict with the path information and sets it as the artifact to be
+        uploaded."""
+
+        bucket_uri = self.artifact
+        if isinstance(bucket_uri, str):
+            bucket_uri = (bucket_uri,)
+
+        for uri in bucket_uri:
+            if not ObjectStorageDetails.from_path(uri).is_bucket_versioned():
+                message = f"Model artifact bucket {uri} is not versioned. Enable versioning on the bucket to proceed with model creation by reference."
+                logger.error(message)
+                raise BucketNotVersionedError(message)
 
         if not self.model_file_description:
-            json_data = self._prepare_file_description_artifact()
+            json_data = self._prepare_file_description_artifact(bucket_uri)
             self.with_model_file_description(json_dict=json_data)
 
         self.local_copy_dir = tempfile.mkdtemp()
@@ -1262,76 +1293,80 @@ class DataScienceModel(Builder):
         )
         with open(json_file_path, "w") as outfile:
             json.dump(self.model_file_description, outfile, indent=2)
+
         self.with_artifact(json_file_path)
 
-    def _prepare_file_description_artifact(self) -> dict:
+    @staticmethod
+    def _prepare_file_description_artifact(bucket_uri: list) -> dict:
         """Prepares yaml file config if model is passed by reference and uploaded to catalog.
 
         Returns
         -------
-        str
-            Path to the model artifact yaml file.
+        dict
+            json dict with the model by reference artifact details
         """
-        # todo: check condition again
-        if not ObjectStorageDetails.is_oci_path(
-            self.artifact
-        ) or self.artifact.endswith(".zip"):
-            logging.error(
-                "Artifact path cannot be a zip file or local directory for model "
-                "creation by reference."
-            )
-            raise
-
-        # read list from objects from artifact location
-        oss_details = ObjectStorageDetails.from_path(self.artifact)
 
         # create json content
         content = dict()
         content["version"] = MODEL_BY_REFERENCE_VERSION
         content["type"] = "modelOSSReferenceDescription"
+        content["models"] = []
 
-        # first retrieve the etag and version id
-        object_versions = oss_details.list_object_versions(fields="etag")
-        version_dict = {
-            obj.etag: obj.version_id for obj in object_versions if obj.etag is not None
-        }
+        for uri in bucket_uri:
+            if not ObjectStorageDetails.is_oci_path(uri) or uri.endswith(".zip"):
+                msg = "Artifact path cannot be a zip file or local directory for model creation by reference."
+                logging.error(msg)
+                raise InvalidArtifactType(msg)
 
-        # add version id based on etag for each object
-        objects = oss_details.list_objects(fields="name,etag,size").objects
+            # read list from objects from artifact location
+            oss_details = ObjectStorageDetails.from_path(uri)
 
-        if len(objects) == 0:
-            raise ModelFileDescriptionError(
-                f"The path {oss_details.path} does not exist or no objects were found in the path. "
-            )
-
-        object_list = []
-        for obj in objects:
-            object_list.append(
-                {
-                    "name": obj.name,
-                    "version": version_dict[obj.etag],
-                    "sizeInBytes": obj.size,
-                }
-            )
-        content["models"] = [
-            {
-                "namespace": oss_details.namespace,
-                "bucketName": oss_details.bucket,
-                "prefix": oss_details.filepath,
-                "objects": object_list,
+            # first retrieve the etag and version id
+            object_versions = oss_details.list_object_versions(fields="etag")
+            version_dict = {
+                obj.etag: obj.version_id
+                for obj in object_versions
+                if obj.etag is not None
             }
-        ]
+
+            # add version id based on etag for each object
+            objects = oss_details.list_objects(fields="name,etag,size").objects
+
+            if len(objects) == 0:
+                raise ModelFileDescriptionError(
+                    f"The path {oss_details.path} does not exist or no objects were found in the path. "
+                )
+
+            object_list = []
+            for obj in objects:
+                object_list.append(
+                    {
+                        "name": obj.name,
+                        "version": version_dict[obj.etag],
+                        "sizeInBytes": obj.size,
+                    }
+                )
+            content["models"].extend(
+                [
+                    {
+                        "namespace": oss_details.namespace,
+                        "bucketName": oss_details.bucket,
+                        "prefix": oss_details.filepath,
+                        "objects": object_list,
+                    }
+                ]
+            )
 
         return content
 
-    def _download_file_description_artifact(self):
+    def _download_file_description_artifact(self) -> Tuple[Union[str, List[str]], int]:
         """Loads the json file from model artifact, updates the
         model file description property, and returns the bucket uri and artifact size details.
 
         Returns
         -------
-        bucket_uri: str
-            Location of bucket where model artifacts are present
+        bucket_uri: Union[str, List[str]]
+            Location(s) of bucket where model artifacts are present
         artifact_size: int
             estimated size of the model files in bytes
 
@@ -1351,14 +1386,17 @@ class DataScienceModel(Builder):
                 self.with_model_file_description(json_uri=json_file_path)
 
         model_file_desc_dict = self.model_file_description
-        # currently only supports downloading from the first model item
-        model = model_file_desc_dict["models"][0]
-        namespace = model["namespace"]
-        bucket_name = model["bucketName"]
-        prefix = model["prefix"]
-        objects = model["objects"]
+        models = model_file_desc_dict["models"]
 
-        bucket_uri = f"oci://{bucket_name}@{namespace}/{prefix}"
-        artifact_size = sum([obj["sizeInBytes"] for obj in objects])
+        bucket_uri = ()
+        artifact_size = 0
+        for model in models:
+            namespace = model["namespace"]
+            bucket_name = model["bucketName"]
+            prefix = model["prefix"]
+            objects = model["objects"]
+            uri = f"oci://{bucket_name}@{namespace}/{prefix}"
+            artifact_size += sum([obj["sizeInBytes"] for obj in objects])
+            bucket_uri += (uri,)
 
-        return bucket_uri, artifact_size
+        return bucket_uri[0] if len(bucket_uri) == 1 else bucket_uri, artifact_size

--- a/tests/unitary/default_setup/model/test_artifact_downloader.py
+++ b/tests/unitary/default_setup/model/test_artifact_downloader.py
@@ -214,7 +214,3 @@ class TestArtifactDownloader:
             ).download()
 
             mock_download.assert_called()
-
-    def test_multiple_artifact_download_from_model_file_description(self):
-        # todo: Tests whether model_file_description is loaded within downloader and is parsed with multiple artifacts."""
-        pass

--- a/tests/unitary/default_setup/model/test_artifact_downloader.py
+++ b/tests/unitary/default_setup/model/test_artifact_downloader.py
@@ -196,14 +196,7 @@ class TestArtifactDownloader:
         with open(self.mock_artifact_file_path, "r") as file_data:
             model_file_description = json.load(file_data)
 
-        model = model_file_description["models"][0]
-        namespace, bucket_name, prefix = (
-            model["namespace"],
-            model["bucketName"],
-            model["prefix"],
-        )
-        bucket_uri = f"oci://{bucket_name}@{namespace}/{prefix}"
-        objects = model["objects"]
+        bucket_uri = None
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             target_dir = os.path.join(tmp_dir, "model_artifacts/")
@@ -221,3 +214,7 @@ class TestArtifactDownloader:
             ).download()
 
             mock_download.assert_called()
+
+    def test_multiple_artifact_download_from_model_file_description(self):
+        # todo: Tests whether model_file_description is loaded within downloader and is parsed with multiple artifacts."""
+        pass

--- a/tests/unitary/default_setup/model/test_datascience_model.py
+++ b/tests/unitary/default_setup/model/test_datascience_model.py
@@ -767,3 +767,12 @@ class TestDataScienceModel:
         # todo: Loads the json file from model artifact, updates the
         #  model file description property, and returns the bucket uri and artifact size details.
         pass
+
+    def test_multiple_artifact_for_model_by_reference(self):
+        # todo: create a datascience model with multiple artifact, check if multiple paths are added to json file.
+        #   for regular model, check if InvalidArtifactType is raised
+        pass
+
+    def test_model_by_reference_created_from_yaml(self):
+        # todo: create a datascience model using yaml, pass single and also multiple artifact.
+        pass

--- a/tests/unitary/default_setup/model/test_datascience_model.py
+++ b/tests/unitary/default_setup/model/test_datascience_model.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
+import copy
 
 # Copyright (c) 2022, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
+import os
 import datetime
 import hashlib
 import json
@@ -22,11 +24,16 @@ from ads.model.datascience_model import (
     _MAX_ARTIFACT_SIZE_IN_BYTES,
     DataScienceModel,
     ModelArtifactSizeError,
+    BucketNotVersionedError,
+    ModelFileDescriptionError,
+    InvalidArtifactType,
 )
 from ads.model.model_metadata import (
     ModelCustomMetadata,
     ModelProvenanceMetadata,
     ModelTaxonomyMetadata,
+    ModelCustomMetadataItem,
+    MetadataCustomCategory,
 )
 from ads.model.service.oci_datascience_model import (
     ModelProvenanceNotFoundError,
@@ -164,6 +171,7 @@ class TestDataScienceModel:
 
     def setup_class(cls):
         cls.mock_date = datetime.datetime(2022, 7, 1)
+        cls.curr_dir = os.path.dirname(os.path.abspath(__file__))
 
     def setup_method(self):
         self.payload = deepcopy(DSC_MODEL_PAYLOAD)
@@ -343,6 +351,13 @@ class TestDataScienceModel:
             self.payload
         )
 
+    @pytest.mark.parametrize(
+        "test_args",
+        [
+            {"model_by_reference": True},
+            {"model_by_reference": False},
+        ],
+    )
     @patch.object(OCIDataScienceModel, "create_model_provenance")
     @patch.object(OCIDataScienceModel, "create")
     @patch.object(DataScienceModel, "sync")
@@ -357,6 +372,7 @@ class TestDataScienceModel:
         mock_sync,
         mock_oci_dsc_model_create,
         mock_create_model_provenance,
+        test_args,
     ):
         """Tests creating datascience model."""
         oci_dsc_model = OCIDataScienceModel(**OCI_MODEL_PAYLOAD)
@@ -369,25 +385,40 @@ class TestDataScienceModel:
             overwrite_existing_artifact=False,
             remove_existing_artifact=False,
             parallel_process_count=3,
+            **test_args,
         )
         mock_oci_dsc_model_create.assert_called()
         mock_create_model_provenance.assert_called_with(
             self.mock_dsc_model.provenance_metadata._to_oci_metadata()
         )
-        mock_upload_artifact.assert_called_with(
-            bucket_uri="test_bucket_uri",
-            overwrite_existing_artifact=False,
-            remove_existing_artifact=False,
-            region=None,
-            auth=None,
-            timeout=None,
-            parallel_process_count=3,
-            model_by_reference=False,
-        )
+        if test_args.get("model_by_reference"):
+            mock_upload_artifact.assert_called_with(
+                bucket_uri="test_bucket_uri",
+                overwrite_existing_artifact=False,
+                remove_existing_artifact=False,
+                region=None,
+                auth=None,
+                timeout=None,
+                parallel_process_count=3,
+                model_by_reference=True,
+            )
+            assert result.custom_metadata_list.get("modelDescription").value == "true"
+        else:
+            mock_upload_artifact.assert_called_with(
+                bucket_uri="test_bucket_uri",
+                overwrite_existing_artifact=False,
+                remove_existing_artifact=False,
+                region=None,
+                auth=None,
+                timeout=None,
+                parallel_process_count=3,
+                model_by_reference=False,
+            )
+            assert self.prepare_dict(result.to_dict()["spec"]) == self.prepare_dict(
+                {**self.payload, "displayName": "random_name"}
+            )
+
         mock_sync.assert_called()
-        assert self.prepare_dict(result.to_dict()["spec"]) == self.prepare_dict(
-            {**self.payload, "displayName": "random_name"}
-        )
 
     @patch.object(DataScienceModel, "_load_default_properties", return_value={})
     def test_create_fail(self, mock__load_default_properties):
@@ -721,51 +752,245 @@ class TestDataScienceModel:
                 assert self.mock_dsc_model.dsc_model.__class__.kwargs == {"timeout": 2}
                 mock_download.assert_called()
 
-    def test_bucket_not_versioned_error(self):
-        # todo: for model passed by reference, check if bucket is not versioned.
-        pass
+    @patch("ads.common.object_storage_details.ObjectStorageDetails.is_bucket_versioned")
+    def test_bucket_not_versioned_error(self, mock_is_bucket_versioned):
+        """For model passed by reference, check if bucket is not versioned."""
+        mock_is_bucket_versioned.return_value = False
+        self.mock_dsc_model.with_artifact(uri="oci://my-bucket@my-tenancy/prefix/")
+        with pytest.raises(BucketNotVersionedError):
+            self.mock_dsc_model.upload_artifact(model_by_reference=True)
 
     def test_setup_model_file_description_property(self):
-        # todo: read the json file, json_string and json_uri and load the
-        #  model_file_description property
-        pass
+        """read the json file, json_string and json_uri and load the model_file_description property"""
+        self.mock_artifact_file_path = os.path.join(
+            self.curr_dir, "test_files/model_description.json"
+        )
+
+        # load using uri
+        self.mock_dsc_model.with_model_file_description(
+            json_uri=self.mock_artifact_file_path
+        )
+        assert self.mock_dsc_model.model_file_description is not None
+
+        # load using json dict
+        with open(self.mock_artifact_file_path, "r") as _file:
+            data = json.load(_file)
+
+        self.mock_dsc_model.with_model_file_description(json_dict=data)
+        assert self.mock_dsc_model.model_file_description is not None
+
+        # load using json string
+        self.mock_dsc_model.with_model_file_description(json_string=json.dumps(data))
+        assert self.mock_dsc_model.model_file_description is not None
 
     def test_invalidate_model_file_description_json_schema(self):
-        # todo: read the json file, json_string and json_uri and load the
-        #  model_file_description property
-        pass
+        """Read the json file, load the model_file_description property with incorrect json schema. Validate
+        for ModelFileDescriptionError"""
 
-    def test_create_model_by_reference(self):
-        # todo: create model passed by reference, check custom metadata and
-        #  test whether upload artifact args have model_by_reference set as True
-        pass
+        self.mock_artifact_file_path = os.path.join(
+            self.curr_dir, "test_files/model_description.json"
+        )
+        # load using json dict
+        with open(self.mock_artifact_file_path, "r") as _file:
+            data = json.load(_file)
+        # json should have at least 1 model object. Set to empty to check for validation error
+        with pytest.raises(ModelFileDescriptionError):
+            data_copy = copy.deepcopy(data)
+            data_copy["models"] = []
+            # load using dict
+            self.mock_dsc_model.with_model_file_description(json_dict=data_copy)
 
-    def test_upload_artifact_for_model_created_by_reference(self):
+        # json should have at least 1 object within the model. Set to empty to check for validation error
+        with pytest.raises(ModelFileDescriptionError):
+            data_copy = copy.deepcopy(data)
+            data_copy["models"][0]["objects"] = []
+            # load using dict
+            self.mock_dsc_model.with_model_file_description(json_dict=data_copy)
+
+        # json should have at bucket name. Set to empty to check for validation error
+        with pytest.raises(ModelFileDescriptionError):
+            data_copy = copy.deepcopy(data)
+            del data_copy["models"][0]["bucketName"]
+            # load using dict
+            self.mock_dsc_model.with_model_file_description(json_dict=data_copy)
+
+    @pytest.mark.parametrize(
+        "test_args",
+        [
+            "",
+            "oci://my-bucket@my-tenancy/prefix/",
+            (
+                "oci://my-bucket@my-tenancy/prefix/",
+                "oci://user-bucket@user-tenancy/prefix/",
+            ),
+        ],
+    )
+    def test_upload_artifact_for_model_created_by_reference(self, test_args):
         # todo: for model passed by reference, check bucket, call small  artifact uploader
         #  and remove temp artifact
-        pass
 
-    def test_download_artifact_for_model_created_by_reference(self):
-        # todo: check if model is passed by reference using custom metadata, then download
-        #  json file and get artifact info and size
-        pass
+        self.mock_artifact_file_path = os.path.join(
+            self.curr_dir, "test_files/model_description.json"
+        )
+        self.mock_dsc_model.with_artifact(test_args)
+
+        with patch.object(
+            SmallArtifactUploader, "__init__", return_value=None
+        ) as mock_init:
+            with patch.object(SmallArtifactUploader, "upload") as mock_upload:
+                with patch(
+                    "ads.common.utils.folder_size",
+                    return_value=_MAX_ARTIFACT_SIZE_IN_BYTES - 100,
+                ):
+                    with patch(
+                        "ads.common.object_storage_details.ObjectStorageDetails.is_bucket_versioned",
+                        return_value=True,
+                    ) as mock_is_bucket_versioned:
+                        self.mock_dsc_model.with_model_file_description(
+                            json_uri=self.mock_artifact_file_path
+                        )
+                        self.mock_dsc_model.upload_artifact(model_by_reference=True)
+                        if test_args == "":
+                            mock_init.assert_not_called()
+                            mock_upload.assert_not_called()
+                        else:
+                            mock_is_bucket_versioned.assert_called()
+                            assert self.mock_dsc_model.artifact.endswith(".json"), True
+                            assert not os.path.exists(
+                                self.mock_dsc_model.artifact
+                            ), True
+
+                            mock_init.assert_called_with(
+                                dsc_model=self.mock_dsc_model.dsc_model,
+                                artifact_path=self.mock_dsc_model.artifact,
+                            )
+                            mock_upload.assert_called()
+
+    @pytest.mark.parametrize(
+        "test_args",
+        [
+            [""],
+            ["oci://my-bucket@my-tenancy/prefix/"],
+            [
+                "oci://my-bucket@my-tenancy/prefix/",
+                "oci://user-bucket@user-tenancy/prefix/",
+            ],
+            ["prefix/"],
+            ["file.zip"],
+        ],
+    )
+    @patch(
+        "ads.common.object_storage_details.ObjectStorageDetails.list_object_versions"
+    )
+    @patch("ads.common.object_storage_details.ObjectStorageDetails.list_objects")
+    def test_prepare_file_description_artifact(
+        self, mock_list_objects, mock_list_object_versions, test_args
+    ):
+        """read list from objects from artifact location and return content of json as dict"""
+
+        # The name attribute cannot be mocked during creation of the mock object,
+        # hence attach it separately to the mocked objects.
+        obj1 = MagicMock(etag="72f7e9ad-fa0b-49c5-99d9-3dc604565bb2", size=0)
+        obj1.name = "prefix/"
+        obj2 = MagicMock(etag="84fef893-a8b1-49dd-a1a9-a03e0b94641b", size=2230303000)
+        obj2.name = "prefix/model.pkl"
+        mock_list_objects.return_value = MagicMock(objects=[obj1, obj2])
+
+        obj3 = MagicMock(
+            etag="72f7e9ad-fa0b-49c5-99d9-3dc604565bb2",
+            version_id="e6588c0f-0bf1-4e32-8876-e4b1cd261d61",
+        )
+        obj3.name = "prefix/"
+        obj4 = MagicMock(
+            etag="84fef893-a8b1-49dd-a1a9-a03e0b94641b",
+            version_id="84fef893-a8b1-49dd-a1a9-a03e0b94641b",
+        )
+        obj4.name = "prefix/model.pkl"
+        obj5 = MagicMock(
+            etag=None,
+            size=0,
+            is_delete_marker=True,
+            version_id="1154bc82-fb0a-4f5d-9dc6-ad4ecdfa31c0",
+        )
+        obj5.name = "prefix/model.pkl"
+        mock_list_object_versions.return_value = [obj3, obj4, obj5]
+
+        if len(test_args) == 1 and (
+            test_args[0] == ""
+            or test_args[0].endswith(".zip")
+            or not test_args[0].startswith("oci:")
+        ):
+            with pytest.raises(InvalidArtifactType):
+                self.mock_dsc_model._prepare_file_description_artifact(test_args)
+        else:
+            result = self.mock_dsc_model._prepare_file_description_artifact(test_args)
+            # validate if result is a json dict and can be validated with the schema when loaded using
+            # with_model_file_description
+            assert len(result["models"][0]["objects"]), 2
+            assert isinstance(
+                self.mock_dsc_model.with_model_file_description(json_dict=result),
+                DataScienceModel,
+            )
+
+    @pytest.mark.parametrize(
+        "test_args",
+        [
+            ["oci://my-bucket@my-tenancy/prefix/"],
+            [
+                "oci://my-bucket@my-tenancy/prefix/",
+                "oci://user-bucket@user-tenancy/prefix/",
+            ],
+        ],
+    )
+    @patch.object(SmallArtifactDownloader, "download")
+    @patch("tempfile.TemporaryDirectory")
+    @patch.object(LargeArtifactDownloader, "__init__")
+    @patch.object(LargeArtifactDownloader, "download")
+    def test_download_artifact_for_model_created_by_reference(
+        self,
+        mock_large_download,
+        mock_init,
+        mock_temp_dir,
+        mock_small_downloader,
+        test_args,
+    ):
+        """check if model is passed by reference using custom metadata, then download json file and get artifact info and size"""
+
+        mock_small_downloader.return_value = None
+        # there's a model_description.json file at this location
+        mock_temp_dir.return_value.__enter__.return_value = os.path.join(
+            self.curr_dir, "test_files"
+        )
+        mock_init.return_value = None
+
+        self.mock_dsc_model.with_artifact(test_args)
+        metadata_item = ModelCustomMetadataItem(
+            key="modelDescription",
+            value="true",
+            description="model by reference flag",
+            category=MetadataCustomCategory.OTHER,
+        )
+        self.mock_dsc_model.custom_metadata_list._add(metadata_item)
+
+        self.mock_dsc_model.download_artifact(target_dir="test_target_dir")
+
+        mock_init.assert_called_with(
+            dsc_model=self.mock_dsc_model.dsc_model,
+            target_dir="test_target_dir",
+            auth=None,
+            force_overwrite=False,
+            region=None,
+            bucket_uri=None,
+            overwrite_existing_artifact=True,
+            remove_existing_artifact=True,
+            model_file_description=self.mock_dsc_model.model_file_description,
+        )
+
+        mock_large_download.assert_called()
 
     def test_load_model_created_by_reference_by_id(self):
         # todo: if model created by reference, then check file extension and if json file is
         #  available then read artifact to get bucket location and populate model_file_description
-        pass
-
-    def test_validate_prepare_file_description_artifact(self):
-        # todo: get model description content abd set artifact path
-        pass
-
-    def test_prepare_file_description_artifact(self):
-        # todo: read list from objects from artifact location and return content of json as dict
-        pass
-
-    def test_download_file_description_artifact(self):
-        # todo: Loads the json file from model artifact, updates the
-        #  model file description property, and returns the bucket uri and artifact size details.
         pass
 
     def test_multiple_artifact_for_model_by_reference(self):


### PR DESCRIPTION
### Description

This PR covers the following:
1. change `artifact` property to be set either as a string or a list using an iterable.
2. For Large Artifact Downloader with model by reference, set bucket_uri as None as artifact will be downloaded using model_file_description.
3. For model by reference, files are saved locally at `target_dir/bucket_name/file_name_with_prefix`.

### Tests

1. Creating model with multiple artifact location

```
artifact_path = "oci://service-bucket@namespace/model_path"
weights_path = "oci://user-bucket@namespace/weights_path"

model = (DataScienceModel()
        .with_compartment_id(compartment_id)
        .with_project_id(project_id)
        .with_display_name(MODEL_NAME)
        .with_artifact(artifact_path, weights_path)
        )

model.create(model_by_reference=True,)

model.download_artifact(target_dir="artifact_dir")
```

2. Creating model using yaml 

`test.yaml`
```
kind: datascienceModel
spec:
  compartmentId: ocid1.compartment.oc1..<OCID>
  projectId: ocid1.datascienceproject.oc1.iad.<OCID>
  artifact: [oci://service-bucket@namespace/model_path, oci://user-bucket@namespace/weights_path]
  displayName: Model Name
...
...
```


```
model = DataScienceModel.from_yaml(uri="test.yaml")
model.create(model_by_reference=True)
```


3. Loading model by id already created by reference with multiple models/artifact location

```
model = DataScienceModel.from_id("ocid1.datasciencemodel.oc1.iad.<OCID>")
model.download_artifact(target_dir="artifact_dir")
```


