### PR TITLE
Telemetry: Track shape name, replica and ocid along with the model.

### DIFF
--- a/ads/aqua/finetune.py
+++ b/ads/aqua/finetune.py
@@ -459,9 +459,8 @@ class AquaFineTuningApp(AquaApp):
             {"ocid": ft_job.id[-6:]} if ft_job and len(ft_job.id) > 6 else {}
         )
         self.telemetry.record_event_async(
-            category="aqua/finetune/create",
-            action=source.display_name,
-            detail=f"{create_fine_tuning_details.shape_name}x{create_fine_tuning_details.replica}",
+            category=f"aqua/service/{source.display_name}/finetune/create/shape/",
+            action=f"{create_fine_tuning_details.shape_name}x{create_fine_tuning_details.replica}",
             **telemetry_kwargs,
         )
         # tracks unique fine-tuned models that were created in the user compartment

--- a/ads/aqua/finetune.py
+++ b/ads/aqua/finetune.py
@@ -454,11 +454,15 @@ class AquaFineTuningApp(AquaApp):
             ),
         )
 
-        # tracks the shape used for fine-tuning the service models
+        # tracks the shape and replica used for fine-tuning the service models
+        telemetry_kwargs = (
+            {"ocid": ft_job.id[-6:]} if ft_job and len(ft_job.id) > 6 else {}
+        )
         self.telemetry.record_event_async(
             category="aqua/finetune/create",
-            action="shape",
-            detail=create_fine_tuning_details.shape_name,
+            action=source.display_name,
+            detail=f"{create_fine_tuning_details.shape_name}x{create_fine_tuning_details.replica}",
+            **telemetry_kwargs,
         )
         # tracks unique fine-tuned models that were created in the user compartment
         self.telemetry.record_event_async(


### PR DESCRIPTION
This would help understanding how the different shape and replica combinations are used for specific models.
Also the last a few characters of the OCID is saved so that we might use it to match with other telemetry records (in the future).