### PR TITLE
[ODSC-55513] Show Aqua extension for the default region

### DIFF
--- a/ads/aqua/extension/common_handler.py
+++ b/ads/aqua/extension/common_handler.py
@@ -9,6 +9,8 @@ from importlib import metadata
 from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua import ODSC_MODEL_COMPARTMENT_OCID
 from ads.aqua.exception import AquaResourceAccessError
+from ads.aqua.utils import known_realm
+from ads.aqua.decorator import handle_exceptions
 
 
 class ADSVersionHandler(AquaAPIhandler):
@@ -21,9 +23,12 @@ class ADSVersionHandler(AquaAPIhandler):
 class CompatibilityCheckHandler(AquaAPIhandler):
     """The handler to check if the extension is compatible."""
 
+    @handle_exceptions
     def get(self):
         if ODSC_MODEL_COMPARTMENT_OCID:
             return self.finish(dict(status="ok"))
+        elif known_realm():
+            return self.finish(dict(status="compatible"))
         else:
             raise AquaResourceAccessError(
                 f"The AI Quick actions extension is not compatible in the given region."

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -737,8 +737,7 @@ def _is_valid_mvs(mvs: ModelVersionSet, target_tag: str) -> bool:
 
 
 def known_realm():
-    """This helper function returns True if the Aqua service is available by default in the
-    given namespace.
+    """This helper function returns True if the Aqua service is available by default in the given namespace.
     Returns
     -------
     bool:

--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -79,6 +79,7 @@ NB_SESSION_IDENTIFIER = "NB_SESSION_OCID"
 LIFECYCLE_DETAILS_MISSING_JOBRUN = "The asscociated JobRun resource has been deleted."
 READY_TO_DEPLOY_STATUS = "ACTIVE"
 READY_TO_FINE_TUNE_STATUS = "TRUE"
+AQUA_GA_LIST = ["id19sfcrra6z"]
 
 
 class LifecycleStatus(Enum):
@@ -733,3 +734,15 @@ def _is_valid_mvs(mvs: ModelVersionSet, target_tag: str) -> bool:
         return False
 
     return target_tag in mvs.freeform_tags
+
+
+def known_realm():
+    """This helper function returns True if the Aqua service is available by default in the
+    given namespace.
+    Returns
+    -------
+    bool:
+        Return True if aqua service is available.
+
+    """
+    return os.environ.get("CONDA_BUCKET_NS", "#") in AQUA_GA_LIST

--- a/tests/unitary/with_extras/aqua/test_common_handler.py
+++ b/tests/unitary/with_extras/aqua/test_common_handler.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*--
+
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+import os
+import json
+from importlib import reload
+from tornado.web import Application
+from tornado.testing import AsyncHTTPTestCase
+
+import ads.config
+import ads.aqua
+from ads.aqua.utils import AQUA_GA_LIST
+from ads.aqua.extension.common_handler import CompatibilityCheckHandler
+
+
+class TestDataset:
+    SERVICE_COMPARTMENT_ID = "ocid1.compartment.oc1..<OCID>"
+
+
+class TestYourHandler(AsyncHTTPTestCase):
+    def get_app(self):
+        return Application([(r"/hello", CompatibilityCheckHandler)])
+
+    def setUp(self):
+        super().setUp()
+        os.environ["ODSC_MODEL_COMPARTMENT_OCID"] = TestDataset.SERVICE_COMPARTMENT_ID
+        reload(ads.config)
+        reload(ads.aqua)
+        reload(ads.aqua.extension.common_handler)
+
+    def tearDown(self):
+        super().tearDown()
+        os.environ.pop("ODSC_MODEL_COMPARTMENT_OCID", None)
+        reload(ads.config)
+        reload(ads.aqua)
+        reload(ads.aqua.extension.common_handler)
+
+    def test_get_ok(self):
+        response = self.fetch("/hello", method="GET")
+        assert json.loads(response.body)["status"] == "ok"
+
+    def test_get_compatible_status(self):
+        os.environ["ODSC_MODEL_COMPARTMENT_OCID"] = ""
+        os.environ["CONDA_BUCKET_NS"] = AQUA_GA_LIST[0]
+        reload(ads.common)
+        reload(ads.aqua)
+        reload(ads.aqua.extension.common_handler)
+        response = self.fetch("/hello", method="GET")
+        assert json.loads(response.body)["status"] == "compatible"
+
+    def test_raise_not_compatible_error(self):
+        os.environ["ODSC_MODEL_COMPARTMENT_OCID"] = ""
+        os.environ["CONDA_BUCKET_NS"] = "test-namespace"
+        reload(ads.common)
+        reload(ads.aqua)
+        reload(ads.aqua.extension.common_handler)
+        response = self.fetch("/hello", method="GET")
+        assert (
+            json.loads(response.body)["message"]
+            == "Authorization Failed: The resource you're looking for isn't accessible."
+        )


### PR DESCRIPTION
### Description
This PR hardcodes the namespace of the realm where Aqua is available and return the "compatible" status to indicate the extension can be enabled for the selected notebook session.

Also, we add the exceptions handler here to return the AquaResourceAccessError error (404) instead of 500 that was thrown before. This needs to be handled by the UI as well.

### Jira
[ODSC-55513](https://jira.oci.oraclecorp.com/browse/ODSC-55513)

### Tests

```
> python3 -m pytest tests/unitary/with_extras/aqua/test_common_handler.py
=================================== test session starts ====================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0 -- /Users/vmascarenhas/miniconda3/envs/ads-local-v38/bin/python3
cachedir: .pytest_cache
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 3 items

tests/unitary/with_extras/aqua/test_common_handler.py::TestYourHandler::test_get_compatible_status PASSED [ 33%]
tests/unitary/with_extras/aqua/test_common_handler.py::TestYourHandler::test_get_ok PASSED [ 66%]
tests/unitary/with_extras/aqua/test_common_handler.py::TestYourHandler::test_raise_not_compatible_error PASSED [100%]

==================================== 3 passed in 4.45s =====================================
```