### PR TITLE
Exclude the model version set OCID from the model details when updating the model.

### DIFF
--- a/ads/model/service/oci_datascience_model.py
+++ b/ads/model/service/oci_datascience_model.py
@@ -423,10 +423,13 @@ class OCIDataScienceModel(
         OCIDataScienceModel
             The `OCIDataScienceModel` instance (self).
         """
+        model_details = self.to_oci_model(UpdateModelDetails)
+
+        # Clean up the model version set, otherwise it throws an error that model is already
+        # associated with the model version set.
+        model_details.model_version_set_id = None
         return self.update_from_oci_model(
-            self.client.update_model(
-                self.id, self.to_oci_model(UpdateModelDetails)
-            ).data
+            self.client.update_model(self.id, model_details).data
         )
 
     @check_for_model_id(


### PR DESCRIPTION
## Description

I've observed that attempting to update a model already linked to a ```ModelVersionSet```, particularly when passing the same ```model_version_set_id``` as before, results in an error indicating the model is already associated with the Model Version Set. 