### PR TITLE
Fixes for Model Deployment

### DIFF
--- a/ads/aqua/base.py
+++ b/ads/aqua/base.py
@@ -19,6 +19,7 @@ from ads.config import (
 from ads.aqua.data import Tags
 from ads.aqua.exception import AquaRuntimeError, AquaValueError
 from ads.aqua.utils import load_config
+from ads.aqua import logger
 
 
 class AquaApp:
@@ -95,8 +96,9 @@ class AquaApp:
         )
 
         if model_name not in config:
-            raise AquaValueError(
+            logger.error(
                 f"{config_file_name} does not have config details for model: {model_name}"
             )
+            return {}
 
         return config[model_name]

--- a/ads/aqua/config/container_index.json
+++ b/ads/aqua/config/container_index.json
@@ -2,13 +2,13 @@
   "odsc-llm-evaluate": [
     {
       "name": "dsmc://odsc-llm-evaluate",
-      "version": "1.0"
+      "version": "0.0.2.6"
     }
   ],
   "odsc-llm-fine-tuning": [
     {
       "name": "dsmc://odsc-llm-fine-tuning",
-      "version": "1.0"
+      "version": "0.2.5.18"
     }
   ],
   "odsc-vllm-serving": [

--- a/ads/config.py
+++ b/ads/config.py
@@ -69,6 +69,9 @@ AQUA_CONFIG_FOLDER = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "aqua/config/"
 )
 AQUA_JOB_SUBNET_ID = os.environ.get("AQUA_JOB_SUBNET_ID", None)
+AQUA_SERVICE_MODELS_BUCKET = os.environ.get(
+    "AQUA_SERVICE_MODELS_BUCKET", "service-managed-models"
+)
 
 
 def export(


### PR DESCRIPTION
This PR covers the following:
1. Return {} shapes/config for deployment and finetuning if not available in the backend.
2. For FT, look up base model name from freeform tags and get shape info for deployment.
3. If artifact_path is an OCI path, then check use it as is, else add CONDA_BUCKET_NS as namespace and service-managed-models as bucket name.
4. Set MODEL_DEPLOY_ENABLE_STREAMING as true.