### PR TITLE
Get shapes availability API

### DIFF
--- a/ads/aqua/config/resource_limit_names.json
+++ b/ads/aqua/config/resource_limit_names.json
@@ -1,0 +1,7 @@
+{
+  "BM.GPU.A10.4": "ds-gpu-a10-count",
+  "BM.GPU.A100-v2.8": "ds-gpu-a100-v2-count",
+  "BM.GPU4.8": "ds-gpu4-count",
+  "VM.GPU.A10.1": "ds-gpu-a10-count",
+  "VM.GPU.A10.2": "ds-gpu-a10-count"
+}

--- a/ads/aqua/extension/ui_handler.py
+++ b/ads/aqua/extension/ui_handler.py
@@ -53,6 +53,8 @@ class AquaUIHandler(AquaAPIhandler):
             return self.list_vcn()
         elif paths.startswith("aqua/subnets"):
             return self.list_subnets()
+        elif paths.startswith("aqua/shapes/limit"):
+            return self.get_shape_availability()
         else:
             raise HTTPError(400, f"The request {self.request.path} is invalid.")
 
@@ -133,6 +135,19 @@ class AquaUIHandler(AquaAPIhandler):
             )
         )
 
+    @handle_exceptions
+    def get_shape_availability(self, **kwargs):
+        """For a given compartmentId, resource limit name, and scope, returns the number of available resources associated
+        with the given limit."""
+        compartment_id = self.get_argument("compartment_id", default=COMPARTMENT_OCID)
+        instance_shape = self.get_argument("instance_shape")
+
+        return self.finish(
+            AquaUIApp().get_shape_availability(
+                compartment_id=compartment_id, instance_shape=instance_shape, **kwargs
+            )
+        )
+
 
 __handlers__ = [
     ("logging/?([^/]*)", AquaUIHandler),
@@ -142,4 +157,5 @@ __handlers__ = [
     ("job/shapes/?([^/]*)", AquaUIHandler),
     ("vcn/?([^/]*)", AquaUIHandler),
     ("subnets/?([^/]*)", AquaUIHandler),
+    ("shapes/limit/?([^/]*)", AquaUIHandler),
 ]

--- a/ads/common/oci_client.py
+++ b/ads/common/oci_client.py
@@ -19,6 +19,7 @@ from oci.secrets import SecretsClient
 from oci.vault import VaultsClient
 from oci.logging import LoggingManagementClient
 from oci.core import VirtualNetworkClient
+from oci.limits import LimitsClient
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +71,7 @@ class OCIClientFactory:
             "data_catalog": DataCatalogClient,
             "logging_management": LoggingManagementClient,
             "virtual_network": VirtualNetworkClient,
+            "limits": LimitsClient,
         }
         try:
             from oci.feature_store import FeatureStoreClient
@@ -162,3 +164,7 @@ class OCIClientFactory:
     @property
     def virtual_network(self):
         return self.create_client("virtual_network")
+
+    @property
+    def limits(self):
+        return self.create_client("limits")

--- a/ads/config.py
+++ b/ads/config.py
@@ -60,6 +60,9 @@ AQUA_MODEL_FINETUNING_CONFIG = os.environ.get(
 AQUA_CONTAINER_INDEX_CONFIG = os.environ.get(
     "AQUA_CONTAINER_INDEX_CONFIG", "container_index.json"
 )
+AQUA_RESOURCE_LIMIT_NAMES_CONFIG = os.environ.get(
+    "AQUA_RESOURCE_LIMIT_NAMES_CONFIG", "resource_limit_names.json"
+)
 AQUA_DEPLOYMENT_CONTAINER_METADATA_NAME = "deployment-container"
 AQUA_FINETUNING_CONTAINER_METADATA_NAME = "finetune-container"
 AQUA_EVALUATION_CONTAINER_METADATA_NAME = "evaluation-container"
@@ -72,6 +75,7 @@ AQUA_JOB_SUBNET_ID = os.environ.get("AQUA_JOB_SUBNET_ID", None)
 AQUA_SERVICE_MODELS_BUCKET = os.environ.get(
     "AQUA_SERVICE_MODELS_BUCKET", "service-managed-models"
 )
+DATA_SCIENCE_SERVICE_NAME = "data-science"
 
 
 def export(


### PR DESCRIPTION
### Description

This PR adds an API to get shapes availability before the user tries to create a deployment (can be used for Fine tuning as well).

### Usage

1. Get shapes (unavailable)
```
http://localhost:8888/aqua/shapes/limit?instance_shape=VM.GPU.A10.2
```
Response
```
{
    "status": 403,
    "message": "We're having trouble processing your request with the information provided.",
    "service_payload": {
        "available_count": 0
    },
    "reason": "Inadequate resources are available to create the BM.GPU.A100-v2.8 resource. The number of available resources associated with the limit name ds-gpu-a100-v2-count are 0.",
    "request_id": "3cf5643c-222d-4e13-a5af-ce16a3148ab7"
}
```

2. Get shapes (available)
```
http://localhost:8888/aqua/shapes/limit?instance_shape=VM.GPU.A10.2
```
Response
```
{
    "available_count": 24
}
```