### PR TITLE
Bucket versioning check API

### DIFF
--- a/ads/aqua/extension/ui_handler.py
+++ b/ads/aqua/extension/ui_handler.py
@@ -55,6 +55,8 @@ class AquaUIHandler(AquaAPIhandler):
             return self.list_subnets()
         elif paths.startswith("aqua/shapes/limit"):
             return self.get_shape_availability()
+        elif paths.startswith("aqua/bucket/versioning"):
+            return self.is_bucket_versioned()
         else:
             raise HTTPError(400, f"The request {self.request.path} is invalid.")
 
@@ -148,6 +150,13 @@ class AquaUIHandler(AquaAPIhandler):
             )
         )
 
+    @handle_exceptions
+    def is_bucket_versioned(self):
+        """For a given compartmentId, resource limit name, and scope, returns the number of available resources associated
+        with the given limit."""
+        bucket_uri = self.get_argument("bucket_uri")
+        return self.finish(AquaUIApp().is_bucket_versioned(bucket_uri=bucket_uri))
+
 
 __handlers__ = [
     ("logging/?([^/]*)", AquaUIHandler),
@@ -158,4 +167,5 @@ __handlers__ = [
     ("vcn/?([^/]*)", AquaUIHandler),
     ("subnets/?([^/]*)", AquaUIHandler),
     ("shapes/limit/?([^/]*)", AquaUIHandler),
+    ("bucket/versioning/?([^/]*)", AquaUIHandler),
 ]

--- a/ads/aqua/ui.py
+++ b/ads/aqua/ui.py
@@ -21,6 +21,7 @@ from ads.config import (
     AQUA_CONFIG_FOLDER,
     AQUA_RESOURCE_LIMIT_NAMES_CONFIG,
 )
+from ads.common.object_storage_details import ObjectStorageDetails
 from ads.aqua.utils import sanitize_response, load_config
 from ads.telemetry import telemetry
 
@@ -380,3 +381,27 @@ class AquaUIApp(AquaApp):
             )
 
         return response
+
+    @telemetry(entry_point="plugin=ui&action=is_bucket_versioned", name="aqua")
+    def is_bucket_versioned(self, bucket_uri: str):
+        """Check if the given bucket is versioned. Required check for fine-tuned model creation process where the model
+        weights are stored.
+
+        Parameters
+        ----------
+        bucket_uri
+
+        Returns
+        -------
+            dict:
+                is_versioned flag that informs whether it is versioned or not.
+
+        """
+        if ObjectStorageDetails.from_path(bucket_uri).is_bucket_versioned():
+            is_versioned = True
+            message = f"Model artifact bucket {bucket_uri} is versioned."
+        else:
+            is_versioned = False
+            message = f"Model artifact bucket {bucket_uri} is not versioned. Check if the path exists and enable versioning on the bucket to proceed with model creation."
+
+        return dict(is_versioned=is_versioned, message=message)


### PR DESCRIPTION
### Description
This PR adds an API to check if the user bucket is versioned.

### Usage

1. Versioned bucket
```
http://localhost:8888/aqua/bucket/versioning?bucket_uri=oci://versioned-bucket-name@<namespace>/prefix/
```
Response
```
{
    "is_versioned": true,
    "message": "Model artifact bucket oci://versioned-bucket-name@<namespace>/prefix/ is versioned."
}
```

2. Unversioned bucket
```
http://localhost:8888/aqua/bucket/versioning?bucket_uri=oci://unversioned-bucket-name@<namespace>/prefix/
```
Response
```
{
    "is_versioned": false,
    "message": "Model artifact bucket oci://unversioned-bucket-name@<namespace>/prefix/ is not versioned. Check if the path exists and enable versioning on the bucket to proceed with model creation."
}
```

3. Bucket does not exist

```
http://localhost:8888/aqua/bucket/versioning?bucket_uri=oci://non-existing-bucket@<namespace>/prefix/
```
Response
```
{
    "status": 404,
    "message": "Authorization Failed: The resource you're looking for isn't accessible.",
    "service_payload": {
        "target_service": "object_storage",
        "status": 404,
        "code": "BucketNotFound",
        ...
        ...
    },
    "reason": "The bucket 'non-existing-bucket' does not exist in namespace 'namespace'",
    ...
}
```