### PR TITLE
Conda bucket env var update

### DIFF
--- a/ads/aqua/model.py
+++ b/ads/aqua/model.py
@@ -28,7 +28,6 @@ from ads.aqua.data import AquaResourceIdentifier, Tags
 
 from ads.aqua.exception import AquaRuntimeError
 from ads.aqua.utils import (
-    CONDA_BUCKET_NS,
     LICENSE_TXT,
     README,
     READY_TO_DEPLOY_STATUS,
@@ -49,6 +48,7 @@ from ads.config import (
     ODSC_MODEL_COMPARTMENT_OCID,
     PROJECT_OCID,
     TENANCY_OCID,
+    CONDA_BUCKET_NS,
 )
 from ads.model import DataScienceModel
 from ads.model.model_metadata import MetadataTaxonomyKeys, ModelCustomMetadata
@@ -147,13 +147,17 @@ class AquaEvalFTCommon(DataClassSerializable):
             loggroup_id = ""
 
         loggroup_url = get_log_links(region=region, log_group_id=loggroup_id)
-        log_url = get_log_links(
-            region=region,
-            log_group_id=loggroup_id,
-            log_id=log_id,
-            compartment_id=jobrun.compartment_id,
-            source_id=jobrun.id
-        ) if jobrun else ""
+        log_url = (
+            get_log_links(
+                region=region,
+                log_group_id=loggroup_id,
+                log_id=log_id,
+                compartment_id=jobrun.compartment_id,
+                source_id=jobrun.id,
+            )
+            if jobrun
+            else ""
+        )
 
         log_name = None
         loggroup_name = None

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -28,13 +28,16 @@ from ads.common.auth import default_signer
 from ads.common.object_storage_details import ObjectStorageDetails
 from ads.common.oci_resource import SEARCH_TYPE, OCIResource
 from ads.common.utils import get_console_link, upload_to_os
-from ads.config import AQUA_CONFIG_FOLDER, AQUA_SERVICE_MODELS_BUCKET, TENANCY_OCID
+from ads.config import (
+    AQUA_CONFIG_FOLDER,
+    AQUA_SERVICE_MODELS_BUCKET,
+    TENANCY_OCID,
+    CONDA_BUCKET_NS,
+)
 from ads.model import DataScienceModel, ModelVersionSet
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger("ODSC_AQUA")
-
-CONDA_BUCKET_NS = os.environ.get("CONDA_BUCKET_NS")
 
 UNKNOWN = ""
 UNKNOWN_DICT = {}


### PR DESCRIPTION
aqua utils.py has it's own CONDA_BUCKET_NS constant without any default value, will fail APIs when not set. We'll use the existing one from ads.config instead.