### PR TITLE
ADSDataset.show_in_notebook fails while rendering visualizations

### DIFF
--- a/ads/catalog/model.py
+++ b/ads/catalog/model.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import warnings
@@ -404,13 +404,13 @@ class Model:
     def _repr_html_(self):
         """Shows model in dataframe format."""
         return (
-            self.to_dataframe().style.set_properties(**{"margin-left": "0px"}).render()
+            self.to_dataframe().style.set_properties(**{"margin-left": "0px"}).to_html()
         )
 
     def __repr__(self):
         """Shows model in dataframe format."""
         return (
-            self.to_dataframe().style.set_properties(**{"margin-left": "0px"}).render()
+            self.to_dataframe().style.set_properties(**{"margin-left": "0px"}).to_html()
         )
 
     def activate(self) -> None:

--- a/ads/catalog/notebook.py
+++ b/ads/catalog/notebook.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import warnings
@@ -220,7 +220,7 @@ class NotebookCatalog:
                 lambda x: "<a href='%s'>%s</a>"
                 % (x if x.startswith("http") else "http://%s" % x, "open")
             )
-            return df.style.set_properties(**{"margin-left": "0px"}).render()
+            return df.style.set_properties(**{"margin-left": "0px"}).to_html()
 
         notebook.commit = MethodType(commit, notebook)
         notebook.rollback = MethodType(rollback, notebook)
@@ -295,7 +295,7 @@ class NotebookCatalog:
         shape=None,
         block_storage_size_in_gbs=None,
         subnet_id=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Create a new notebook session with the supplied details.

--- a/ads/catalog/project.py
+++ b/ads/catalog/project.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import warnings
@@ -237,7 +237,7 @@ class ProjectCatalog(Mapping):
             return (
                 project_self.to_dataframe()
                 .style.set_properties(**{"margin-left": "0px"})
-                .render()
+                .to_html()
             )
 
         project.commit = MethodType(commit, project)

--- a/ads/catalog/summary.py
+++ b/ads/catalog/summary.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*--
 
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 from __future__ import print_function, absolute_import
@@ -98,7 +98,6 @@ class SummaryList(list, metaclass=ABCMeta):
         pass
 
     def to_dataframe(self, datetime_format=None):
-
         """
         Returns the model catalog summary as a pandas dataframe
 
@@ -121,7 +120,6 @@ class SummaryList(list, metaclass=ABCMeta):
 
     @runtime_dependency(module="IPython", install_from=OptionalDependency.NOTEBOOK)
     def show_in_notebook(self, datetime_format=None):
-
         """
         Displays the model catalog summary in a Jupyter Notebook cell
 
@@ -144,7 +142,7 @@ class SummaryList(list, metaclass=ABCMeta):
     def _repr_html_(self):
         return self.df.style.applymap(
             self._color_lifecycle_state, subset=["lifecycle_state"]
-        ).render()
+        ).to_html()
 
     def _sort_by(self, cols, reverse=False):
         return sorted(

--- a/ads/data_labeling/metadata.py
+++ b/ads/data_labeling/metadata.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 from dataclasses import asdict, dataclass, field
@@ -75,7 +75,7 @@ class Metadata(DataClassSerializable):
     def _repr_html_(self):
         """Shows metadata in dataframe format."""
         return (
-            self.to_dataframe().style.set_properties(**{"margin-left": "0px"}).render()
+            self.to_dataframe().style.set_properties(**{"margin-left": "0px"}).to_html()
         )
 
     @classmethod

--- a/ads/dataset/dataset.py
+++ b/ads/dataset/dataset.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*--
 
-# Copyright (c) 2020, 2023 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 from __future__ import print_function, absolute_import, division
@@ -85,7 +85,6 @@ class ADSDataset(PandasDataset):
         interactive=False,
         **kwargs,
     ):
-
         #
         # to keep performance high and linear no matter the size of the distributed dataset we
         # create a pandas df that's used internally because this has a fixed upper size.
@@ -204,7 +203,7 @@ class ADSDataset(PandasDataset):
                     .style.set_table_styles(utils.get_dataframe_styles())
                     .set_table_attributes("class=table")
                     .hide_index()
-                    .render()
+                    .to_html()
                 )
             )
         )
@@ -263,7 +262,7 @@ class ADSDataset(PandasDataset):
                             self.style.set_table_styles(utils.get_dataframe_styles())
                             .set_table_attributes("class=table")
                             .hide_index()
-                            .render()
+                            .to_html()
                         )
                     )
                 )
@@ -1265,7 +1264,6 @@ class ADSDataset(PandasDataset):
         n=None,
         **init_kwargs,
     ):
-
         prev_doc_mode = utils.is_documentation_mode()
 
         set_documentation_mode(False)

--- a/ads/dataset/factory.py
+++ b/ads/dataset/factory.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 from __future__ import print_function, absolute_import
@@ -367,7 +367,7 @@ class DatasetFactory:
                 HTML(
                     list_df.style.set_table_attributes("class=table")
                     .hide_index()
-                    .render()
+                    .to_html()
                 )
             )
         return list_df
@@ -884,7 +884,6 @@ class CustomFormatReaders:
         import xml.etree.cElementTree as et
 
         def get_children(df, node, parent, i):
-
             for name in node.attrib.keys():
                 df.at[i, parent + name] = node.attrib[name]
             for child in list(node):

--- a/ads/dataset/sampled_dataset.py
+++ b/ads/dataset/sampled_dataset.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8; -*-
 
-# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import matplotlib
@@ -48,6 +48,7 @@ from ads.common.decorator.runtime_dependency import (
 )
 
 NATURAL_EARTH_DATASET = "naturalearth_lowres"
+
 
 class PandasDataset(object):
     """
@@ -107,7 +108,6 @@ class PandasDataset(object):
         self.sampled_df = self.sampled_df.reset_index(drop=True)
 
     def _find_feature_subset(self, df, target_name, include_n_features=32):
-
         if len(df.columns) <= include_n_features:
             return self.sampled_df
         else:
@@ -212,7 +212,6 @@ class PandasDataset(object):
     def _generate_features_html(
         self, is_wide_dataset, n_features, df_stats, visualizations_follow
     ):
-
         html = utils.get_bootstrap_styles()
 
         if is_wide_dataset:
@@ -233,7 +232,7 @@ class PandasDataset(object):
                 if ("float" in str(type(x))) or ("int" in str(type(x)))
                 else x
             )
-            .render()
+            .to_html()
         )
 
         if visualizations_follow:
@@ -244,7 +243,6 @@ class PandasDataset(object):
     def _generate_warnings_html(
         self, is_wide_dataset, n_rows, n_features, df_stats, out, accordion
     ):
-
         #
         # create the "Warnings" accordion section:
         #  - show high cardinal categoricals


### PR DESCRIPTION
### Description

ADSDataset.show_in_notebook fails while rendering visualizations.

When user tries to run ds.show_in_notebook() when trying to print visualizations in a notebook, they get the following error:
```
ERROR - Exception
Traceback (most recent call last):
  File "/apps/mambaforge/envs/jupyter/lib/python3.11/site-packages/IPython/core/interactiveshell.py", line 3553, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "/tmp/ipykernel_11835/2876128834.py", line 1, in <cell line: 0>
    ds.show_in_notebook()
  File "/apps/mambaforge/envs/jupyter/lib/python3.11/site-packages/ads/common/decorator/runtime_dependency.py", line 174, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/apps/mambaforge/envs/jupyter/lib/python3.11/site-packages/ads/common/decorator/runtime_dependency.py", line 174, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/apps/mambaforge/envs/jupyter/lib/python3.11/site-packages/ads/dataset/dataset.py", line 1929, in show_in_notebook
    features.value = self._generate_features_html(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/apps/mambaforge/envs/jupyter/lib/python3.11/site-packages/ads/dataset/sampled_dataset.py", line 236, in _generate_features_html
    .render()
     ^^^^^^
AttributeError: 'Styler' object has no attribute 'render'
AttributeError: 'Styler' object has no attribute 'render'
```

To fix this, we can try we to replace the `render()` with `to_html` in the code.

### Jira ticket
[ODSC-55804](https://jira.oci.oraclecorp.com/browse/ODSC-55804)


### Testing
On making the code change, the content in html is rendered without any issues.

![image](https://github.com/oracle/accelerated-data-science/assets/10899050/3d8456d6-c22b-42b5-961a-692154859b8b)
