### PR TITLE
Update shapes for Fine Tuning

### DIFF
--- a/ads/aqua/base.py
+++ b/ads/aqua/base.py
@@ -11,7 +11,13 @@ from oci.data_science.models import UpdateModelDetails, UpdateModelProvenanceDet
 from ads import set_auth
 from ads.aqua import logger
 from ads.aqua.data import Tags
-from ads.aqua.utils import UNKNOWN, is_valid_ocid, load_config, logger
+from ads.aqua.utils import (
+    UNKNOWN,
+    is_valid_ocid,
+    load_config,
+    logger,
+    get_base_model_from_tags,
+)
 from ads.common import oci_client as oc
 from ads.common.auth import default_signer
 from ads.common.utils import extract_region
@@ -223,6 +229,14 @@ class AquaApp:
         """
         oci_model = self.ds_client.get_model(model_id).data
         model_name = oci_model.display_name
+
+        is_fine_tuned_model = (
+            True
+            if oci_model.freeform_tags.get(Tags.AQUA_FINE_TUNED_MODEL_TAG.value)
+            else False
+        )
+        if is_fine_tuned_model:
+            _, model_name = get_base_model_from_tags(oci_model.freeform_tags)
 
         oci_aqua = (
             (

--- a/ads/aqua/base.py
+++ b/ads/aqua/base.py
@@ -231,10 +231,9 @@ class AquaApp:
         model_name = oci_model.display_name
 
         is_fine_tuned_model = (
-            True
-            if oci_model.freeform_tags.get(Tags.AQUA_FINE_TUNED_MODEL_TAG.value)
-            else False
+            Tags.AQUA_FINE_TUNED_MODEL_TAG.value in oci_model.freeform_tags
         )
+
         if is_fine_tuned_model:
             _, model_name = get_base_model_from_tags(oci_model.freeform_tags)
 

--- a/ads/aqua/deployment.py
+++ b/ads/aqua/deployment.py
@@ -19,7 +19,7 @@ from ads.aqua.utils import (
     MODEL_BY_REFERENCE_OSS_PATH_KEY,
     load_config,
     get_container_image,
-    is_valid_ocid,
+    get_base_model_from_tags,
 )
 from ads.common.utils import get_console_link
 from ads.common.auth import default_signer
@@ -249,15 +249,14 @@ class AquaDeploymentApp(AquaApp):
             config_file_name=AQUA_MODEL_DEPLOYMENT_CONFIG,
         )
         # todo: revisit after create FT model is implemented
-        if Tags.AQUA_FINE_TUNED_MODEL_TAG.value in tags:
-            tag = tags[Tags.AQUA_FINE_TUNED_MODEL_TAG.value]
-            base_model_ocid, base_model_name = tag.split("#")
-            if is_valid_ocid(base_model_ocid) and base_model_name:
-                model_name = base_model_name
-            else:
-                raise AquaValueError(
-                    f"{Tags.AQUA_FINE_TUNED_MODEL_TAG.value} tag should have the format `Service Model OCID>#Model Name`."
-                )
+
+        is_fine_tuned_model = (
+            True
+            if aqua_model.freeform_tags.get(Tags.AQUA_FINE_TUNED_MODEL_TAG.value)
+            else False
+        )
+        if is_fine_tuned_model:
+            _, model_name = get_base_model_from_tags(aqua_model.freeform_tags)
         else:
             model_name = aqua_model.display_name
 

--- a/ads/aqua/deployment.py
+++ b/ads/aqua/deployment.py
@@ -251,10 +251,9 @@ class AquaDeploymentApp(AquaApp):
         # todo: revisit after create FT model is implemented
 
         is_fine_tuned_model = (
-            True
-            if aqua_model.freeform_tags.get(Tags.AQUA_FINE_TUNED_MODEL_TAG.value)
-            else False
+            Tags.AQUA_FINE_TUNED_MODEL_TAG.value in aqua_model.freeform_tags
         )
+
         if is_fine_tuned_model:
             _, model_name = get_base_model_from_tags(aqua_model.freeform_tags)
         else:

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -576,13 +576,15 @@ def fire_and_forget(func):
 
 
 def get_base_model_from_tags(tags):
-    base_model_ocid = None
-    base_model_name = None
+    base_model_ocid = ""
+    base_model_name = ""
     if Tags.AQUA_FINE_TUNED_MODEL_TAG.value in tags:
         tag = tags[Tags.AQUA_FINE_TUNED_MODEL_TAG.value]
-        base_model_ocid, base_model_name = tag.split("#")
+        if "#" in tag:
+            base_model_ocid, base_model_name = tag.split("#")
+
         if not (is_valid_ocid(base_model_ocid) and base_model_name):
-            logger.error(
+            raise AquaValueError(
                 f"{Tags.AQUA_FINE_TUNED_MODEL_TAG.value} tag should have the format `Service Model OCID#Model Name`."
             )
 

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -24,6 +24,7 @@ from oci.data_science.models import JobRun, Model
 from ads.aqua.constants import RqsAdditionalDetails
 from ads.aqua.data import AquaResourceIdentifier
 from ads.aqua.exception import AquaFileNotFoundError, AquaRuntimeError, AquaValueError
+from ads.aqua.data import Tags
 from ads.common.object_storage_details import ObjectStorageDetails
 from ads.common.oci_resource import SEARCH_TYPE, OCIResource
 from ads.common.utils import get_console_link, upload_to_os
@@ -572,3 +573,17 @@ def fire_and_forget(func):
         return asyncio.get_event_loop().run_in_executor(None, func, *args, *kwargs)
 
     return wrapped
+
+
+def get_base_model_from_tags(tags):
+    base_model_ocid = None
+    base_model_name = None
+    if Tags.AQUA_FINE_TUNED_MODEL_TAG.value in tags:
+        tag = tags[Tags.AQUA_FINE_TUNED_MODEL_TAG.value]
+        base_model_ocid, base_model_name = tag.split("#")
+        if not (is_valid_ocid(base_model_ocid) and base_model_name):
+            logger.error(
+                f"{Tags.AQUA_FINE_TUNED_MODEL_TAG.value} tag should have the format `Service Model OCID#Model Name`."
+            )
+
+    return base_model_ocid, base_model_name


### PR DESCRIPTION
This PR adds additional logic to look up configs for fine tuning creation and deployment. If config for fine tuned models need to be looked up, then we'll use the base name instead of the model name.
