### PR TITLE
Add test cases for handlers: Evaluation/Common/Base

### DIFF
--- a/tests/unitary/with_extras/aqua/test_evaluation_handler.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation_handler.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*--
-
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -11,33 +11,8 @@ from parameterized import parameterized
 
 from ads.aqua.evaluation import AquaEvaluationApp, CreateAquaEvaluationDetails
 from ads.aqua.extension.base_handler import Errors
-from ads.aqua.extension.evaluation_handler import (
-    AquaEvaluationConfigHandler,
-    AquaEvaluationHandler,
-    AquaEvaluationMetricsHandler,
-    AquaEvaluationReportHandler,
-    AquaEvaluationStatusHandler,
-)
-
-
-class TestDataset:
-    EVAL_ID = "ocid.datasciencemdoel.<ocid>"
-    mock_valid_input = dict(
-        evaluation_source_id="ocid1.datasciencemodel.oc1.iad.<OCID>",
-        evaluation_name="test_evaluation_name",
-        dataset_path="oci://dataset_bucket@namespace/prefix/dataset.jsonl",
-        report_path="oci://report_bucket@namespace/prefix/",
-        model_parameters=dict(max_token=500),
-        shape_name="VM.Standard.E3.Flex",
-        block_storage_size=1,
-        experiment_name="test_experiment_name",
-        memory_in_gbs=1,
-        ocpus=1,
-    )
-    mock_invalid_input = dict(name="myvalue")
-
-    def mock_url(self, action):
-        return f"{self.EVAL_ID}/{action}"
+from ads.aqua.extension.evaluation_handler import AquaEvaluationHandler
+from tests.unitary.with_extras.aqua.utils import HandlerTestDataset as TestDataset
 
 
 class TestEvaluationHandler(unittest.TestCase):
@@ -52,10 +27,10 @@ class TestEvaluationHandler(unittest.TestCase):
     @patch.object(AquaEvaluationApp, "delete")
     def test_delete(self, mock_delete):
         """Tests DELETE method."""
-        self.test_instance.delete(TestDataset.EVAL_ID)
+        self.test_instance.delete(TestDataset.MOCK_OCID)
 
         self.test_instance.finish.assert_called_with(mock_delete.return_value)
-        mock_delete.assert_called_with(TestDataset.EVAL_ID)
+        mock_delete.assert_called_with(TestDataset.MOCK_OCID)
 
     @patch.object(AquaEvaluationApp, "cancel")
     def test_put(self, mock_cancel):
@@ -64,7 +39,7 @@ class TestEvaluationHandler(unittest.TestCase):
         self.test_instance.put(arg)
 
         self.test_instance.finish.assert_called_with(mock_cancel.return_value)
-        mock_cancel.assert_called_with(TestDataset.EVAL_ID)
+        mock_cancel.assert_called_with(TestDataset.MOCK_OCID)
 
     @patch.object(AquaEvaluationApp, "create")
     def test_post(self, mock_create):
@@ -118,7 +93,7 @@ class TestEvaluationHandler(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("", TestDataset.EVAL_ID, "get"),
+            ("", TestDataset.MOCK_OCID, "get"),
             ("", "", "list"),
             ("aqua/evaluation/metrics", "", "get_supported_metrics"),
         ]
@@ -131,95 +106,3 @@ class TestEvaluationHandler(unittest.TestCase):
 
             self.test_instance.finish.assert_called_with(mock_app_method.return_value)
             mock_app_method.assert_called_once()
-
-
-class TestEvaluationStatusHandler(unittest.TestCase):
-    """Contains unittest for AquaEvaluationStatusHandler."""
-
-    @patch.object(IPythonHandler, "__init__")
-    def setUp(self, ipython_init_mock) -> None:
-        ipython_init_mock.return_value = None
-        self.test_instance = AquaEvaluationStatusHandler(MagicMock(), MagicMock())
-        self.test_instance.finish = MagicMock()
-
-    @parameterized.expand(
-        [
-            (TestDataset.EVAL_ID, TestDataset.EVAL_ID),
-            (TestDataset().mock_url("status"), TestDataset.EVAL_ID),
-        ]
-    )
-    @patch.object(AquaEvaluationApp, "get_status")
-    def test_get(self, input, expected_call, mock_get_status):
-        """Tests GET method."""
-        self.test_instance.get(input)
-
-        self.test_instance.finish.assert_called_with(mock_get_status.return_value)
-        mock_get_status.assert_called_with(expected_call)
-
-
-class TestEvaluationReportHandler(unittest.TestCase):
-    """Contains unittest for AquaEvaluationReportHandler."""
-
-    @patch.object(IPythonHandler, "__init__")
-    def setUp(self, ipython_init_mock) -> None:
-        ipython_init_mock.return_value = None
-        self.test_instance = AquaEvaluationReportHandler(MagicMock(), MagicMock())
-        self.test_instance.finish = MagicMock()
-
-    @parameterized.expand(
-        [
-            (TestDataset.EVAL_ID, TestDataset.EVAL_ID),
-            (TestDataset().mock_url("report"), TestDataset.EVAL_ID),
-        ]
-    )
-    @patch.object(AquaEvaluationApp, "download_report")
-    def test_get(self, input, expected_call, mock_download_report):
-        """Tests GET method."""
-        self.test_instance.get(input)
-
-        self.test_instance.finish.assert_called_with(mock_download_report.return_value)
-        mock_download_report.assert_called_with(expected_call)
-
-
-class TestEvaluationMetricsHandler(unittest.TestCase):
-    """Contains unittest for AquaEvaluationMetricsHandler."""
-
-    @patch.object(IPythonHandler, "__init__")
-    def setUp(self, ipython_init_mock) -> None:
-        ipython_init_mock.return_value = None
-        self.test_instance = AquaEvaluationMetricsHandler(MagicMock(), MagicMock())
-        self.test_instance.finish = MagicMock()
-
-    @parameterized.expand(
-        [
-            (TestDataset.EVAL_ID, TestDataset.EVAL_ID),
-            (TestDataset().mock_url("metrics"), TestDataset.EVAL_ID),
-        ]
-    )
-    @patch.object(AquaEvaluationApp, "load_metrics")
-    def test_get(self, input, expected_call, mock_load_metrics):
-        """Tests GET method."""
-        self.test_instance.get(input)
-
-        self.test_instance.finish.assert_called_with(mock_load_metrics.return_value)
-        mock_load_metrics.assert_called_with(expected_call)
-
-
-class TestEvaluationConfigHandler(unittest.TestCase):
-    """Contains unittest for AquaEvaluationConfigHandler."""
-
-    @patch.object(IPythonHandler, "__init__")
-    def setUp(self, ipython_init_mock) -> None:
-        ipython_init_mock.return_value = None
-        self.test_instance = AquaEvaluationConfigHandler(MagicMock(), MagicMock())
-        self.test_instance.finish = MagicMock()
-
-    @patch.object(AquaEvaluationApp, "load_evaluation_config")
-    def test_get(self, mock_load_evaluation_config):
-        """Tests GET method."""
-        self.test_instance.get(TestDataset.EVAL_ID)
-
-        self.test_instance.finish.assert_called_with(
-            mock_load_evaluation_config.return_value
-        )
-        mock_load_evaluation_config.assert_called_with(TestDataset.EVAL_ID)

--- a/tests/unitary/with_extras/aqua/test_evaluation_handler.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation_handler.py
@@ -10,6 +10,7 @@ from notebook.base.handlers import IPythonHandler
 from parameterized import parameterized
 
 from ads.aqua.evaluation import AquaEvaluationApp, CreateAquaEvaluationDetails
+from ads.aqua.extension.base_handler import Errors
 from ads.aqua.extension.evaluation_handler import (
     AquaEvaluationConfigHandler,
     AquaEvaluationHandler,
@@ -33,6 +34,7 @@ class TestDataset:
         memory_in_gbs=1,
         ocpus=1,
     )
+    mock_invalid_input = dict(name="myvalue")
 
     def mock_url(self, action):
         return f"{self.EVAL_ID}/{action}"
@@ -79,6 +81,40 @@ class TestEvaluationHandler(unittest.TestCase):
                 CreateAquaEvaluationDetails(**TestDataset.mock_valid_input)
             )
         )
+
+    @parameterized.expand(
+        [
+            (
+                dict(return_value=TestDataset.mock_invalid_input),
+                400,
+                "Missing required parameter:",
+            ),
+            (dict(side_effect=Exception()), 400, Errors.INVALID_INPUT_DATA_FORMAT),
+            (dict(return_value=None), 400, Errors.NO_INPUT_DATA),
+        ]
+    )
+    @unittest.skip(
+        "Need a fix in `handle_exceptions` decorator before enabling this test."
+    )
+    def test_post_fail(
+        self, mock_get_json_body_response, expected_status_code, expected_error_msg
+    ):
+        """Tests POST when encounter error."""
+        self.test_instance.get_json_body = MagicMock(
+            side_effect=mock_get_json_body_response.get("side_effect", None),
+            return_value=mock_get_json_body_response.get("return_value", None),
+        )
+        self.test_instance.write_error = MagicMock()
+
+        self.test_instance.post()
+
+        assert (
+            self.test_instance.write_error.call_args[1].get("status_code")
+            == expected_status_code
+        ), "Raised wrong status code."
+        assert expected_error_msg in self.test_instance.write_error.call_args[1].get(
+            "reason"
+        ), "Error message is incorrect."
 
     @parameterized.expand(
         [

--- a/tests/unitary/with_extras/aqua/test_evaluation_handler.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation_handler.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*--
+
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+import unittest
+from unittest.mock import MagicMock, patch
+
+from notebook.base.handlers import IPythonHandler
+from parameterized import parameterized
+
+from ads.aqua.evaluation import AquaEvaluationApp, CreateAquaEvaluationDetails
+from ads.aqua.extension.evaluation_handler import (
+    AquaEvaluationConfigHandler,
+    AquaEvaluationHandler,
+    AquaEvaluationMetricsHandler,
+    AquaEvaluationReportHandler,
+    AquaEvaluationStatusHandler,
+)
+
+
+class TestDataset:
+    EVAL_ID = "ocid.datasciencemdoel.<ocid>"
+    mock_valid_input = dict(
+        evaluation_source_id="ocid1.datasciencemodel.oc1.iad.<OCID>",
+        evaluation_name="test_evaluation_name",
+        dataset_path="oci://dataset_bucket@namespace/prefix/dataset.jsonl",
+        report_path="oci://report_bucket@namespace/prefix/",
+        model_parameters=dict(max_token=500),
+        shape_name="VM.Standard.E3.Flex",
+        block_storage_size=1,
+        experiment_name="test_experiment_name",
+        memory_in_gbs=1,
+        ocpus=1,
+    )
+
+    def mock_url(self, action):
+        return f"{self.EVAL_ID}/{action}"
+
+
+class TestEvaluationHandler(unittest.TestCase):
+    """Contains unittest for Evaluation handler."""
+
+    @patch.object(IPythonHandler, "__init__")
+    def setUp(self, ipython_init_mock) -> None:
+        ipython_init_mock.return_value = None
+        self.test_instance = AquaEvaluationHandler(MagicMock(), MagicMock())
+        self.test_instance.finish = MagicMock()
+
+    @patch.object(AquaEvaluationApp, "delete")
+    def test_delete(self, mock_delete):
+        """Tests DELETE method."""
+        self.test_instance.delete(TestDataset.EVAL_ID)
+
+        self.test_instance.finish.assert_called_with(mock_delete.return_value)
+        mock_delete.assert_called_with(TestDataset.EVAL_ID)
+
+    @patch.object(AquaEvaluationApp, "cancel")
+    def test_put(self, mock_cancel):
+        """Tests PUT method."""
+        arg = TestDataset().mock_url("status")
+        self.test_instance.put(arg)
+
+        self.test_instance.finish.assert_called_with(mock_cancel.return_value)
+        mock_cancel.assert_called_with(TestDataset.EVAL_ID)
+
+    @patch.object(AquaEvaluationApp, "create")
+    def test_post(self, mock_create):
+        """Tests POST method."""
+        self.test_instance.get_json_body = MagicMock(
+            return_value=TestDataset.mock_valid_input
+        )
+
+        self.test_instance.post()
+
+        self.test_instance.finish.assert_called_with(mock_create.return_value)
+        mock_create.assert_called_with(
+            create_aqua_evaluation_details=(
+                CreateAquaEvaluationDetails(**TestDataset.mock_valid_input)
+            )
+        )
+
+    @parameterized.expand(
+        [
+            ("", TestDataset.EVAL_ID, "get"),
+            ("", "", "list"),
+            ("aqua/evaluation/metrics", "", "get_supported_metrics"),
+        ]
+    )
+    def test_get(self, path, input, mock_method):
+        """Tests GET method."""
+        self.test_instance.request = MagicMock(path=path)
+        with patch.object(AquaEvaluationApp, mock_method) as mock_app_method:
+            self.test_instance.get(input)
+
+            self.test_instance.finish.assert_called_with(mock_app_method.return_value)
+            mock_app_method.assert_called_once()
+
+
+class TestEvaluationStatusHandler(unittest.TestCase):
+    """Contains unittest for AquaEvaluationStatusHandler."""
+
+    @patch.object(IPythonHandler, "__init__")
+    def setUp(self, ipython_init_mock) -> None:
+        ipython_init_mock.return_value = None
+        self.test_instance = AquaEvaluationStatusHandler(MagicMock(), MagicMock())
+        self.test_instance.finish = MagicMock()
+
+    @parameterized.expand(
+        [
+            (TestDataset.EVAL_ID, TestDataset.EVAL_ID),
+            (TestDataset().mock_url("status"), TestDataset.EVAL_ID),
+        ]
+    )
+    @patch.object(AquaEvaluationApp, "get_status")
+    def test_get(self, input, expected_call, mock_get_status):
+        """Tests GET method."""
+        self.test_instance.get(input)
+
+        self.test_instance.finish.assert_called_with(mock_get_status.return_value)
+        mock_get_status.assert_called_with(expected_call)
+
+
+class TestEvaluationReportHandler(unittest.TestCase):
+    """Contains unittest for AquaEvaluationReportHandler."""
+
+    @patch.object(IPythonHandler, "__init__")
+    def setUp(self, ipython_init_mock) -> None:
+        ipython_init_mock.return_value = None
+        self.test_instance = AquaEvaluationReportHandler(MagicMock(), MagicMock())
+        self.test_instance.finish = MagicMock()
+
+    @parameterized.expand(
+        [
+            (TestDataset.EVAL_ID, TestDataset.EVAL_ID),
+            (TestDataset().mock_url("report"), TestDataset.EVAL_ID),
+        ]
+    )
+    @patch.object(AquaEvaluationApp, "download_report")
+    def test_get(self, input, expected_call, mock_download_report):
+        """Tests GET method."""
+        self.test_instance.get(input)
+
+        self.test_instance.finish.assert_called_with(mock_download_report.return_value)
+        mock_download_report.assert_called_with(expected_call)
+
+
+class TestEvaluationMetricsHandler(unittest.TestCase):
+    """Contains unittest for AquaEvaluationMetricsHandler."""
+
+    @patch.object(IPythonHandler, "__init__")
+    def setUp(self, ipython_init_mock) -> None:
+        ipython_init_mock.return_value = None
+        self.test_instance = AquaEvaluationMetricsHandler(MagicMock(), MagicMock())
+        self.test_instance.finish = MagicMock()
+
+    @parameterized.expand(
+        [
+            (TestDataset.EVAL_ID, TestDataset.EVAL_ID),
+            (TestDataset().mock_url("metrics"), TestDataset.EVAL_ID),
+        ]
+    )
+    @patch.object(AquaEvaluationApp, "load_metrics")
+    def test_get(self, input, expected_call, mock_load_metrics):
+        """Tests GET method."""
+        self.test_instance.get(input)
+
+        self.test_instance.finish.assert_called_with(mock_load_metrics.return_value)
+        mock_load_metrics.assert_called_with(expected_call)
+
+
+class TestEvaluationConfigHandler(unittest.TestCase):
+    """Contains unittest for AquaEvaluationConfigHandler."""
+
+    @patch.object(IPythonHandler, "__init__")
+    def setUp(self, ipython_init_mock) -> None:
+        ipython_init_mock.return_value = None
+        self.test_instance = AquaEvaluationConfigHandler(MagicMock(), MagicMock())
+        self.test_instance.finish = MagicMock()
+
+    @patch.object(AquaEvaluationApp, "load_evaluation_config")
+    def test_get(self, mock_load_evaluation_config):
+        """Tests GET method."""
+        self.test_instance.get(TestDataset.EVAL_ID)
+
+        self.test_instance.finish.assert_called_with(
+            mock_load_evaluation_config.return_value
+        )
+        mock_load_evaluation_config.assert_called_with(TestDataset.EVAL_ID)

--- a/tests/unitary/with_extras/aqua/test_handlers.py
+++ b/tests/unitary/with_extras/aqua/test_handlers.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*--
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+import os
+import unittest
+from importlib import metadata, reload
+from unittest.mock import MagicMock, patch
+
+from notebook.base.handlers import IPythonHandler
+from parameterized import parameterized
+
+import ads.aqua
+import ads.aqua.exception
+import ads.aqua.extension
+import ads.aqua.extension.common_handler
+import ads.config
+from ads.aqua.evaluation import AquaEvaluationApp
+from ads.aqua.extension.common_handler import (
+    ADSVersionHandler,
+    CompatibilityCheckHandler,
+)
+from ads.aqua.extension.evaluation_handler import (
+    AquaEvaluationConfigHandler,
+    AquaEvaluationMetricsHandler,
+    AquaEvaluationReportHandler,
+    AquaEvaluationStatusHandler,
+)
+from ads.aqua.extension.model_handler import AquaModelHandler, AquaModelLicenseHandler
+from ads.aqua.model import AquaModelApp
+from tests.unitary.with_extras.aqua.utils import HandlerTestDataset as TestDataset
+
+
+class TestHandlers(unittest.TestCase):
+    """Contains test cases for the following handlers which have GET:
+
+    AquaEvaluationConfigHandler,
+    AquaEvaluationMetricsHandler,
+    AquaEvaluationReportHandler,
+    AquaEvaluationStatusHandler,
+    ADSVersionHandler,
+    CompatibilityCheckHandler,
+    AquaModelLicenseHandler,
+    AquaModelHandler,
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        os.environ["ODSC_MODEL_COMPARTMENT_OCID"] = "mytemp"
+
+        reload(ads.config)
+        reload(ads.aqua)
+        reload(ads.aqua.extension.common_handler)
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        os.environ.pop("ODSC_MODEL_COMPARTMENT_OCID", None)
+
+        reload(ads.config)
+        reload(ads.aqua)
+        reload(ads.aqua.extension.common_handler)
+
+    @parameterized.expand(
+        [
+            (
+                AquaEvaluationConfigHandler,
+                AquaEvaluationApp,
+                "load_evaluation_config",
+                TestDataset.MOCK_OCID,
+                TestDataset.MOCK_OCID,
+            ),
+            (
+                AquaEvaluationMetricsHandler,
+                AquaEvaluationApp,
+                "load_metrics",
+                TestDataset().mock_url("metrics"),
+                TestDataset.MOCK_OCID,
+            ),
+            (
+                AquaEvaluationReportHandler,
+                AquaEvaluationApp,
+                "download_report",
+                TestDataset().mock_url("report"),
+                TestDataset.MOCK_OCID,
+            ),
+            (
+                AquaEvaluationStatusHandler,
+                AquaEvaluationApp,
+                "get_status",
+                TestDataset().mock_url("status"),
+                TestDataset.MOCK_OCID,
+            ),
+            (
+                ADSVersionHandler,
+                None,
+                None,
+                None,
+                {"data": metadata.version("oracle_ads")},
+            ),
+            (
+                CompatibilityCheckHandler,
+                None,
+                None,
+                None,
+                dict(status="ok"),
+            ),
+            (
+                AquaModelLicenseHandler,
+                AquaModelApp,
+                "load_license",
+                TestDataset().mock_url("license"),
+                TestDataset.MOCK_OCID,
+            ),
+            (
+                AquaModelHandler,
+                AquaModelApp,
+                "get",
+                TestDataset.MOCK_OCID,
+                TestDataset.MOCK_OCID,
+            ),
+            (AquaModelHandler, AquaModelApp, "list", "", (None, None)),
+        ]
+    )
+    @patch.object(IPythonHandler, "__init__")
+    def test_get(
+        self,
+        target_handler,
+        target_app,
+        associated_api,
+        url,
+        expected_call,
+        ipython_init_mock,
+    ):
+        """Tests invoking GET method successfully."""
+
+        ipython_init_mock.return_value = None
+        test_instance = target_handler(MagicMock(), MagicMock())
+        test_instance.finish = MagicMock()
+        test_instance.request = MagicMock()
+
+        if associated_api:
+            with patch.object(target_app, associated_api) as mock_api:
+                test_instance.get(url)
+
+                if associated_api:
+                    test_instance.finish.assert_called_with(mock_api.return_value)
+
+                    (
+                        mock_api.assert_called_with(expected_call)
+                        if isinstance(expected_call, str)
+                        else mock_api.assert_called
+                    )
+        else:
+            test_instance.get()
+            test_instance.finish.assert_called_with(expected_call)

--- a/tests/unitary/with_extras/aqua/utils.py
+++ b/tests/unitary/with_extras/aqua/utils.py
@@ -9,6 +9,26 @@ from typing import Dict
 from pydantic import BaseModel, PositiveInt, ValidationError
 
 
+class HandlerTestDataset:
+    MOCK_OCID = "ocid.datasciencemdoel.<ocid>"
+    mock_valid_input = dict(
+        evaluation_source_id="ocid1.datasciencemodel.oc1.iad.<OCID>",
+        evaluation_name="test_evaluation_name",
+        dataset_path="oci://dataset_bucket@namespace/prefix/dataset.jsonl",
+        report_path="oci://report_bucket@namespace/prefix/",
+        model_parameters=dict(max_token=500),
+        shape_name="VM.Standard.E3.Flex",
+        block_storage_size=1,
+        experiment_name="test_experiment_name",
+        memory_in_gbs=1,
+        ocpus=1,
+    )
+    mock_invalid_input = dict(name="myvalue")
+
+    def mock_url(self, action):
+        return f"{self.MOCK_OCID}/{action}"
+
+
 class SupportMetricsFormat(BaseModel):
     """Format for supported evaluation metrics."""
 

--- a/tests/unitary/with_extras/aqua/utils.py
+++ b/tests/unitary/with_extras/aqua/utils.py
@@ -7,7 +7,6 @@
 from dataclasses import dataclass
 from typing import Dict
 
-import pandas as pd
 from pydantic import BaseModel, PositiveInt, ValidationError
 
 

--- a/tests/unitary/with_extras/aqua/utils.py
+++ b/tests/unitary/with_extras/aqua/utils.py
@@ -35,6 +35,26 @@ class HandlerTestDataset:
     )
     mock_invalid_input = dict(name="myvalue")
     mock_dataclass_obj = MockData(id="myid", name="myname")
+    mock_service_payload_create = {
+        "target_service": "data_science",
+        "status": 404,
+        "code": "NotAuthenticated",
+        "opc-request-id": "1234",
+        "message": "The required information to complete authentication was not provided or was incorrect.",
+        "operation_name": "create_resources",
+        "timestamp": "2024-04-12T02:51:24.977404+00:00",
+        "request_endpoint": "POST xxx",
+    }
+    mock_service_payload_get = {
+        "target_service": "data_science",
+        "status": 404,
+        "code": "NotAuthenticated",
+        "opc-request-id": "1234",
+        "message": "The required information to complete authentication was not provided or was incorrect.",
+        "operation_name": "get_job_run",
+        "timestamp": "2024-04-12T02:51:24.977404+00:00",
+        "request_endpoint": "GET xxx",
+    }
 
     def mock_url(self, action):
         return f"{self.MOCK_OCID}/{action}"

--- a/tests/unitary/with_extras/aqua/utils.py
+++ b/tests/unitary/with_extras/aqua/utils.py
@@ -4,9 +4,19 @@
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
+from dataclasses import dataclass
 from typing import Dict
 
+import pandas as pd
 from pydantic import BaseModel, PositiveInt, ValidationError
+
+
+@dataclass(repr=False)
+class MockData:
+    """Used for testing serializing dataclass in handler."""
+
+    id: str = ""
+    name: str = ""
 
 
 class HandlerTestDataset:
@@ -24,6 +34,7 @@ class HandlerTestDataset:
         ocpus=1,
     )
     mock_invalid_input = dict(name="myvalue")
+    mock_dataclass_obj = MockData(id="myid", name="myname")
 
     def mock_url(self, action):
         return f"{self.MOCK_OCID}/{action}"


### PR DESCRIPTION
# Description
This PR aims to add tests for aqua handlers

# Coverage
![Screenshot 2024-04-11 at 13 35 42](https://github.com/oracle/accelerated-data-science/assets/49049296/6131e443-be51-4bec-9749-c36106434230)
![Screenshot 2024-04-12 at 00 52 53](https://github.com/oracle/accelerated-data-science/assets/49049296/0d0e562c-9382-4751-bfad-6d880e269b28)
![Screenshot 2024-04-12 at 12 48 37](https://github.com/oracle/accelerated-data-science/assets/49049296/c644d1c0-b615-4442-80f4-d0e87da3092e)



# Test for aqua.module
<img width="1512" alt="Screenshot 2024-04-12 at 12 48 56" src="https://github.com/oracle/accelerated-data-science/assets/49049296/042f693e-ac7d-48bd-a3fb-1d55775eca26">
