### PR TITLE
Fixing the loading metrics for a failed evaluation

### DIFF
--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -745,30 +745,26 @@ class AquaEvaluationApp(AquaApp):
         loggroup_name = None
 
         if log_id:
-            log = utils.query_resource(log_id, return_all=False)
-            log_name = log.display_name if log else ""
+            try:
+                log = utils.query_resource(log_id, return_all=False)
+                log_name = log.display_name if log else ""
+            except:
+                pass
 
         if loggroup_id:
-            loggroup = utils.query_resource(log_id, return_all=False)
-            loggroup_name = loggroup.display_name if loggroup else ""
+            try:
+                loggroup = utils.query_resource(loggroup_id, return_all=False)
+                loggroup_name = loggroup.display_name if loggroup else ""
+            except:
+                pass
 
         try:
             introspection = json.loads(
                 self._get_attribute_from_model_metadata(resource, "ArtifactTestResults")
             )
         except:
-            # TODO: remove this hardcode value later
-            introspection = {
-                "aqua_evaluate": {
-                    "input_dataset_path": {
-                        "key": "input_dataset_path",
-                        "category": "aqua_evaluate",
-                        "description": "Some description here",
-                        "error_msg": "The error details",
-                        "success": False,
-                    }
-                }
-            }
+            introspection = {}
+
         summary = AquaEvaluationDetail(
             **self._process(resource),
             **self._get_status(model=resource, jobrun=job_run_details),

--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -38,10 +38,10 @@ from ads.aqua.utils import (
     CONDA_REGION,
     CONDA_URI,
     HF_MODELS,
-    SOURCE_FILE,
-    UNKNOWN,
     JOB_INFRASTRUCTURE_TYPE_DEFAULT_NETWORKING,
     NB_SESSION_IDENTIFIER,
+    SOURCE_FILE,
+    UNKNOWN,
     fire_and_forget,
     is_valid_ocid,
     upload_local_to_os,
@@ -504,9 +504,7 @@ class AquaEvaluationApp(AquaApp):
                     ocpus=create_aqua_evaluation_details.ocpus,
                 )
             if AQUA_JOB_SUBNET_ID:
-                evaluation_job.infrastructure.with_subnet_id(
-                    AQUA_JOB_SUBNET_ID
-                )
+                evaluation_job.infrastructure.with_subnet_id(AQUA_JOB_SUBNET_ID)
             else:
                 if NB_SESSION_IDENTIFIER in os.environ:
                     # apply default subnet id for job by setting ME_STANDALONE
@@ -951,16 +949,22 @@ class AquaEvaluationApp(AquaApp):
             report_content = self._read_from_artifact(
                 temp_dir, files_in_artifact, utils.EVALUATION_REPORT_MD
             )
-            report = json.loads(
-                self._read_from_artifact(
-                    temp_dir, files_in_artifact, utils.EVALUATION_REPORT_JSON
+            try:
+                report = json.loads(
+                    self._read_from_artifact(
+                        temp_dir, files_in_artifact, utils.EVALUATION_REPORT_JSON
+                    )
                 )
-            )
+            except Exception as e:
+                logger.debug(
+                    "Failed to load `report.json` from evaluation artifact" f"{str(e)}"
+                )
+                report = {}
 
         # TODO: after finalizing the format of report.json, move the constant to class
         eval_metrics = AquaEvalMetrics(
             id=eval_id,
-            report=report_content,
+            report=base64.b64encode(report_content).decode(),
             metric_results=[
                 AquaEvalMetric(
                     key=metric_key,


### PR DESCRIPTION
# Description
A failed evaluation won't have `report.json` in its artifact. Fixing the `load_metrics` to return `report.md` only in this case. 

