### PR TITLE
Evaluation APIs Improvements

### DIFF
--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
@@ -66,6 +67,11 @@ from ads.model.model_metadata import (
 )
 from ads.model.model_version_set import ModelVersionSet
 from ads.telemetry import telemetry
+
+EVAL_TERMINATION_STATE = [
+    JobRun.LIFECYCLE_STATE_SUCCEEDED,
+    JobRun.LIFECYCLE_STATE_FAILED,
+]
 
 
 class EvaluationJobExitCode(Enum):
@@ -139,6 +145,7 @@ class EvaluationCustomMetadata(Enum):
     EVALUATION_JOB_RUN_ID = "evaluation_job_run_id"
     EVALUATION_OUTPUT_PATH = "evaluation_output_path"
     EVALUATION_SOURCE_NAME = "evaluation_source_name"
+    EVALUATION_ERROR = "aqua_evaluate_error"
 
 
 class EvaluationModelTags(Enum):
@@ -349,6 +356,7 @@ class AquaEvaluationApp(AquaApp):
 
     _report_cache = TTLCache(maxsize=10, ttl=timedelta(hours=5), timer=datetime.now)
     _metrics_cache = TTLCache(maxsize=10, ttl=timedelta(hours=5), timer=datetime.now)
+    _eval_cache = TTLCache(maxsize=100, ttl=timedelta(hours=5), timer=datetime.now)
     _cache_lock = Lock()
 
     @telemetry(entry_point="plugin=evaluation&action=create", name="aqua")
@@ -899,7 +907,6 @@ class AquaEvaluationApp(AquaApp):
         List[AquaEvaluationSummary]:
             The list of the `ads.aqua.evalution.AquaEvaluationSummary`.
         """
-        # add cache for terminal state
         logger.info(f"Fetching evaluations from compartment {compartment_id}.")
         models = utils.query_resources(
             compartment_id=compartment_id,
@@ -912,29 +919,79 @@ class AquaEvaluationApp(AquaApp):
 
         mapping = self._prefetch_resources(compartment_id)
 
-        # TODO: check if caching for service model list can be used
         evaluations = []
-        # TODO: use threadpool
+        async_tasks = []
         for model in models:
-            job_run = self._get_jobrun(model, mapping)
 
-            evaluations.append(
-                AquaEvaluationSummary(
-                    **self._process(model),
-                    **self._get_status(
-                        model=model,
-                        jobrun=job_run,
-                    ),
-                    job=self._build_job_identifier(
-                        job_run_details=job_run,
-                    ),
+            if model.identifier in self._eval_cache.keys():
+                logger.debug(f"Retrieving evaluation {model.identifier} from cache.")
+                evaluation_summary = self._eval_cache.get(model.identifier)
+
+            else:
+                jobrun_id = self._get_attribute_from_model_metadata(
+                    model, EvaluationCustomMetadata.EVALUATION_JOB_RUN_ID.value
                 )
-            )
+                job_run = mapping.get(jobrun_id)
+
+                if not job_run:
+                    async_tasks.append((model, jobrun_id))
+                else:
+                    evaluation_summary = self._process_evaluation_summary(
+                        model, job_run
+                    )
+
+            evaluations.append(evaluation_summary)
+
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            future_to_model = {
+                executor.submit(
+                    self._fetch_jobrun, model, use_rqs=True, jobrun_id=jobrun_id
+                ): model
+                for model, jobrun_id in async_tasks
+            }
+            for future in as_completed(future_to_model):
+                model = future_to_model[future]
+                try:
+                    jobrun = future.result()
+                    evaluations.append(
+                        self._process_evaluation_summary(model=model, jobrun=jobrun)
+                    )
+                except Exception as exc:
+                    logger.error(
+                        f"Processing evaluation: {model.identifier} generated an exception: {exc}"
+                    )
+                    evaluations.append(
+                        self._process_evaluation_summary(model=model, jobrun=None)
+                    )
 
         # tracks number of times deployment listing was called
         self.telemetry.record_event_async(category="aqua/evaluation", action="list")
 
         return evaluations
+
+    def _process_evaluation_summary(
+        self,
+        model: oci.resource_search.models.ResourceSummary,
+        jobrun: oci.resource_search.models.ResourceSummary = None,
+    ) -> AquaEvaluationSummary:
+        """Builds AquaEvaluationSummary from model and jobrun."""
+
+        evaluation_summary = AquaEvaluationSummary(
+            **self._process(model),
+            **self._get_status(
+                model=model,
+                jobrun=jobrun,
+            ),
+            job=self._build_job_identifier(
+                job_run_details=jobrun,
+            ),
+        )
+
+        # Add evaluation in terminal state into cache
+        if evaluation_summary.lifecycle_state in EVAL_TERMINATION_STATE:
+            self._eval_cache.__setitem__(key=model.identifier, value=evaluation_summary)
+
+        return evaluation_summary
 
     def _if_eval_artifact_exist(
         self, model: oci.resource_search.models.ResourceSummary
@@ -1399,6 +1456,7 @@ class AquaEvaluationApp(AquaApp):
             if not source_name:
                 resource_type = utils.get_resource_type(source_id)
 
+                # TODO: adjust resource principal mapping
                 if resource_type == "datasciencemodel":
                     source_name = self.ds_client.get_model(source_id).data.display_name
                 elif resource_type == "datasciencemodeldeployment":
@@ -1589,8 +1647,17 @@ class AquaEvaluationApp(AquaApp):
         ] = None,
     ) -> dict:
         """Builds evaluation status based on the model status and job run status."""
-        model_status = model.lifecycle_state
+
         job_run_status = (
+            JobRun.LIFECYCLE_STATE_FAILED
+            if self._get_attribute_from_model_metadata(
+                model, EvaluationCustomMetadata.EVALUATION_ERROR.value
+            )
+            else None
+        )
+
+        model_status = model.lifecycle_state
+        job_run_status = job_run_status or (
             jobrun.lifecycle_state
             if jobrun and not jobrun.lifecycle_state == JobRun.LIFECYCLE_STATE_DELETED
             else (
@@ -1634,7 +1701,7 @@ class AquaEvaluationApp(AquaApp):
             connect_by_ampersands=False,
             return_all=False,
         )
-        logger.info(f"Fetched {len(resources)} AQUA resources.")
+        logger.debug(f"Fetched {len(resources)} AQUA resources.")
         return {item.identifier: item for item in resources}
 
     def _extract_job_lifecycle_details(self, lifecycle_details: str) -> str:

--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -925,7 +925,7 @@ class AquaEvaluationApp(AquaApp):
 
             if model.identifier in self._eval_cache.keys():
                 logger.debug(f"Retrieving evaluation {model.identifier} from cache.")
-                evaluation_summary = self._eval_cache.get(model.identifier)
+                evaluations.append(self._eval_cache.get(model.identifier))
 
             else:
                 jobrun_id = self._get_attribute_from_model_metadata(
@@ -936,11 +936,7 @@ class AquaEvaluationApp(AquaApp):
                 if not job_run:
                     async_tasks.append((model, jobrun_id))
                 else:
-                    evaluation_summary = self._process_evaluation_summary(
-                        model, job_run
-                    )
-
-            evaluations.append(evaluation_summary)
+                    evaluations.append(self._process_evaluation_summary(model, job_run))
 
         with ThreadPoolExecutor(max_workers=10) as executor:
             future_to_model = {

--- a/ads/aqua/extension/finetune_handler.py
+++ b/ads/aqua/extension/finetune_handler.py
@@ -4,13 +4,14 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 
-from tornado.web import HTTPError
 from urllib.parse import urlparse
 
+from tornado.web import HTTPError
+
+from ads.aqua.decorator import handle_exceptions
 from ads.aqua.extension.base_handler import AquaAPIhandler, Errors
 from ads.aqua.extension.utils import validate_function_parameters
 from ads.aqua.finetune import AquaFineTuningApp, CreateFineTuningDetails
-from ads.aqua.decorator import handle_exceptions
 
 
 class AquaFineTuneHandler(AquaAPIhandler):
@@ -51,11 +52,7 @@ class AquaFineTuneHandler(AquaAPIhandler):
             data_class=CreateFineTuningDetails, input_data=input_data
         )
 
-        self.finish(
-            AquaFineTuningApp().create(
-                CreateFineTuningDetails(**input_data)
-            )
-        )
+        self.finish(AquaFineTuningApp().create(CreateFineTuningDetails(**input_data)))
 
     @handle_exceptions
     def get_finetuning_config(self, model_id):

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -31,6 +31,7 @@ from ads.common.utils import get_console_link, upload_to_os
 from ads.config import AQUA_CONFIG_FOLDER, AQUA_SERVICE_MODELS_BUCKET, TENANCY_OCID
 from ads.model import DataScienceModel, ModelVersionSet
 
+# TODO: allow the user to setup the logging level?
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger("ODSC_AQUA")
 
@@ -315,7 +316,7 @@ def query_resource(
     return_all = " return allAdditionalFields " if return_all else " "
     resource_type = get_resource_type(ocid)
     query = f"query {resource_type} resources{return_all}where (identifier = '{ocid}')"
-    logger.info(query)
+    logger.debug(query)
 
     resources = OCIResource.search(
         query,
@@ -376,8 +377,8 @@ def query_resources(
         connect_by_ampersands=connect_by_ampersands,
     )
     query = f"query {resource_type} resources{return_all}where (compartmentId = '{compartment_id}'{condition_lifecycle}{condition_tags})"
-    logger.info(query)
-    logger.info(f"tenant_id=`{TENANCY_OCID}`")
+    logger.debug(query)
+    logger.debug(f"tenant_id=`{TENANCY_OCID}`")
 
     return OCIResource.search(
         query, type=SEARCH_TYPE.STRUCTURED, tenant_id=TENANCY_OCID, **kwargs


### PR DESCRIPTION
# Description
This PR contains improvements on the following APIs:
* List eval
* Get status

# Major change
* Fix the logic for determine termination state
* Add cache for evaluation in terminal state
* Still use rqs to get each jobrun but use threadpool with 10 threads and send all possible requests in parallel

# Test 
```
GET http://localhost:8888/aqua/evaluation
```