### PR TITLE
FT/EVAL improvement regarding MVS

### DIFF
--- a/ads/aqua/base.py
+++ b/ads/aqua/base.py
@@ -11,12 +11,14 @@ from oci.data_science.models import UpdateModelDetails, UpdateModelProvenanceDet
 from ads import set_auth
 from ads.aqua import logger
 from ads.aqua.data import Tags
+from ads.aqua.exception import AquaRuntimeError, AquaValueError
 from ads.aqua.utils import (
     UNKNOWN,
+    _is_valid_mvs,
+    get_base_model_from_tags,
     is_valid_ocid,
     load_config,
     logger,
-    get_base_model_from_tags,
 )
 from ads.common import oci_client as oc
 from ads.common.auth import default_signer
@@ -34,8 +36,6 @@ from ads.model.model_metadata import (
     ModelTaxonomyMetadata,
 )
 from ads.model.model_version_set import ModelVersionSet
-
-from ads.aqua.exception import AquaRuntimeError, AquaValueError
 
 
 class AquaApp:
@@ -132,24 +132,54 @@ class AquaApp:
         project_id: str = None,
         **kwargs,
     ) -> tuple:
+        """Creates ModelVersionSet from given ID or Name.
+
+        Parameters
+        ----------
+        model_version_set_id (str, optional):
+            ModelVersionSet OCID.
+        model_version_set_name (str, optional):
+            ModelVersionSet Name.
+        description (str, optional):
+            TBD
+        compartment_id (str, optional):
+            Compartment OCID.
+        project_id (str, optional):
+            Project OCID.
+
+        Returns
+        -------
+        tuple: (model_version_set_id, model_version_set_name)
+        """
         if not model_version_set_id:
             try:
                 model_version_set = ModelVersionSet.from_name(
                     name=model_version_set_name,
                     compartment_id=compartment_id,
                 )
+                # TODO: tag should be selected based on which operation (eval/FT) invoke this method
+                if not _is_valid_mvs(model_version_set, Tags.AQUA_FINE_TUNING.value):
+                    raise AquaValueError(
+                        f"Invalid model version set name. Please provide a model version set with `{Tags.AQUA_FINE_TUNING.value}` in tags."
+                    )
+
             except:
                 logger.debug(
                     f"Model version set {model_version_set_name} doesn't exist. "
                     "Creating new model version set."
                 )
+                mvs_freeform_tags = {
+                    Tags.AQUA_FINE_TUNING.value: Tags.AQUA_FINE_TUNING.value,
+                }
                 model_version_set = (
                     ModelVersionSet()
                     .with_compartment_id(compartment_id)
                     .with_project_id(project_id)
                     .with_name(model_version_set_name)
                     .with_description(description)
+                    .with_freeform_tags(**mvs_freeform_tags)
                     # TODO: decide what parameters will be needed
+                    # when refactor eval to use this method, we need to pass tag here.
                     .create(**kwargs)
                 )
                 logger.debug(
@@ -158,6 +188,11 @@ class AquaApp:
             return (model_version_set.id, model_version_set_name)
         else:
             model_version_set = ModelVersionSet.from_id(model_version_set_id)
+            # TODO: tag should be selected based on which operation (eval/FT) invoke this method
+            if not _is_valid_mvs(model_version_set, Tags.AQUA_FINE_TUNING.value):
+                raise AquaValueError(
+                    f"Invalid model version set id. Please provide a model version set with `{Tags.AQUA_FINE_TUNING.value}` in tags."
+                )
             return (model_version_set_id, model_version_set.name)
 
     # TODO: refactor model evaluation implementation to use it.
@@ -215,6 +250,7 @@ class AquaApp:
 
     def get_config(self, model_id: str, config_file_name: str) -> Dict:
         """Gets the config for the given Aqua model.
+
         Parameters
         ----------
         model_id: str

--- a/ads/aqua/extension/ui_handler.py
+++ b/ads/aqua/extension/ui_handler.py
@@ -4,7 +4,10 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 from urllib.parse import urlparse
+
 from tornado.web import HTTPError
+
+from ads.aqua.data import Tags
 from ads.aqua.decorator import handle_exceptions
 from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua.ui import AquaUIApp
@@ -44,6 +47,8 @@ class AquaUIHandler(AquaAPIhandler):
         elif paths.startswith("aqua/compartments"):
             return self.list_compartments()
         elif paths.startswith("aqua/experiment"):
+            return self.list_experiments()
+        elif paths.startswith("aqua/finetuning/modelversionsets"):
             return self.list_model_version_sets()
         elif paths.startswith("aqua/buckets"):
             return self.list_buckets()
@@ -95,9 +100,27 @@ class AquaUIHandler(AquaAPIhandler):
     @handle_exceptions
     def list_model_version_sets(self, **kwargs):
         """Lists all model version sets for the specified compartment or tenancy."""
+
         compartment_id = self.get_argument("compartment_id", default=COMPARTMENT_OCID)
         return self.finish(
-            AquaUIApp().list_model_version_sets(compartment_id=compartment_id, **kwargs)
+            AquaUIApp().list_model_version_sets(
+                compartment_id=compartment_id,
+                target_tag=Tags.AQUA_FINE_TUNING.value,
+                **kwargs,
+            )
+        )
+
+    @handle_exceptions
+    def list_experiments(self, **kwargs):
+        """Lists all experiments for the specified compartment or tenancy."""
+
+        compartment_id = self.get_argument("compartment_id", default=COMPARTMENT_OCID)
+        return self.finish(
+            AquaUIApp().list_model_version_sets(
+                compartment_id=compartment_id,
+                target_tag=Tags.AQUA_EVALUATION.value,
+                **kwargs,
+            )
         )
 
     @handle_exceptions
@@ -152,7 +175,9 @@ class AquaUIHandler(AquaAPIhandler):
 __handlers__ = [
     ("logging/?([^/]*)", AquaUIHandler),
     ("compartments/?([^/]*)", AquaUIHandler),
+    # TODO: change url to evaluation/experiements/?([^/]*)
     ("experiment/?([^/]*)", AquaUIHandler),
+    ("finetuning/modelversionsets/?([^/]*)", AquaUIHandler),
     ("buckets/?([^/]*)", AquaUIHandler),
     ("job/shapes/?([^/]*)", AquaUIHandler),
     ("vcn/?([^/]*)", AquaUIHandler),

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -39,7 +39,7 @@ CONDA_BUCKET_NS = os.environ.get("CONDA_BUCKET_NS")
 UNKNOWN = ""
 UNKNOWN_DICT = {}
 README = "README.md"
-LICENSE_TXT= "config/LICENSE.txt"
+LICENSE_TXT = "config/LICENSE.txt"
 DEPLOYMENT_CONFIG = "deployment_config.json"
 CONTAINER_INDEX = "container_index.json"
 EVALUATION_REPORT_JSON = "report.json"
@@ -510,7 +510,9 @@ def _build_job_identifier(
         return AquaResourceIdentifier()
 
 
-def get_container_image(config_file_name: str=None, container_type: str=None) -> str:
+def get_container_image(
+    config_file_name: str = None, container_type: str = None
+) -> str:
     """Gets the image name from the given model and container type.
     Parameters
     ----------
@@ -524,8 +526,10 @@ def get_container_image(config_file_name: str=None, container_type: str=None) ->
     Dict:
         A dict of allowed configs.
     """
-    
-    config_file_name = f"oci://{AQUA_SERVICE_MODELS_BUCKET}@{CONDA_BUCKET_NS}/service_models/config"
+
+    config_file_name = (
+        f"oci://{AQUA_SERVICE_MODELS_BUCKET}@{CONDA_BUCKET_NS}/service_models/config"
+    )
 
     config = load_config(
         file_path=config_file_name,
@@ -637,3 +641,24 @@ def get_resource_name(ocid: str) -> str:
     except:
         name = UNKNOWN
     return name
+
+
+def _is_valid_mvs(cls, mvs: "ads.model.ModelVersionSet", target_tag: str) -> bool:
+    """Returns whether the given model version sets has the target tag.
+
+    Parameters
+    ----------
+    mvs: str
+        The instance of `ads.model.ModelVersionSet`.
+    target_tag: list
+        Target tag expected to be in MVS.
+
+    Returns
+    -------
+    bool:
+        Return True if the given model version sets is valid.
+    """
+    if mvs.freeform_tags is None:
+        return False
+
+    return target_tag in mvs.freeform_tags


### PR DESCRIPTION
# Description
The model version that we use in FT should not show the version set from evaluation. We need to add tags to the version set that is create for evaluation and FT to distinguish them and show them accordingly.

# APIs
* List experiments for evaluation:
```
GET  http://localhost:8888/aqua/experiment/
```

* List model version sets for FT
```
GET  http://localhost:8888/aqua/finetuning/modelversionsets
```