### PR TITLE
Saves the evaluation config into the Input schema.

### DIFF
--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -563,8 +563,7 @@ class AquaEvaluationApp(AquaApp):
             .with_custom_metadata_list(evaluation_model_custom_metadata)
             .with_defined_metadata_list(evaluation_model_taxonomy_metadata)
             .with_provenance_metadata(ModelProvenanceMetadata(training_id=UNKNOWN))
-            # TODO uncomment this once the evaluation container will get the updated version of the ADS
-            # .with_input_schema(create_aqua_evaluation_details.to_dict())
+            .with_input_schema(create_aqua_evaluation_details.to_dict())
             # TODO: decide what parameters will be needed
             .create(
                 remove_existing_artifact=False,  # TODO: added here for the purpose of demo and will revisit later


### PR DESCRIPTION
## Description
Saves the evaluation input config  into the input schema field in Model Catalog. 
This enhancement will allow to make the input config visible for user and in the future add this details into the evaluation detailed page. 