### PR TITLE
Update container index with new images

### DIFF
--- a/ads/aqua/config/container_index.json
+++ b/ads/aqua/config/container_index.json
@@ -3,6 +3,10 @@
     {
       "name": "dsmc://odsc-llm-evaluate",
       "version": "0.0.2.6"
+    },
+    {
+      "name": "iad.ocir.io/ociodscdev/odsc-llm-evaluate",
+      "version": "0.0.2.11"
     }
   ],
   "odsc-llm-fine-tuning": [
@@ -19,6 +23,10 @@
     {
       "name": "dsmc://odsc-vllm-serving",
       "version": "0.3.0.2"
+    },
+    {
+      "name": "iad.ocir.io/ociodscdev/odsc-vllm-serving",
+      "version": "0.3.0.3"
     }
   ]
 }

--- a/ads/aqua/config/container_index.json
+++ b/ads/aqua/config/container_index.json
@@ -2,7 +2,7 @@
   "odsc-llm-evaluate": [
     {
       "name": "dsmc://odsc-llm-evaluate",
-      "version": "0.0.2.6"
+      "version": "0.0.2.10"
     },
     {
       "name": "iad.ocir.io/ociodscdev/odsc-llm-evaluate",

--- a/ads/aqua/deployment.py
+++ b/ads/aqua/deployment.py
@@ -299,7 +299,6 @@ class AquaDeploymentApp(AquaApp):
             os_path = ObjectStorageDetails.from_path(model_path_prefix)
             model_path_prefix = os_path.filepath.rstrip("/")
 
-        # todo: revisit this after new image is built
         env_var.update({"BASE_MODEL": f"{model_path_prefix}"})
         env_var.update({"PARAMS": f"--served-model-name {AQUA_SERVED_MODEL_NAME}"})
         env_var.update({"MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions"})
@@ -319,14 +318,6 @@ class AquaDeploymentApp(AquaApp):
                 fine_tune_output_path = os_path.filepath.rstrip("/")
 
             env_var.update({"FT_MODEL": f"{fine_tune_output_path}"})
-
-        # todo: added for testing, remove when TENSOR_PARALLELISM will be set inside the container
-        try:
-            cards = instance_shape.split(".")[-1]
-            if int(cards) > 1:
-                env_var.update({"TENSOR_PARALLELISM": cards})
-        except:
-            pass
 
         logging.info(f"Env vars used for deploying {aqua_model.id} :{env_var}")
 

--- a/ads/aqua/deployment.py
+++ b/ads/aqua/deployment.py
@@ -22,6 +22,7 @@ from ads.aqua.utils import (
     get_base_model_from_tags,
     get_resource_name,
 )
+from ads.aqua.finetune import FineTuneCustomMetadata
 from ads.aqua.data import AquaResourceIdentifier
 from ads.common.utils import get_console_link, get_log_links
 from ads.common.auth import default_signer
@@ -299,10 +300,25 @@ class AquaDeploymentApp(AquaApp):
             model_path_prefix = os_path.filepath.rstrip("/")
 
         # todo: revisit this after new image is built
-        env_var.update({"MODEL": f"{AQUA_MODEL_DEPLOYMENT_FOLDER}{model_path_prefix}"})
+        env_var.update({"BASE_MODEL": f"{model_path_prefix}"})
         env_var.update({"PARAMS": f"--served-model-name {AQUA_SERVED_MODEL_NAME}"})
         env_var.update({"MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions"})
         env_var.update({"MODEL_DEPLOY_ENABLE_STREAMING": "true"})
+
+        if is_fine_tuned_model:
+            try:
+                fine_tune_output_path = aqua_model.custom_metadata_list.get(
+                    FineTuneCustomMetadata.FINE_TUNE_OUTPUT_PATH.value
+                ).value.rstrip("/")
+            except ValueError:
+                raise AquaValueError(
+                    f"{FineTuneCustomMetadata.FINE_TUNE_OUTPUT_PATH.value} key is not available in the custom metadata field."
+                )
+            if ObjectStorageDetails.is_oci_path(fine_tune_output_path):
+                os_path = ObjectStorageDetails.from_path(fine_tune_output_path)
+                fine_tune_output_path = os_path.filepath.rstrip("/")
+
+            env_var.update({"FT_MODEL": f"{fine_tune_output_path}"})
 
         # todo: added for testing, remove when TENSOR_PARALLELISM will be set inside the container
         try:

--- a/ads/aqua/deployment.py
+++ b/ads/aqua/deployment.py
@@ -314,15 +314,22 @@ class AquaDeploymentApp(AquaApp):
 
         logging.info(f"Env vars used for deploying {aqua_model.id} :{env_var}")
 
+        try:
+            container_type_key = aqua_model.custom_metadata_list.get(
+                AQUA_DEPLOYMENT_CONTAINER_METADATA_NAME
+            ).value
+        except ValueError:
+            raise AquaValueError(
+                f"{AQUA_DEPLOYMENT_CONTAINER_METADATA_NAME} key is not available in the custom metadata field for model {aqua_model.id}"
+            )
+
         # fetch image name from config
         container_image = get_container_image(
-            custom_metadata_list=aqua_model.custom_metadata_list,
             config_file_name=AQUA_CONTAINER_INDEX_CONFIG,
-            container_type=AQUA_DEPLOYMENT_CONTAINER_METADATA_NAME,
+            container_type=container_type_key,
         )
-
         logging.info(
-            f"Aqua Image used for deploying {aqua_model.id} :{container_image}"
+            f"Aqua Image used for deploying {aqua_model.id} : {container_image}"
         )
 
         # Start model deployment

--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -558,7 +558,9 @@ class AquaEvaluationApp(AquaApp):
                     JOB_INFRASTRUCTURE_TYPE_DEFAULT_NETWORKING
                 )
 
-        container_image = self._get_evaluation_container(evaluation_source)
+        container_image = self._get_evaluation_container(
+            create_aqua_evaluation_details.evaluation_source_id
+        )
 
         evaluation_job.with_runtime(
             self._build_evaluation_runtime(
@@ -706,9 +708,7 @@ class AquaEvaluationApp(AquaApp):
         return runtime
 
     @staticmethod
-    def _get_evaluation_container(
-        source: Union[ModelDeployment, DataScienceModel]
-    ) -> str:
+    def _get_evaluation_container(source_id: str) -> str:
         # todo: use the source, identify if it is a model or a deployment. If latter, then fetch the base model id
         #   from the deployment object, and call ds_client.get_model() to get model details. Use custom metadata to
         #   get the container_type_key. Pass this key as container_type to get_container_image method.
@@ -718,7 +718,7 @@ class AquaEvaluationApp(AquaApp):
             config_file_name=AQUA_CONTAINER_INDEX_CONFIG,
             container_type="odsc-llm-evaluate",
         )
-        logger.info(f"Aqua Image used for evaluating {source.id} :{container_image}")
+        logger.info(f"Aqua Image used for evaluating {source_id} :{container_image}")
         return container_image
 
     def _build_launch_cmd(

--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -33,24 +33,24 @@ from ads.aqua.exception import (
     AquaValueError,
 )
 from ads.aqua.utils import (
-    BERT_BASE_MULTILINGUAL_CASED,
-    BERT_SCORE_PATH,
-    CONDA_REGION,
-    CONDA_URI,
-    HF_MODELS,
     JOB_INFRASTRUCTURE_TYPE_DEFAULT_NETWORKING,
     NB_SESSION_IDENTIFIER,
-    SOURCE_FILE,
     UNKNOWN,
     is_valid_ocid,
     upload_local_to_os,
     fire_and_forget,
+    get_container_image,
 )
 from ads.common.auth import AuthType, default_signer
 from ads.common.object_storage_details import ObjectStorageDetails
 from ads.common.serializer import DataClassSerializable
 from ads.common.utils import get_console_link, get_files, upload_to_os
-from ads.config import AQUA_JOB_SUBNET_ID, COMPARTMENT_OCID, PROJECT_OCID
+from ads.config import (
+    AQUA_JOB_SUBNET_ID,
+    COMPARTMENT_OCID,
+    PROJECT_OCID,
+    AQUA_CONTAINER_INDEX_CONFIG,
+)
 from ads.jobs.ads_job import DataScienceJobRun, Job
 from ads.jobs.builders.infrastructure.dsc_job import DataScienceJob
 from ads.jobs.builders.runtimes.base import Runtime
@@ -557,12 +557,16 @@ class AquaEvaluationApp(AquaApp):
                 evaluation_job.infrastructure.with_job_infrastructure_type(
                     JOB_INFRASTRUCTURE_TYPE_DEFAULT_NETWORKING
                 )
+
+        container_image = self._get_evaluation_container(evaluation_source)
+
         evaluation_job.with_runtime(
             self._build_evaluation_runtime(
                 evaluation_id=evaluation_model.id,
                 evaluation_source_id=(
                     create_aqua_evaluation_details.evaluation_source_id
                 ),
+                container_image=container_image,
                 dataset_path=evaluation_dataset_path,
                 report_path=create_aqua_evaluation_details.report_path,
                 model_parameters=create_aqua_evaluation_details.model_parameters,
@@ -670,6 +674,7 @@ class AquaEvaluationApp(AquaApp):
         self,
         evaluation_id: str,
         evaluation_source_id: str,
+        container_image: str,
         dataset_path: str,
         report_path: str,
         model_parameters: dict,
@@ -679,7 +684,7 @@ class AquaEvaluationApp(AquaApp):
         # TODO the image name needs to be extracted from the mapping index.json file.
         runtime = (
             ContainerRuntime()
-            .with_image("dsmc://odsc-llm-evaluate:0.0.2.10")
+            .with_image(container_image)
             .with_environment_variable(
                 **{
                     "AIP_SMC_EVALUATION_ARGUMENTS": json.dumps(
@@ -699,6 +704,22 @@ class AquaEvaluationApp(AquaApp):
         )
 
         return runtime
+
+    @staticmethod
+    def _get_evaluation_container(
+        source: Union[ModelDeployment, DataScienceModel]
+    ) -> str:
+        # todo: use the source, identify if it is a model or a deployment. If latter, then fetch the base model id
+        #   from the deployment object, and call ds_client.get_model() to get model details. Use custom metadata to
+        #   get the container_type_key. Pass this key as container_type to get_container_image method.
+
+        # fetch image name from config
+        container_image = get_container_image(
+            config_file_name=AQUA_CONTAINER_INDEX_CONFIG,
+            container_type="odsc-llm-evaluate",
+        )
+        logger.info(f"Aqua Image used for evaluating {source.id} :{container_image}")
+        return container_image
 
     def _build_launch_cmd(
         self,

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -565,10 +565,10 @@ def get_max_version(versions):
         parts2 = list(map(int, version2.split(".")))
 
         # compare each part
-        for i in range(min(len(parts1), len(parts2))):
-            if parts1[i] < parts2[i]:
+        for idx in range(min(len(parts1), len(parts2))):
+            if parts1[idx] < parts2[idx]:
                 return version2
-            elif parts1[i] > parts2[i]:
+            elif parts1[idx] > parts2[idx]:
                 return version1
 
         # if all parts are equal up to this point, return the longer version string

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -555,22 +555,23 @@ def get_container_image(config_file_name: str, container_type: str) -> str:
 
 
 def get_max_version(versions):
+    """Takes in a list of versions and returns the higher version."""
     if not versions:
-        return None
+        return UNKNOWN
 
     def compare_versions(version1, version2):
-        # split version strings into parts
+        # split version strings into parts and convert to int values for comparison
         parts1 = list(map(int, version1.split(".")))
         parts2 = list(map(int, version2.split(".")))
 
-        # compare each part numerically
+        # compare each part
         for i in range(min(len(parts1), len(parts2))):
             if parts1[i] < parts2[i]:
                 return version2
             elif parts1[i] > parts2[i]:
                 return version1
 
-        # ff all parts are equal up to this point, return the longer version string
+        # if all parts are equal up to this point, return the longer version string
         return version1 if len(parts1) > len(parts2) else version2
 
     max_version = versions[0]

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -540,9 +540,9 @@ def get_container_image(config_file_name: str, container_type: str) -> str:
     mapping = config[container_type]
     versions = [obj["version"] for obj in mapping]
     # assumes numbered versions, update if `latest` is used
-    latest = max(versions)
+    latest = get_max_version(versions)
     for obj in mapping:
-        if obj["version"] == latest:
+        if obj["version"] == str(latest):
             container_image = f"{obj['name']}:{obj['version']}"
             break
 
@@ -552,6 +552,32 @@ def get_container_image(config_file_name: str, container_type: str) -> str:
         )
 
     return container_image
+
+
+def get_max_version(versions):
+    if not versions:
+        return None
+
+    def compare_versions(version1, version2):
+        # split version strings into parts
+        parts1 = list(map(int, version1.split(".")))
+        parts2 = list(map(int, version2.split(".")))
+
+        # compare each part numerically
+        for i in range(min(len(parts1), len(parts2))):
+            if parts1[i] < parts2[i]:
+                return version2
+            elif parts1[i] > parts2[i]:
+                return version1
+
+        # ff all parts are equal up to this point, return the longer version string
+        return version1 if len(parts1) > len(parts2) else version2
+
+    max_version = versions[0]
+    for version in versions[1:]:
+        max_version = compare_versions(max_version, version)
+
+    return max_version
 
 
 def fire_and_forget(func):

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -510,14 +510,10 @@ def _build_job_identifier(
         return AquaResourceIdentifier()
 
 
-def get_container_image(
-    custom_metadata_list, config_file_name: str, container_type: str
-) -> str:
+def get_container_image(config_file_name: str, container_type: str) -> str:
     """Gets the image name from the given model and container type.
     Parameters
     ----------
-    custom_metadata_list:
-        custom metadata of a given model
     config_file_name: str
         name of the config file
     container_type: str
@@ -528,13 +524,6 @@ def get_container_image(
     Dict:
         A dict of allowed configs.
     """
-
-    try:
-        container_type = custom_metadata_list.get(container_type).value
-    except ValueError:
-        raise AquaValueError(
-            f"{container_type} key is not available in the custom metadata field."
-        )
 
     # todo: currently loads config within ads, artifact_path will be an external bucket
     config = load_config(
@@ -550,7 +539,7 @@ def get_container_image(
     container_image = None
     mapping = config[container_type]
     versions = [obj["version"] for obj in mapping]
-    # todo: assumes numbered versions, update if `latest` is used
+    # assumes numbered versions, update if `latest` is used
     latest = max(versions)
     for obj in mapping:
         if obj["version"] == latest:


### PR DESCRIPTION
This PR covers the following:
1. Add new evaluation and deployment images
2. Update get_container_image to take in only key and config file
3. Use latest container image for evaluation from index file


Testing:
Note: ocid and namespace has been hidden.

Create MD Logs
```
INFO:root:Env vars used for deploying ocid1.datasciencemodel.oc1.iad.<OCID>:{'BASE_MODEL': 'aqua/models/falcon-7b', 'PARAMS': '--served-model-name odsc-llm', 'MODEL_DEPLOY_PREDICT_ENDPOINT': '/v1/completions', 'MODEL_DEPLOY_ENABLE_STREAMING': 'true'}
INFO:root:Aqua Image used for deploying ocid1.datasciencemodel.oc1.iad.<OCID> : iad.ocir.io/<namespace>/odsc-vllm-serving:0.3.0.3
```

Create Eval Logs
```
INFO:ads.aqua:Aqua Image used for evaluating ocid1.datasciencemodeldeployment.oc1.iad.<OCID>  :iad.ocir.io/<namespace>/odsc-llm-evaluate:0.0.2.11
```