### PR TITLE
Changes the evaluation jobs runtime environment to a container-based setting.

### DIFF
--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -630,10 +630,10 @@ class AquaEvaluationApp(AquaApp):
         # TODO the image name needs to be extracted from the mapping index.json file.
         runtime = (
             ContainerRuntime()
-            .with_image("iad.ocir.io/ociodscdev/odsc-llm-evaluate:0.0.2.6")
+            .with_image("iad.ocir.io/ociodscdev/odsc-llm-evaluate:0.0.2.7")
             .with_environment_variable(
                 **{
-                    "OCI__LAUNCH_CMD": json.dumps(
+                    "AIP_SMC_EVALUATION_ARGUMENTS": json.dumps(
                         asdict(
                             self._build_launch_cmd(
                                 evaluation_id=evaluation_id,

--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -630,7 +630,7 @@ class AquaEvaluationApp(AquaApp):
         # TODO the image name needs to be extracted from the mapping index.json file.
         runtime = (
             ContainerRuntime()
-            .with_image("iad.ocir.io/ociodscdev/odsc-llm-evaluate:0.0.2.8")
+            .with_image("iad.ocir.io/ociodscdev/odsc-llm-evaluate:0.0.2.9")
             .with_environment_variable(
                 **{
                     "AIP_SMC_EVALUATION_ARGUMENTS": json.dumps(

--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -630,7 +630,7 @@ class AquaEvaluationApp(AquaApp):
         # TODO the image name needs to be extracted from the mapping index.json file.
         runtime = (
             ContainerRuntime()
-            .with_image("iad.ocir.io/ociodscdev/odsc-llm-evaluate:0.0.2.7")
+            .with_image("iad.ocir.io/ociodscdev/odsc-llm-evaluate:0.0.2.8")
             .with_environment_variable(
                 **{
                     "AIP_SMC_EVALUATION_ARGUMENTS": json.dumps(


### PR DESCRIPTION
## Description

Modifies the evaluation job's runtime environment to utilize containers. Currently, the image name is hardcoded to ```iad.ocir.io/ociodscdev/odsc-llm-evaluate:0.0.2.9```.  Additional functionality is required to dynamically retrieve the latest image version for the evaluation.