### PR TITLE
Fix Jobs API independent authentication issue for different objects/threads.

### DIFF
--- a/ads/jobs/ads_job.py
+++ b/ads/jobs/ads_job.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 
 import fsspec
 import oci
+import yaml
 from ads.common.auth import default_signer
 from ads.common.decorator.utils import class_or_instance_method
 from ads.jobs.builders.base import Builder
@@ -545,6 +546,26 @@ class Job(Builder):
             # "apiVersion": self.api_version,
             "spec": spec,
         }
+
+    @class_or_instance_method
+    def from_yaml(
+        cls,
+        yaml_string: str = None,
+        uri: str = None,
+        loader: callable = yaml.SafeLoader,
+        **kwargs,
+    ):
+        if inspect.isclass(cls):
+            job = cls(**cls.auth)
+        else:
+            job = cls.__class__(**cls.auth)
+
+        if yaml_string:
+            return job.from_dict(yaml.load(yaml_string, Loader=loader))
+        if uri:
+            yaml_dict = yaml.load(cls._read_from_file(uri=uri, **kwargs), Loader=loader)
+            return job.from_dict(yaml_dict)
+        raise ValueError("Must provide either YAML string or URI location")
 
     @class_or_instance_method
     def from_dict(cls, config: dict) -> "Job":

--- a/ads/jobs/ads_job.py
+++ b/ads/jobs/ads_job.py
@@ -263,6 +263,7 @@ class Job(Builder):
             Job runtime, by default None.
 
         """
+        self.auth = self.auth.copy()
         for key in ["config", "signer", "client_kwargs"]:
             if kwargs.get(key):
                 self.auth[key] = kwargs.pop(key)
@@ -573,9 +574,9 @@ class Job(Builder):
             "runtime": cls._RUNTIME_MAPPING,
         }
         if inspect.isclass(cls):
-            job = cls()
+            job = cls(**cls.auth)
         else:
-            job = cls.__class__()
+            job = cls.__class__(**cls.auth)
 
         for key, value in spec.items():
             if key in mappings:

--- a/ads/jobs/builders/infrastructure/dsc_job.py
+++ b/ads/jobs/builders/infrastructure/dsc_job.py
@@ -6,8 +6,8 @@
 from __future__ import annotations
 
 import datetime
+import inspect
 import logging
-import oci
 import os
 import time
 import traceback
@@ -17,11 +17,12 @@ from string import Template
 from typing import Any, Dict, List, Optional, Union
 
 import fsspec
+import oci
 import oci.data_science
 import oci.util as oci_util
-import yaml
 from oci.data_science.models import JobInfrastructureConfigurationDetails
 from oci.exceptions import ServiceError
+import yaml
 from ads.common import utils
 from ads.common.oci_datascience import DSCNotebookSession, OCIDataScienceMixin
 from ads.common.oci_logging import OCILog
@@ -782,7 +783,7 @@ class DataScienceJobRun(
         # Update runtime from job run
         from ads.jobs import Job
 
-        job = Job.from_dict(job_dict)
+        job = Job(**self.auth).from_dict(job_dict)
         envs = job.runtime.envs
         run_config_override = run_dict.get("jobConfigurationOverrideDetails", {})
         envs.update(run_config_override.get("environmentVariables", {}))
@@ -811,7 +812,7 @@ class DataScienceJobRun(
         """
         from ads.jobs import Job
 
-        return Job.from_datascience_job(self.job_id)
+        return Job(**self.auth).from_datascience_job(self.job_id)
 
     def download(self, to_dir):
         """Downloads files from job run output URI to local.
@@ -953,9 +954,9 @@ class DataScienceJob(Infrastructure):
             if key not in attribute_map and key.lower() in snake_to_camel_map:
                 value = spec.pop(key)
                 if isinstance(value, dict):
-                    spec[
-                        snake_to_camel_map[key.lower()]
-                    ] = DataScienceJob.standardize_spec(value)
+                    spec[snake_to_camel_map[key.lower()]] = (
+                        DataScienceJob.standardize_spec(value)
+                    )
                 else:
                     spec[snake_to_camel_map[key.lower()]] = value
         return spec
@@ -971,6 +972,7 @@ class DataScienceJob(Infrastructure):
             Specification as keyword arguments.
             If spec contains the same key as the one in kwargs, the value from kwargs will be used.
         """
+        self.auth = self.auth.copy()
         for key in ["config", "signer", "client_kwargs"]:
             if kwargs.get(key):
                 self.auth[key] = kwargs.pop(key)
@@ -1709,6 +1711,15 @@ class DataScienceJob(Infrastructure):
 
         """
         return cls.from_dsc_job(DSCJob(**cls.auth).from_ocid(job_id))
+
+    @class_or_instance_method
+    def from_dict(cls, obj_dict: dict):
+        """Initialize the object from a Python dictionary"""
+        if inspect.isclass(cls):
+            job_cls = cls
+        else:
+            job_cls = cls.__class__
+        return job_cls(spec=obj_dict.get("spec"), **cls.auth)
 
     @class_or_instance_method
     def list_jobs(cls, compartment_id: str = None, **kwargs) -> List[DataScienceJob]:

--- a/tests/unitary/default_setup/auth/test_jobs_auth.py
+++ b/tests/unitary/default_setup/auth/test_jobs_auth.py
@@ -1,0 +1,47 @@
+"""Contains tests for Jobs API authentication."""
+
+from unittest import TestCase
+from ads.jobs import Job
+
+JOB_YAML = """
+kind: job
+apiVersion: v1.0
+spec:
+  name: llama2
+  infrastructure:
+    kind: infrastructure
+    spec:
+      blockStorageSize: 256
+      compartmentId: "ocid1.compartment.oc1..aaa"
+      logGroupId: "ocid1.loggroup.oc1.iad.aaa"
+      logId: "ocid1.log.oc1.iad.aaa"
+      projectId: "ocid1.datascienceproject.oc1.iad.aaa"
+      subnetId: "ocid1.subnet.oc1.iad.aaa"
+      shapeName: VM.GPU.A10.2
+    type: dataScienceJob
+  runtime:
+    kind: runtime
+    type: pyTorchDistributed
+    spec:
+      replicas: 2
+      conda:
+        type: service
+        slug: pytorch20_p39_gpu_v2
+      command: >-
+        torchrun examples/finetuning.py
+"""
+
+
+class JobsAuthTest(TestCase):
+    """Contains tests for Jobs API authentication."""
+
+    def test_auth_from_yaml(self):
+        """Test using different endpoints for different jobs."""
+        auth1 = {"client_kwargs": {"endpoint": "endpoint1.com"}}
+        auth2 = {"client_kwargs": {"endpoint": "endpoint2.com"}}
+        job1 = Job(**auth1).from_yaml(JOB_YAML)
+        job2 = Job(**auth2).from_yaml(JOB_YAML)
+        self.assertEqual(job1.auth, auth1)
+        self.assertEqual(job1.infrastructure.auth, auth1)
+        self.assertEqual(job2.auth, auth2)
+        self.assertEqual(job2.infrastructure.auth, auth2)


### PR DESCRIPTION
The jobs API supports specifying authentication when making API calls, for example, `Job(auth=**ads_auth).from_dict().create()`. However, the current implementation is not thread safe.

The following code will not work as expected (all jobs will be using `auth2`) when `create()` is called:
```
job1 = Job(**auth1).from_yaml(JOB_YAML)
# Assigning a new auth obj to job2 is also change the auth in job1, as well as the auth for the Job class.
job2 = Job(**auth2).from_yaml(JOB_YAML)
job3 = Job.from_yaml(JOB_YAML)

# Now all jobs will be created using auth2
job1.create()
job2.create()
job3.create()
```
This PR fixed the above issue.