### PR TITLE
[Do not merge] Revert to 0.3.0.2 version inference container

### DIFF
--- a/ads/aqua/config/container_index.json
+++ b/ads/aqua/config/container_index.json
@@ -23,10 +23,6 @@
     {
       "name": "dsmc://odsc-vllm-serving",
       "version": "0.3.0.2"
-    },
-    {
-      "name": "iad.ocir.io/ociodscdev/odsc-vllm-serving",
-      "version": "0.3.0.3"
     }
   ]
 }

--- a/ads/aqua/deployment.py
+++ b/ads/aqua/deployment.py
@@ -299,7 +299,7 @@ class AquaDeploymentApp(AquaApp):
             os_path = ObjectStorageDetails.from_path(model_path_prefix)
             model_path_prefix = os_path.filepath.rstrip("/")
 
-        env_var.update({"BASE_MODEL": f"{model_path_prefix}"})
+        env_var.update({"MODEL": f"{AQUA_MODEL_DEPLOYMENT_FOLDER}{model_path_prefix}"})
         env_var.update({"PARAMS": f"--served-model-name {AQUA_SERVED_MODEL_NAME}"})
         env_var.update({"MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions"})
         env_var.update({"MODEL_DEPLOY_ENABLE_STREAMING": "true"})
@@ -318,6 +318,14 @@ class AquaDeploymentApp(AquaApp):
                 fine_tune_output_path = os_path.filepath.rstrip("/")
 
             env_var.update({"FT_MODEL": f"{fine_tune_output_path}"})
+
+        # todo: remove when TENSOR_PARALLELISM will be set inside the container
+        try:
+            cards = instance_shape.split(".")[-1]
+            if int(cards) > 1:
+                env_var.update({"TENSOR_PARALLELISM": cards})
+        except:
+            pass
 
         logging.info(f"Env vars used for deploying {aqua_model.id} :{env_var}")
 


### PR DESCRIPTION
This PR covers the following:
- Change BASE_MODEL to MODEL and add TENSOR_PARALLELISM env var.

Testing:

MD create logs:
```
INFO:root:Env vars used for deploying ocid1.datasciencemodel.oc1.iad.<OCID>:{'MODEL': '/opt/ds/model/deployed_model/aqua/models/falcon-7b', 'PARAMS': '--served-model-name odsc-llm', 'MODEL_DEPLOY_PREDICT_ENDPOINT': '/v1/completions', 'MODEL_DEPLOY_ENABLE_STREAMING': 'true', 'TENSOR_PARALLELISM': '2'}
INFO:root:Aqua Image used for deploying ocid1.datasciencemodel.oc1.iad.<OCID> : dsmc://odsc-vllm-serving:0.3.0.2
```