### PR TITLE
Set Aqua logging level

### DIFF
--- a/ads/aqua/__init__.py
+++ b/ads/aqua/__init__.py
@@ -6,23 +6,22 @@
 
 import logging
 import os
+import sys
 
 
 def get_logger_level():
     """Retrieves logging level from environment variable `LOG_LEVEL`."""
-
     level = os.environ.get("LOG_LEVEL", "INFO").upper()
     return level
 
 
 def configure_aqua_logger():
     """Configures the AQUA logger."""
-
     log_level = get_logger_level()
     logger = logging.getLogger(__name__)
     logger.setLevel(log_level)
 
-    handler = logging.StreamHandler()  # sys.stdout
+    handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
@@ -35,3 +34,11 @@ def configure_aqua_logger():
 
 
 logger = configure_aqua_logger()
+
+
+def set_log_level(log_level: str):
+    """Global for setting logging level."""
+
+    log_level = log_level.upper()
+    logger.setLevel(log_level)
+    logger.handlers[0].setLevel(log_level)

--- a/ads/aqua/__init__.py
+++ b/ads/aqua/__init__.py
@@ -6,8 +6,6 @@
 
 import logging
 import os
-import sys
-from argparse import ArgumentParser
 
 
 def get_logger_level():

--- a/ads/aqua/__init__.py
+++ b/ads/aqua/__init__.py
@@ -18,12 +18,9 @@ def get_logger_level():
 def configure_aqua_logger():
     """Configures the AQUA logger."""
 
-    # duplicate with utils?
     log_level = get_logger_level()
     logger = logging.getLogger(__name__)
     logger.setLevel(log_level)
-    # logger.log(log_level, "Log level set to %r", log_level)
-    logger.info("Log level set to %r", log_level)
 
     handler = logging.StreamHandler()  # sys.stdout
     formatter = logging.Formatter(
@@ -33,6 +30,7 @@ def configure_aqua_logger():
     handler.setLevel(log_level)
 
     logger.addHandler(handler)
+    logger.propagate = False
     return logger
 
 

--- a/ads/aqua/__init__.py
+++ b/ads/aqua/__init__.py
@@ -23,7 +23,7 @@ def configure_aqua_logger():
 
     handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        "%(asctime)s - %(name)s.%(module)s - %(levelname)s - %(message)s"
     )
     handler.setFormatter(formatter)
     handler.setLevel(log_level)

--- a/ads/aqua/__init__.py
+++ b/ads/aqua/__init__.py
@@ -5,8 +5,37 @@
 
 
 import logging
+import os
 import sys
+from argparse import ArgumentParser
 
-logger = logging.getLogger(__name__)
-handler = logging.StreamHandler(sys.stdout)
-logger.setLevel(logging.INFO)
+
+def get_logger_level():
+    """Retrieves logging level from environment variable `LOG_LEVEL`."""
+
+    level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    return level
+
+
+def configure_aqua_logger():
+    """Configures the AQUA logger."""
+
+    # duplicate with utils?
+    log_level = get_logger_level()
+    logger = logging.getLogger(__name__)
+    logger.setLevel(log_level)
+    # logger.log(log_level, "Log level set to %r", log_level)
+    logger.info("Log level set to %r", log_level)
+
+    handler = logging.StreamHandler()  # sys.stdout
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    handler.setFormatter(formatter)
+    handler.setLevel(log_level)
+
+    logger.addHandler(handler)
+    return logger
+
+
+logger = configure_aqua_logger()

--- a/ads/aqua/base.py
+++ b/ads/aqua/base.py
@@ -19,7 +19,6 @@ from ads.aqua.utils import (
     get_artifact_path,
     is_valid_ocid,
     load_config,
-    logger,
 )
 from ads.common import oci_client as oc
 from ads.common.auth import default_signer
@@ -164,7 +163,7 @@ class AquaApp:
         tag = Tags.AQUA_FINE_TUNING.value
 
         if not model_version_set_id:
-            tag = Tags.AQUA_FINE_TUNING.value # TODO: Fix this
+            tag = Tags.AQUA_FINE_TUNING.value  # TODO: Fix this
             try:
                 model_version_set = ModelVersionSet.from_name(
                     name=model_version_set_name,

--- a/ads/aqua/cli.py
+++ b/ads/aqua/cli.py
@@ -4,10 +4,13 @@
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
+import os
+
+from ads.aqua import set_log_level
 from ads.aqua.deployment import AquaDeploymentApp
+from ads.aqua.evaluation import AquaEvaluationApp
 from ads.aqua.finetune import AquaFineTuningApp
 from ads.aqua.model import AquaModelApp
-from ads.aqua.evaluation import AquaEvaluationApp
 
 
 class AquaCommand:
@@ -17,3 +20,6 @@ class AquaCommand:
     fine_tuning = AquaFineTuningApp
     deployment = AquaDeploymentApp
     evaluation = AquaEvaluationApp
+
+    def __init__(self, log_level=os.environ.get("LOG_LEVEL", "INFO").upper()):
+        set_log_level(log_level)

--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -923,7 +923,6 @@ class AquaEvaluationApp(AquaApp):
             tag_list=[EvaluationModelTags.AQUA_EVALUATION.value],
         )
         logger.info(f"Fetched {len(models)} evaluations.")
-
         # TODO: add filter based on project_id if needed.
 
         mapping = self._prefetch_resources(compartment_id)

--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -962,7 +962,7 @@ class AquaEvaluationApp(AquaApp):
                         self._process_evaluation_summary(model=model, jobrun=jobrun)
                     )
                 except Exception as exc:
-                    logger.error(
+                    logger.warning(
                         f"Processing evaluation: {model.identifier} generated an exception: {exc}"
                     )
                     evaluations.append(
@@ -1007,7 +1007,7 @@ class AquaEvaluationApp(AquaApp):
             return True if response.status == 200 else False
         except oci.exceptions.ServiceError as ex:
             if ex.status == 404:
-                logger.info("Evaluation artifact not found.")
+                logger.debug(f"Evaluation artifact not found for {model.identifier}.")
                 return False
 
     @telemetry(entry_point="plugin=evaluation&action=get_status", name="aqua")
@@ -1416,10 +1416,11 @@ class AquaEvaluationApp(AquaApp):
                 target_attribute,
             )
         except:
-            logger.debug(
-                f"Missing `{target_attribute}` in custom metadata of the evaluation."
-                f"Evaluation id: {model.identifier} "
-            )
+            if target_attribute != EvaluationCustomMetadata.EVALUATION_ERROR:
+                logger.debug(
+                    f"Missing `{target_attribute}` in custom metadata of the evaluation."
+                    f"Evaluation id: {model.identifier} "
+                )
             return ""
 
     def _extract_metadata(self, metadata_list: List[Dict], key: str) -> Any:
@@ -1468,6 +1469,7 @@ class AquaEvaluationApp(AquaApp):
         except Exception as e:
             logger.debug(
                 f"Failed to retrieve source information for evaluation {evaluation.identifier}."
+                f"DEBUG INFO : {str(e)}"
             )
             source_name = ""
 
@@ -1538,8 +1540,9 @@ class AquaEvaluationApp(AquaApp):
                 ),
             )
         except Exception as e:
-            logger.error(
-                f"Failed to construct AquaResourceIdentifier from given id=`{id}`, and name=`{name}`, {str(e)}"
+            logger.debug(
+                f"Failed to construct AquaResourceIdentifier from given id=`{id}`, and name=`{name}`."
+                f"DEBUG INFO: {str(e)}"
             )
             return AquaResourceIdentifier()
 
@@ -1608,7 +1611,7 @@ class AquaEvaluationApp(AquaApp):
             return AquaEvalParams(**params[EvaluationConfig.PARAMS])
         except Exception as e:
             logger.debug(
-                f"Failed to retrieve model parameters for the model: {str(resource)}."
+                f"Failed to retrieve model parameters for the model: {str(resource)}. "
                 f"DEBUG INFO: {str(e)}."
             )
             return AquaEvalParams()
@@ -1631,7 +1634,7 @@ class AquaEvaluationApp(AquaApp):
 
         except Exception as e:
             logger.debug(
-                f"Failed to get job details from job_run_details: {job_run_details}"
+                f"Failed to get job details from job_run_details: {job_run_details} "
                 f"DEBUG INFO:{str(e)}"
             )
             return AquaResourceIdentifier()

--- a/ads/aqua/finetune.py
+++ b/ads/aqua/finetune.py
@@ -28,7 +28,6 @@ from ads.aqua.utils import (
     UNKNOWN,
     UNKNOWN_DICT,
     get_container_image,
-    logger,
     upload_local_to_os,
 )
 from ads.common.auth import default_signer

--- a/ads/aqua/model.py
+++ b/ads/aqua/model.py
@@ -26,7 +26,6 @@ from ads.aqua.constants import (
 )
 from ads.aqua.data import AquaResourceIdentifier, Tags
 from ads.aqua.exception import AquaRuntimeError
-
 from ads.aqua.training.exceptions import exit_code_dict
 from ads.aqua.utils import (
     LICENSE_TXT,
@@ -228,7 +227,7 @@ class AquaFineTuneModel(AquaModel, AquaEvalFTCommon, DataClassSerializable):
             ).value
         except Exception as e:
             logger.debug(
-                f"Failed to extract model hyperparameters from {model.id}:" f"{str(e)}"
+                f"Failed to extract model hyperparameters from {model.id}: " f"{str(e)}"
             )
             model_hyperparameters = {}
 

--- a/ads/aqua/model.py
+++ b/ads/aqua/model.py
@@ -674,7 +674,6 @@ class AquaModelApp(AquaApp):
         List[AquaModelSummary]:
             The list of the `ads.aqua.model.AquaModelSummary`.
         """
-
         models = []
         if compartment_id:
             # tracks number of times custom model listing was called

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -21,6 +21,7 @@ import fsspec
 import oci
 from oci.data_science.models import JobRun, Model
 
+from ads.aqua import logger
 from ads.aqua.constants import RqsAdditionalDetails
 from ads.aqua.data import AquaResourceIdentifier, Tags
 from ads.aqua.exception import AquaFileNotFoundError, AquaRuntimeError, AquaValueError
@@ -36,9 +37,8 @@ from ads.config import (
 )
 from ads.model import DataScienceModel, ModelVersionSet
 
-# TODO: allow the user to setup the logging level?
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-logger = logging.getLogger("ODSC_AQUA")
+# for not breaking current change
+logger = logger
 
 UNKNOWN = ""
 UNKNOWN_DICT = {}

--- a/ads/cli.py
+++ b/ads/cli.py
@@ -4,19 +4,21 @@
 # Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-import traceback
 import sys
+import traceback
 
 import fire
-from ads.common import logger
+
 from ads.aqua.cli import AquaCommand
+from ads.common import logger
 
 try:
     import click
-    import ads.opctl.cli
+
     import ads.jobs.cli
-    import ads.pipeline.cli
+    import ads.opctl.cli
     import ads.opctl.operator.cli
+    import ads.pipeline.cli
 except Exception as ex:
     print(
         "Please run `pip install oracle-ads[opctl]` to install "


### PR DESCRIPTION
# Description
Set AQUA logging through environment variables and CLI argument

# CLI
`--log-level=DEBUG`

## CLI help message
<img width="1414" alt="Screenshot 2024-03-19 at 1 35 35 PM" src="https://github.com/oracle/accelerated-data-science/assets/49049296/2b865f83-ecb5-49bd-a073-c6c94110c68c">

## Example
```
ads aqua model list --compartment_id ocid1.compartment.oc1..<ocid> --log-level=DEBUG
2024-03-19 13:31:22,714 - ads.aqua - DEBUG - This is a test
2024-03-19 13:31:22,742 - ads.aqua - INFO - Fetching custom models from compartment_id=ocid1.compartment.oc1..<ocid>.
2024-03-19 13:31:22,742 - ads.aqua - INFO - query datasciencemodel resources where (compartmentId = 'ocid1.compartment.oc1..<ocid>' && lifecycleState = 'ACTIVE' && (freeformTags.key = 'OCI_AQUA' && freeformTags.key = 'aqua_fine_tuned_model'))
2024-03-19 13:31:22,742 - ads.aqua - INFO - tenant_id=None
2024-03-19 13:31:22,959 - ads.aqua - INFO - Fetch 0 model in compartment_id=ocid1.compartment.oc1..<ocid>.
```


# ENV
`LOG_LEVEL="DEBUG"`