### PR TITLE
Ignore artifact when model file description is available during model creation

### DIFF
--- a/ads/aqua/model.py
+++ b/ads/aqua/model.py
@@ -77,9 +77,10 @@ class AquaFineTuningMetric(DataClassSerializable):
 @dataclass(repr=False)
 class AquaModelLicense(DataClassSerializable):
     """Represents the response of Get Model License."""
-    
+
     id: str = field(default_factory=str)
     license: str = field(default_factory=str)
+
 
 @dataclass(repr=False)
 class AquaModelSummary(DataClassSerializable):
@@ -322,13 +323,10 @@ class AquaModelApp(AquaApp):
             .with_compartment_id(target_compartment)
             .with_project_id(target_project)
             .with_model_file_description(json_dict=service_model.model_file_description)
-            .with_artifact(service_model.artifact)
             .with_display_name(service_model.display_name)
             .with_description(service_model.description)
             .with_freeform_tags(**(service_model.freeform_tags or {}))
             .with_defined_tags(**(service_model.defined_tags or {}))
-            .with_model_version_set_id(service_model.model_version_set_id)
-            .with_version_label(service_model.version_label)
             .with_custom_metadata_list(service_model.custom_metadata_list)
             .with_defined_metadata_list(service_model.defined_metadata_list)
             .with_provenance_metadata(service_model.provenance_metadata)
@@ -724,10 +722,9 @@ class AquaModelApp(AquaApp):
         separator = " " if description else ""
         return f"{description}{separator}{tags_text}"
 
-
     def load_license(self, model_id: str) -> AquaModelLicense:
         """Loads the license full text for the given model.
-        
+
         Parameters
         ----------
         model_id: str
@@ -742,7 +739,9 @@ class AquaModelApp(AquaApp):
         artifact_path = get_artifact_path(oci_model.custom_metadata_list)
         if not artifact_path:
             raise AquaRuntimeError("Failed to get artifact path from custom metadata.")
-         
-        content = str(read_file(file_path=f"{artifact_path}/{LICENSE_TXT}", auth=default_signer()))
-            
+
+        content = str(
+            read_file(file_path=f"{artifact_path}/{LICENSE_TXT}", auth=default_signer())
+        )
+
         return AquaModelLicense(id=model_id, license=content)

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -815,7 +815,7 @@ class DataScienceModel(Builder):
             Whether model artifact is made available to Model Store by reference.
         """
         # Upload artifact to the model catalog
-        if model_by_reference and not self.model_file_description:
+        if model_by_reference and self.model_file_description:
             logger.info(
                 "Model artifact will be uploaded using model_file_description file, "
                 "artifact location will not be used."

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -815,7 +815,12 @@ class DataScienceModel(Builder):
             Whether model artifact is made available to Model Store by reference.
         """
         # Upload artifact to the model catalog
-        if not self.artifact:
+        if model_by_reference and not self.model_file_description:
+            logger.info(
+                "Model artifact will be uploaded using model_file_description file, "
+                "artifact location will not be used."
+            )
+        elif not self.artifact:
             logger.warn(
                 "Model artifact location not provided. "
                 "Provide the artifact location to upload artifacts to the model catalog."
@@ -1305,17 +1310,17 @@ class DataScienceModel(Builder):
         the files exist. Next, it creates a json dict with the path information and sets it as the artifact to be
         uploaded."""
 
-        bucket_uri = self.artifact
-        if isinstance(bucket_uri, str):
-            bucket_uri = [bucket_uri]
-
-        for uri in bucket_uri:
-            if not ObjectStorageDetails.from_path(uri).is_bucket_versioned():
-                message = f"Model artifact bucket {uri} is not versioned. Enable versioning on the bucket to proceed with model creation by reference."
-                logger.error(message)
-                raise BucketNotVersionedError(message)
-
         if not self.model_file_description:
+            bucket_uri = self.artifact
+            if isinstance(bucket_uri, str):
+                bucket_uri = [bucket_uri]
+
+            for uri in bucket_uri:
+                if not ObjectStorageDetails.from_path(uri).is_bucket_versioned():
+                    message = f"Model artifact bucket {uri} is not versioned. Enable versioning on the bucket to proceed with model creation by reference."
+                    logger.error(message)
+                    raise BucketNotVersionedError(message)
+
             json_data = self._prepare_file_description_artifact(bucket_uri)
             self.with_model_file_description(json_dict=json_data)
 

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -817,7 +817,7 @@ class DataScienceModel(Builder):
         # Upload artifact to the model catalog
         if model_by_reference and self.model_file_description:
             logger.info(
-                "Model artifact will be uploaded using model_file_description file, "
+                "Model artifact will be uploaded using model_file_description contents, "
                 "artifact location will not be used."
             )
         elif not self.artifact:

--- a/tests/unitary/default_setup/model/test_datascience_model.py
+++ b/tests/unitary/default_setup/model/test_datascience_model.py
@@ -870,6 +870,7 @@ class TestDataScienceModel:
     @pytest.mark.parametrize(
         "test_args",
         [
+            "",
             "oci://my-bucket@my-tenancy/prefix/",
             (
                 "oci://my-bucket@my-tenancy/prefix/",
@@ -902,19 +903,23 @@ class TestDataScienceModel:
                         "ads.common.object_storage_details.ObjectStorageDetails.is_bucket_versioned",
                         return_value=True,
                     ) as mock_is_bucket_versioned:
-                        # self.mock_dsc_model.with_model_file_description(
-                        #     json_uri=self.mock_artifact_file_path
-                        # )
                         self.mock_dsc_model.upload_artifact(model_by_reference=True)
-                        mock_is_bucket_versioned.assert_called()
-                        assert self.mock_dsc_model.artifact.endswith(".json"), True
-                        assert not os.path.exists(self.mock_dsc_model.artifact), True
+                        if test_args == "":
+                            mock_is_bucket_versioned.assert_not_called()
+                            mock_init.assert_not_called()
+                            mock_upload.assert_not_called()
+                        else:
+                            mock_is_bucket_versioned.assert_called()
+                            assert self.mock_dsc_model.artifact.endswith(".json"), True
+                            assert not os.path.exists(
+                                self.mock_dsc_model.artifact
+                            ), True
 
-                        mock_init.assert_called_with(
-                            dsc_model=self.mock_dsc_model.dsc_model,
-                            artifact_path=self.mock_dsc_model.artifact,
-                        )
-                        mock_upload.assert_called()
+                            mock_init.assert_called_with(
+                                dsc_model=self.mock_dsc_model.dsc_model,
+                                artifact_path=self.mock_dsc_model.artifact,
+                            )
+                            mock_upload.assert_called()
 
     @pytest.mark.parametrize(
         "test_args",


### PR DESCRIPTION
### Description

This PR covers the following:

- If model_file_description is available, the user don't need to pass artifact using `with_artifact` when creating a model by reference.

### Usage

1. Creating model with artifact location

```
artifact_path = "oci://service-bucket@namespace/model_path"

model = (DataScienceModel()
        .with_compartment_id(compartment_id)
        .with_project_id(project_id)
        .with_display_name(MODEL_NAME)
        .with_artifact(artifact_path)
        )
model.create(model_by_reference=True,)

```
2. Creating model with model_file_description


```
model = DataScienceModel.from_id("ocid1.datasciencemodel.oc1.iad.<OCID>")
model_file_description = model.model_file_description

model = (DataScienceModel()
        .with_compartment_id(compartment_id)
        .with_project_id(project_id)
        .with_display_name(MODEL_NAME)
        .with_model_file_description(model_file_description)
        )
model.create(model_by_reference=True,)

```

### Unit Tests

```

> python3 -m pytest -q tests/unitary/default_setup/model/test_datascience_model.py
============================================= test session starts =============================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/vmascarenhas/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: anyio-4.2.0
collected 34 items

tests/unitary/default_setup/model/test_datascience_model.py ..................................          [100%]

============================================= 34 passed in 4.05s ==============================================

```

