### PR TITLE
Add deployment log links in get api

### DIFF
--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -589,3 +589,34 @@ def get_base_model_from_tags(tags):
             )
 
     return base_model_ocid, base_model_name
+
+
+def get_resource_name(ocid: str) -> str:
+    """Gets resource name based on the given ocid.
+
+    Parameters
+    ----------
+    ocid: str
+        Oracle Cloud Identifier (OCID).
+
+    Returns
+    -------
+    str:
+        The resource name indicated in the given ocid.
+
+    Raises
+    -------
+    ValueError:
+        When the given ocid is not a valid ocid.
+    """
+    if not is_valid_ocid(ocid):
+        raise ValueError(
+            f"The given ocid {ocid} is not a valid ocid."
+            "Check out this page https://docs.oracle.com/en-us/iaas/Content/General/Concepts/identifiers.htm to see more details."
+        )
+    try:
+        resource = query_resource(ocid, return_all=False)
+        name = resource.display_name if resource else ""
+    except:
+        name = ""
+    return name

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -616,7 +616,7 @@ def get_resource_name(ocid: str) -> str:
         )
     try:
         resource = query_resource(ocid, return_all=False)
-        name = resource.display_name if resource else ""
+        name = resource.display_name if resource else UNKNOWN
     except:
-        name = ""
+        name = UNKNOWN
     return name

--- a/ads/common/utils.py
+++ b/ads/common/utils.py
@@ -1740,3 +1740,33 @@ def get_console_link(
         f"https://cloud.oracle.com/data-science/{resource}/{ocid}?region={region}"
     )
     return console_link_url
+
+
+def get_log_links(
+    region: str,
+    log_group_id: str,
+    log_id: str = None,
+) -> str:
+    """
+    This method returns the web console link for the given log ids.
+    Parameters
+    ----------
+    log_group_id: str, required
+        OCID of the resource
+    log_id: str, optional
+        OCID of the resource
+    region: str
+        The Region Identifier that the client should connect to.
+
+    Returns
+    -------
+    console_link_url: str
+        a valid link to the console for the given resource.
+    """
+    console_link_url = ""
+    if log_group_id and log_id:
+        console_link_url = f"https://cloud.oracle.com/logging/log-groups/{log_group_id}/logs/{log_id}?region={region}"
+    elif log_group_id:
+        console_link_url = f"https://cloud.oracle.com/logging/log-groups/{log_group_id}?region={region}"
+
+    return console_link_url


### PR DESCRIPTION
This PR adds log and log group details in the get model deployment result.

```
{
    "id": "ocid1.datasciencemodeldeployment.oc1.iad.<OCID>",
    "display_name": "Test deploy",
    "aqua_service_model": true,
    "state": "DELETED",
    "description": null,
    "created_on": "2024-02-06 04:31:10.684000+00:00",
    "created_by": "ocid1.user.oc1..<OCID>",
    "endpoint": "https://modeldeployment.us-ashburn-1.oci.customer-oci.com/ocid1.datasciencemodeldeployment.oc1.iad.<OCID>",
    "console_link": "https://cloud.oracle.com/data-science/model-deployments/ocid1.datasciencemodeldeployment.oc1.iad.<OCID>?region=us-ashburn-1",
    "lifecycle_details": "Model Deployment with all associated resources has been deleted",
    "shape_info": {
        "instance_shape": "VM.Standard.E4.Flex",
        "instance_count": 1,
        "ocpus": 1.0,
        "memory_in_gbs": 16.0
    },
    "tags": {
        "aqua_service_model": "ocid1.datasciencemodel.oc1.iad.<OCID>#<Base_Model>",
        "OCI_AQUA": ""
    },
    "log_group": {
        "id": "ocid1.loggroup.oc1.iad.<OCID>",
        "name": "vipul-logs",
        "url": "https://cloud.oracle.com/logging/log-groups/ocid1.loggroup.oc1.iad.<OCID>?region=us-ashburn-1"
    },
    "log": {
        "id": "ocid1.log.oc1.iad.<OCID>",
        "name": "model-deployment-logs",
        "url": "https://cloud.oracle.com/logging/log-groups/ocid1.loggroup.oc1.iad.<OCID>/logs/ocid1.log.oc1.iad.<OCID>?region=us-ashburn-1"
    }
}
```

If no logs are associated, then the following is returned:
```
...
    "log_group": {
        "id": "",
        "name": "",
        "url": ""
    },
    "log": {
        "id": "",
        "name": "",
        "url": ""
    }

```