### PR TITLE
Add ready_to_finetune info

### DIFF
--- a/ads/aqua/data.py
+++ b/ads/aqua/data.py
@@ -38,3 +38,4 @@ class Tags(Enum):
     AQUA_FINE_TUNED_MODEL_TAG = "aqua_fine_tuned_model"
     AQUA_EVALUATION = "aqua_evaluation"
     AQUA_FINE_TUNING = "aqua_finetuning"
+    READY_TO_FINE_TUNE = "ready_to_fine_tune"

--- a/ads/aqua/finetune.py
+++ b/ads/aqua/finetune.py
@@ -433,6 +433,7 @@ class AquaFineTuningApp(AquaApp):
 
         source_freeform_tags = source.freeform_tags or {}
         source_freeform_tags.pop(Tags.LICENSE.value, None)
+        source_freeform_tags.update({Tags.READY_TO_FINE_TUNE.value: False})
 
         self.update_model(
             model_id=ft_model.id,

--- a/ads/aqua/model.py
+++ b/ads/aqua/model.py
@@ -2,11 +2,11 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+import os
 import re
 from dataclasses import InitVar, dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
-import os
 from threading import Lock
 from typing import List, Union
 
@@ -25,18 +25,18 @@ from ads.aqua.constants import (
     FineTuningDefinedMetadata,
 )
 from ads.aqua.data import AquaResourceIdentifier, Tags
-
 from ads.aqua.exception import AquaRuntimeError
+from ads.aqua.training.exceptions import exit_code_dict
 from ads.aqua.utils import (
     LICENSE_TXT,
     README,
     READY_TO_DEPLOY_STATUS,
+    READY_TO_FINE_TUNE_STATUS,
     UNKNOWN,
     create_word_icon,
     get_artifact_path,
     read_file,
 )
-from ads.aqua.training.exceptions import exit_code_dict
 from ads.common.auth import default_signer
 from ads.common.object_storage_details import ObjectStorageDetails
 from ads.common.oci_resource import SEARCH_TYPE, OCIResource
@@ -45,10 +45,10 @@ from ads.common.utils import get_console_link, get_log_links
 from ads.config import (
     AQUA_SERVICE_MODELS_BUCKET,
     COMPARTMENT_OCID,
+    CONDA_BUCKET_NS,
     ODSC_MODEL_COMPARTMENT_OCID,
     PROJECT_OCID,
     TENANCY_OCID,
-    CONDA_BUCKET_NS,
 )
 from ads.model import DataScienceModel
 from ads.model.model_metadata import MetadataTaxonomyKeys, ModelCustomMetadata
@@ -106,6 +106,7 @@ class AquaModelSummary(DataClassSerializable):
     console_link: str = None
     search_text: str = None
     ready_to_deploy: bool = True
+    ready_to_finetune: bool = False
 
 
 @dataclass(repr=False)
@@ -626,8 +627,10 @@ class AquaModelApp(AquaApp):
         is_fine_tuned_model = Tags.AQUA_FINE_TUNED_MODEL_TAG.value in freeform_tags
         ready_to_deploy = (
             freeform_tags.get(Tags.AQUA_TAG.value, "").upper() == READY_TO_DEPLOY_STATUS
-            if is_fine_tuned_model
-            else True
+        )
+        ready_to_finetune = (
+            freeform_tags.get(Tags.READY_TO_FINE_TUNE.value, "").upper()
+            == READY_TO_FINE_TUNE_STATUS
         )
 
         return dict(
@@ -644,6 +647,7 @@ class AquaModelApp(AquaApp):
             console_link=console_link,
             search_text=search_text,
             ready_to_deploy=ready_to_deploy,
+            ready_to_finetune=ready_to_finetune,
         )
 
     @telemetry(entry_point="plugin=model&action=list", name="aqua")

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -31,8 +31,8 @@ from ads.common.utils import get_console_link, upload_to_os
 from ads.config import (
     AQUA_CONFIG_FOLDER,
     AQUA_SERVICE_MODELS_BUCKET,
-    TENANCY_OCID,
     CONDA_BUCKET_NS,
+    TENANCY_OCID,
 )
 from ads.model import DataScienceModel, ModelVersionSet
 
@@ -78,6 +78,7 @@ JOB_INFRASTRUCTURE_TYPE_DEFAULT_NETWORKING = "ME_STANDALONE"
 NB_SESSION_IDENTIFIER = "NB_SESSION_OCID"
 LIFECYCLE_DETAILS_MISSING_JOBRUN = "The asscociated JobRun resource has been deleted."
 READY_TO_DEPLOY_STATUS = "ACTIVE"
+READY_TO_FINE_TUNE_STATUS = "TRUE"
 
 
 class LifecycleStatus(Enum):


### PR DESCRIPTION
# Changes
* Send ready_to_finetune info for List/Get models.
* Extracts ready_to_deploy info from tag `OCI_AQUA` for service model. 

# Test 
* Checking custom models
![Screenshot 2024-03-20 at 3 56 36 PM](https://github.com/oracle/accelerated-data-science/assets/49049296/4a08d484-3cc8-40a2-90fa-cf30863685aa)

* Checking service models
![Screenshot 2024-03-20 at 3 58 39 PM](https://github.com/oracle/accelerated-data-science/assets/49049296/658d108d-ee97-40bc-b8c9-b21e2946e4ea)

