### PR TITLE
Add `ready_to_deploy` in model's attributes

### DIFF
--- a/ads/aqua/model.py
+++ b/ads/aqua/model.py
@@ -221,13 +221,13 @@ class AquaFineTuneModel(AquaModel, AquaEvalFTCommon, DataClassSerializable):
             )
             model_hyperparameters = {}
 
-        self.dataset = model_hyperparameters.get(
-            FineTuningDefinedMetadata.TRAINING_DATA.value
-        )
-        if not self.dataset:
-            logger.debug(
-                f"Key={FineTuningDefinedMetadata.TRAINING_DATA.value} not found in model hyperparameters."
-            )
+        # self.dataset = model_hyperparameters.get(
+        #     FineTuningDefinedMetadata.TRAINING_DATA.value
+        # )
+        # if not self.dataset:
+        #     logger.debug(
+        #         f"Key={FineTuningDefinedMetadata.TRAINING_DATA.value} not found in model hyperparameters."
+        #     )
 
         self.validation = AquaFineTuneValidation(
             value=model_hyperparameters.get(
@@ -444,7 +444,8 @@ class AquaModelApp(AquaApp):
                 evaluation_status=ds_model.lifecycle_state,
                 job_run_status=job_run_status,
             )
-
+            # TODO: read ft_output_path from artifact.json
+            dataset = ""
             model_details = AquaFineTuneModel(
                 **aqua_model_atttributes,
                 source=source_identifier,
@@ -453,6 +454,7 @@ class AquaModelApp(AquaApp):
                     if lifecycle_state == JobRun.LIFECYCLE_STATE_SUCCEEDED
                     else lifecycle_state
                 ),
+                dataset=dataset,
                 metrics=ft_metrics,
                 model=ds_model,
                 jobrun=jobrun,

--- a/ads/aqua/model.py
+++ b/ads/aqua/model.py
@@ -28,6 +28,7 @@ from ads.aqua.utils import (
     CONDA_BUCKET_NS,
     LICENSE_TXT,
     README,
+    READY_TO_DEPLOY_STATUS,
     UNKNOWN,
     create_word_icon,
     get_artifact_path,
@@ -239,13 +240,6 @@ class AquaFineTuneModel(AquaModel, AquaEvalFTCommon, DataClassSerializable):
             logger.debug(
                 f"Key={FineTuningDefinedMetadata.VAL_SET_SIZE.value} not found in model hyperparameters."
             )
-
-        self.ready_to_deploy = (
-            True
-            if model.freeform_tags
-            and model.freeform_tags.get(Tags.AQUA_TAG.value, "").upper() == "ACTIVE"
-            else False
-        )
 
 
 # TODO: merge metadata key used in create FT
@@ -585,7 +579,7 @@ class AquaModelApp(AquaApp):
         freeform_tags = model.freeform_tags or {}
         is_fine_tuned_model = Tags.AQUA_FINE_TUNED_MODEL_TAG.value in freeform_tags
         ready_to_deploy = (
-            freeform_tags.get(Tags.AQUA_TAG.value, "").upper() == "ACTIVE"
+            freeform_tags.get(Tags.AQUA_TAG.value, "").upper() == READY_TO_DEPLOY_STATUS
             if is_fine_tuned_model
             else True
         )

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -39,7 +39,7 @@ CONDA_BUCKET_NS = os.environ.get("CONDA_BUCKET_NS")
 UNKNOWN = ""
 UNKNOWN_DICT = {}
 README = "README.md"
-LICENSE_TXT= "config/LICENSE.txt"
+LICENSE_TXT = "config/LICENSE.txt"
 DEPLOYMENT_CONFIG = "deployment_config.json"
 CONTAINER_INDEX = "container_index.json"
 EVALUATION_REPORT_JSON = "report.json"
@@ -64,6 +64,7 @@ MAXIMUM_ALLOWED_DATASET_IN_BYTE = 52428800  # 1024 x 1024 x 50 = 50MB
 JOB_INFRASTRUCTURE_TYPE_DEFAULT_NETWORKING = "ME_STANDALONE"
 NB_SESSION_IDENTIFIER = "NB_SESSION_OCID"
 LIFECYCLE_DETAILS_MISSING_JOBRUN = "The asscociated JobRun resource has been deleted."
+READY_TO_DEPLOY_STATUS = "ACTIVE"
 
 
 class LifecycleStatus(Enum):
@@ -510,7 +511,9 @@ def _build_job_identifier(
         return AquaResourceIdentifier()
 
 
-def get_container_image(config_file_name: str=None, container_type: str=None) -> str:
+def get_container_image(
+    config_file_name: str = None, container_type: str = None
+) -> str:
     """Gets the image name from the given model and container type.
     Parameters
     ----------
@@ -524,8 +527,10 @@ def get_container_image(config_file_name: str=None, container_type: str=None) ->
     Dict:
         A dict of allowed configs.
     """
-    
-    config_file_name = f"oci://{AQUA_SERVICE_MODELS_BUCKET}@{CONDA_BUCKET_NS}/service_models/config"
+
+    config_file_name = (
+        f"oci://{AQUA_SERVICE_MODELS_BUCKET}@{CONDA_BUCKET_NS}/service_models/config"
+    )
 
     config = load_config(
         file_path=config_file_name,


### PR DESCRIPTION
# Description 
Add  `ready_to_deploy` in the response format of LIST Models and GET Model

service models will always have ready_to_deploy=True
For custom models, the value of `OCI_AQUA` tag will be `ACTIVE` if it is ready for deployment.

# Test APIs
```
GET http://localhost:8888/aqua/model/<model_ocid>

# list service model
GET http://localhost:8888/aqua/model/
# list custom model
GET http://localhost:8890/aqua/model/?compartment_id=<ocid>
```