### PR TITLE
Default error message

### DIFF
--- a/ads/aqua/exception.py
+++ b/ads/aqua/exception.py
@@ -68,13 +68,6 @@ class AquaMissingKeyError(AquaError):
         super().__init__(reason, status, service_payload)
 
 
-class AquaFileNotFoundError(AquaError, FileNotFoundError):
-    """Exception raised when missing metadata in resource."""
-
-    def __init__(self, reason, status=400, service_payload=None):
-        super().__init__(reason, status, service_payload)
-
-
 class AquaFileExistsError(AquaError, FileExistsError):
     """Exception raised when file already exists in resource."""
 

--- a/ads/aqua/extension/base_handler.py
+++ b/ads/aqua/extension/base_handler.py
@@ -54,11 +54,12 @@ class AquaAPIhandler(APIHandler):
         self.set_header("Content-Type", "application/json")
         reason = kwargs.get("reason")
         self.set_status(status_code, reason=reason)
-        message = self.get_default_error_messages(status_code)
+        service_payload = kwargs.get("service_payload", {})
+        message = self.get_default_error_messages(service_payload, status_code)
         reply = {
             "status": status_code,
             "message": message,
-            "service_payload": kwargs.get("service_payload", {}),
+            "service_payload": service_payload,
             "reason": reason,
         }
         exc_info = kwargs.get("exc_info")
@@ -76,7 +77,9 @@ class AquaAPIhandler(APIHandler):
         self.finish(json.dumps(reply))
 
     @staticmethod
-    def get_default_error_messages(status_code):
+    def get_default_error_messages(service_payload, status_code):
+        if service_payload and "operation_name" in service_payload:
+            pass
         messages = {
             400: "Something went wrong with your request.",
             403: "We're having trouble processing your request with the information provided.",

--- a/ads/aqua/extension/base_handler.py
+++ b/ads/aqua/extension/base_handler.py
@@ -54,7 +54,7 @@ class AquaAPIhandler(APIHandler):
         self.set_header("Content-Type", "application/json")
         reason = kwargs.get("reason")
         self.set_status(status_code, reason=reason)
-        message = responses.get(status_code, "Unknown HTTP Error")
+        message = self.get_default_error_messages(status_code)
         reply = {
             "status": status_code,
             "message": message,
@@ -74,6 +74,20 @@ class AquaAPIhandler(APIHandler):
 
         logger.warning(reply["message"])
         self.finish(json.dumps(reply))
+
+    @staticmethod
+    def get_default_error_messages(status_code):
+        messages = {
+            400: "Something went wrong with your request.",
+            403: "We're having trouble processing your request with the information provided.",
+            404: "Authorization Failed: The resource you're looking for isn't accessible.",
+            408: "Server is taking too long to response, please try again.",
+            500: "An error occurred while creating the resource.",
+        }
+        if status_code in messages:
+            return messages[status_code]
+        else:
+            return "Unknown HTTP Error."
 
 
 # todo: remove after error handler is implemented

--- a/ads/aqua/extension/base_handler.py
+++ b/ads/aqua/extension/base_handler.py
@@ -55,7 +55,7 @@ class AquaAPIhandler(APIHandler):
         reason = kwargs.get("reason")
         self.set_status(status_code, reason=reason)
         service_payload = kwargs.get("service_payload", {})
-        message = self.get_default_error_messages(service_payload, status_code)
+        message = self.get_default_error_messages(service_payload, str(status_code))
         reply = {
             "status": status_code,
             "message": message,
@@ -77,16 +77,29 @@ class AquaAPIhandler(APIHandler):
         self.finish(json.dumps(reply))
 
     @staticmethod
-    def get_default_error_messages(service_payload, status_code):
-        if service_payload and "operation_name" in service_payload:
-            pass
+    def get_default_error_messages(service_payload: dict, status_code: str):
+        """Method that maps the error messages based on the operation performed or the status codes encountered."""
+
         messages = {
-            400: "Something went wrong with your request.",
-            403: "We're having trouble processing your request with the information provided.",
-            404: "Authorization Failed: The resource you're looking for isn't accessible.",
-            408: "Server is taking too long to response, please try again.",
-            500: "An error occurred while creating the resource.",
+            "400": "Something went wrong with your request.",
+            "403": "We're having trouble processing your request with the information provided.",
+            "404": "Authorization Failed: The resource you're looking for isn't accessible.",
+            "408": "Server is taking too long to response, please try again.",
+            "500": "An error occurred while creating the resource.",
+            "create": "Authorization Failed: Could not create resource.",
+            "get": "Authorization Failed: The resource you're looking for isn't accessible.",
         }
+
+        if service_payload and "operation_name" in service_payload:
+            operation_name = service_payload["operation_name"]
+            if operation_name:
+                if operation_name.startswith("create"):
+                    return messages["create"]
+                elif operation_name.startswith("list") or operation_name.startswith(
+                    "get"
+                ):
+                    return messages["get"]
+
         if status_code in messages:
             return messages[status_code]
         else:


### PR DESCRIPTION
This PR adds default messages for error responses from the backend APIs. Also, removed a duplicate class `AquaFileNotFoundError` from the `exception.py` file.

The errors based on the user actions, and if they don't have the operation_name, then we default to status codes.
```  
"400": "Something went wrong with your request."
"403": "We're having trouble processing your request with the information provided."
"404": "Authorization Failed: The resource you're looking for isn't accessible."
"408": "Server is taking too long to response, please try again."
"500": "An error occurred while creating the resource."
"create": "Authorization Failed: Could not create resource."
"get": "Authorization Failed: The resource you're looking for isn't accessible."
```

Testing:

Create MD failed Error
```
{
    "status": 400,
    "message": "Authorization Failed: Could not create resource.",
    "service_payload": {
        "target_service": "data_science",
        "status": 400,
        "code": "LimitExceeded",
        "opc-request-id": "<opc-request-id>",
        "message": "The following service limits were exceeded: ds-gpu-a10-count. Request a service limit increase from the service limits page in the console. ",
        "operation_name": "create_model_deployment",
        "timestamp": "2024-03-12T22:31:23.673718+00:00",
```

Get MD failed Error
```
{
    "status": 404,
    "message": "Authorization Failed: The resource you're looking for isn't accessible.",
    "service_payload": {
        "target_service": "data_science",
        "status": 404,
        "code": "NotAuthorizedOrNotFound",
        "opc-request-id": "<opc-request-id>",
        "message": "Authorization failed or requested resource not found.",
        "operation_name": "get_model_deployment",
        "timestamp": "2024-03-12T22:51:11.859501+00:00",
```

List MD Error
```
{
    "status": 404,
    "message": "Authorization Failed: The resource you're looking for isn't accessible.",
    "service_payload": {
        "target_service": "data_science",
        "status": 404,
        "code": "NotAuthorizedOrNotFound",
        "opc-request-id": "<opc-request-id>",
        "message": "Authorization failed or requested resource not found.",
        "operation_name": "list_model_deployments",
```
