### PR TITLE
Shapes limit error handling

### DIFF
--- a/ads/aqua/exception.py
+++ b/ads/aqua/exception.py
@@ -73,3 +73,10 @@ class AquaFileExistsError(AquaError, FileExistsError):
 
     def __init__(self, reason, status=400, service_payload=None):
         super().__init__(reason, status, service_payload)
+
+
+class AquaResourceAccessError(AquaError):
+    """Exception raised when file already exists in resource."""
+
+    def __init__(self, reason, status=404, service_payload=None):
+        super().__init__(reason, status, service_payload)

--- a/ads/aqua/extension/base_handler.py
+++ b/ads/aqua/extension/base_handler.py
@@ -123,7 +123,7 @@ class AquaAPIhandler(APIHandler):
                 elif operation_name.startswith("list") or operation_name.startswith(
                     "get"
                 ):
-                    return messages["get"]
+                    return messages["get"] + f" Operation Name: {operation_name}."
 
         if status_code in messages:
             return messages[status_code]

--- a/ads/aqua/ui.py
+++ b/ads/aqua/ui.py
@@ -404,9 +404,10 @@ class AquaUIApp(AquaApp):
             res = limits_client.get_resource_availability(
                 DATA_SCIENCE_SERVICE_NAME, limit_name, compartment_id, **kwargs
             ).data
-        except:
+        except ServiceError as se:
             raise AquaResourceAccessError(
-                f"Could not check limits availability for the shape {instance_shape}."
+                f"Could not check limits availability for the shape {instance_shape}.",
+                service_payload=se.args[0] if se.args else None,
             )
 
         available = res.available

--- a/ads/aqua/ui.py
+++ b/ads/aqua/ui.py
@@ -13,7 +13,7 @@ from oci.identity.models import Compartment
 from ads.aqua import logger
 from ads.aqua.base import AquaApp
 from ads.aqua.data import Tags
-from ads.aqua.exception import AquaValueError
+from ads.aqua.exception import AquaValueError, AquaResourceAccessError
 from ads.aqua.utils import load_config, sanitize_response
 from ads.common import oci_client as oc
 from ads.common.auth import default_signer
@@ -380,9 +380,15 @@ class AquaUIApp(AquaApp):
             return {}
 
         limit_name = config[instance_shape]
-        res = limits_client.get_resource_availability(
-            DATA_SCIENCE_SERVICE_NAME, limit_name, compartment_id, **kwargs
-        ).data
+        try:
+            res = limits_client.get_resource_availability(
+                DATA_SCIENCE_SERVICE_NAME, limit_name, compartment_id, **kwargs
+            ).data
+        except:
+            raise AquaResourceAccessError(
+                f"Could not check limits availability for the shape {instance_shape}."
+            )
+
         available = res.available
 
         try:


### PR DESCRIPTION
If user does not have access to list shape availability, we'll now show the following error message:

```
{
    "status": 404,
    "message": "Authorization Failed: The resource you're looking for isn't accessible. Operation name: get_resource_availability",
    "service_payload": {},
    "reason": "Could not check limits availability for the shape VM.GPU.A10.1",
    "request_id": "56ce00a4-a530-428d-b483-853b487a0586"
}
```