### PR TITLE
Fix telemetry event record to better report output

### DIFF
--- a/ads/aqua/deployment.py
+++ b/ads/aqua/deployment.py
@@ -396,34 +396,24 @@ class AquaDeploymentApp(AquaApp):
             self.telemetry.record_event_async(
                 category="aqua/custom/deployment", action="create", detail=model_name
             )
-            # tracks the shape used for deploying the custom models
-            self.telemetry.record_event_async(
-                category="aqua/custom/deployment/create",
-                action="shape",
-                detail=instance_shape,
-            )
             # tracks the shape used for deploying the custom models by name
             self.telemetry.record_event_async(
-                category=f"aqua/custom/{model_name}/deployment/create",
+                category=f"aqua/custom/deployment/create",
                 action="shape",
                 detail=instance_shape,
+                value=model_name
             )
         else:
             # tracks unique deployments that were created in the user compartment
             self.telemetry.record_event_async(
                 category="aqua/service/deployment", action="create", detail=model_name
             )
-            # tracks the shape used for deploying the service models
+            # tracks the shape used for deploying the service models by name
             self.telemetry.record_event_async(
                 category="aqua/service/deployment/create",
                 action="shape",
                 detail=instance_shape,
-            )
-            # tracks the shape used for deploying the service models by name
-            self.telemetry.record_event_async(
-                category=f"aqua/service/{model_name}/deployment/create",
-                action="shape",
-                detail=instance_shape,
+                value=model_name
             )
 
         return AquaDeployment.from_oci_model_deployment(

--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -673,6 +673,14 @@ class AquaEvaluationApp(AquaApp):
             ),
         )
 
+        # tracks shapes used in evaluation that were created for the given evaluation source
+        self.telemetry.record_event_async(
+            category="aqua/evaluation/create",
+            action="shape",
+            detail=create_aqua_evaluation_details.shape_name,
+            value=evaluation_source.display_name
+        )
+
         # tracks unique evaluation that were created for the given evaluation source
         self.telemetry.record_event_async(
             category="aqua/evaluation",

--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -688,7 +688,7 @@ class AquaEvaluationApp(AquaApp):
             category="aqua/evaluation/create",
             action="shape",
             detail=create_aqua_evaluation_details.shape_name,
-            value=evaluation_source.display_name,
+            value=self._get_service_model_name(evaluation_source),
         )
 
         # tracks unique evaluation that were created for the given evaluation source
@@ -785,7 +785,7 @@ class AquaEvaluationApp(AquaApp):
         )
 
         return runtime
-    
+
     @staticmethod
     def _get_service_model_name(
         source: Union[ModelDeployment, DataScienceModel]
@@ -811,7 +811,7 @@ class AquaEvaluationApp(AquaApp):
                 return source.freeform_tags.get(Tags.AQUA_MODEL_NAME_TAG.value)
             else:
                 return extract_id_and_name_from_tag(fine_tuned_model_tag)[1]
-        
+
         return source.display_name
 
     @staticmethod

--- a/ads/aqua/finetune.py
+++ b/ads/aqua/finetune.py
@@ -460,11 +460,10 @@ class AquaFineTuningApp(AquaApp):
         telemetry_kwargs = (
             {"ocid": ft_job.id[-6:]} if ft_job and len(ft_job.id) > 6 else {}
         )
+        # track shapes that were used for fine-tune creation
         self.telemetry.record_event_async(
-            category="aqua/service/finetune/create",
-            action="shape",
-            detail=f"{create_fine_tuning_details.shape_name}x{create_fine_tuning_details.replica}",
-            value=source.display_name,
+            category=f"aqua/service/finetune/create/shape/",
+            action=f"{create_fine_tuning_details.shape_name}x{create_fine_tuning_details.replica}",
             **telemetry_kwargs,
         )
         # tracks unique fine-tuned models that were created in the user compartment
@@ -472,6 +471,14 @@ class AquaFineTuningApp(AquaApp):
             category="aqua/service/finetune",
             action="create",
             detail=source.display_name,
+            **telemetry_kwargs,
+        )
+        # track combination of model and shape used for fine-tune creation
+        self.telemetry.record_event_async(
+            category="aqua/service/finetune/create",
+            action="shape",
+            detail=f"{create_fine_tuning_details.shape_name}x{create_fine_tuning_details.replica}",
+            value=source.display_name,
         )
 
         return AquaFineTuningSummary(

--- a/ads/aqua/finetune.py
+++ b/ads/aqua/finetune.py
@@ -461,8 +461,10 @@ class AquaFineTuningApp(AquaApp):
             {"ocid": ft_job.id[-6:]} if ft_job and len(ft_job.id) > 6 else {}
         )
         self.telemetry.record_event_async(
-            category=f"aqua/service/{source.display_name}/finetune/create/shape/",
-            action=f"{create_fine_tuning_details.shape_name}x{create_fine_tuning_details.replica}",
+            category="aqua/service/finetune/create",
+            action="shape",
+            detail=f"{create_fine_tuning_details.shape_name}x{create_fine_tuning_details.replica}",
+            value=source.display_name,
             **telemetry_kwargs,
         )
         # tracks unique fine-tuned models that were created in the user compartment


### PR DESCRIPTION
### Description

Telemetry data related to shape model combination for MD and finetune has a bad design so that visualized report not easily build out for this metrics. Suggesting an update, so that we will do:

```
aqua/custom/deployment/create/shape/{shape}
{value=model_name}
aqua/service/deployment/create/shape/{shape}
{value=model_name}
aqua/service/finetune/create/shape/{shape}
{value=model_name}
```

instead:
```
aqua/custom/{model_name}/deployment/create/shape/{shape}
aqua/service/{model_name}/deployment/create/shape/{shape}
aqua/service/{model_name}/finetune/create/shape/{shape}
```

Also dropping:
```aqua/service/deployment/create/shape/{shape}```, this will duplicate suggested change above, if used without value
```aqua/custom/deployment/create/shape/{shape}```, this will duplicate suggested change above, if used without value
