### PR TITLE
Bugfix/aqua error handle

### DIFF
--- a/ads/aqua/decorator.py
+++ b/ads/aqua/decorator.py
@@ -59,6 +59,7 @@ def handle_exceptions(func):
         except ServiceError as error:
             self.write_error(
                 status_code=error.status or 500,
+                message=error.message,
                 reason=error.message,
                 service_payload=error.args[0] if error.args else None,
                 exc_info=sys.exc_info(),

--- a/ads/aqua/decorator.py
+++ b/ads/aqua/decorator.py
@@ -17,6 +17,7 @@ from oci.exceptions import (
     RequestException,
     ServiceError,
 )
+from tornado.web import HTTPError
 
 from ads.aqua.exception import AquaError
 from ads.aqua.extension.base_handler import AquaAPIhandler
@@ -89,6 +90,12 @@ def handle_exceptions(func):
                 status_code=error.status,
                 reason=error.reason,
                 service_payload=error.service_payload,
+                exc_info=sys.exc_info(),
+            )
+        except HTTPError as e:
+            self.write_error(
+                status_code=e.status_code,
+                reason=e.log_message,
                 exc_info=sys.exc_info(),
             )
         except Exception as ex:

--- a/ads/aqua/extension/base_handler.py
+++ b/ads/aqua/extension/base_handler.py
@@ -11,11 +11,12 @@ from dataclasses import asdict, is_dataclass
 from typing import Any
 
 from notebook.base.handlers import APIHandler
-from tornado.web import HTTPError, Application
 from tornado import httputil
-from ads.telemetry.client import TelemetryClient
-from ads.config import AQUA_TELEMETRY_BUCKET, AQUA_TELEMETRY_BUCKET_NS
+from tornado.web import Application, HTTPError
+
 from ads.aqua import logger
+from ads.config import AQUA_TELEMETRY_BUCKET, AQUA_TELEMETRY_BUCKET_NS
+from ads.telemetry.client import TelemetryClient
 
 
 class AquaAPIhandler(APIHandler):
@@ -66,7 +67,6 @@ class AquaAPIhandler(APIHandler):
 
     def write_error(self, status_code, **kwargs):
         """AquaAPIhandler errors are JSON, not human pages."""
-
         self.set_header("Content-Type", "application/json")
         reason = kwargs.get("reason")
         self.set_status(status_code, reason=reason)
@@ -84,7 +84,7 @@ class AquaAPIhandler(APIHandler):
             e = exc_info[1]
             if isinstance(e, HTTPError):
                 reply["message"] = e.log_message or message
-                reply["reason"] = e.reason
+                reply["reason"] = e.reason if e.reason else reply["reason"]
                 reply["request_id"] = str(uuid.uuid4())
             else:
                 reply["request_id"] = str(uuid.uuid4())

--- a/ads/aqua/extension/common_handler.py
+++ b/ads/aqua/extension/common_handler.py
@@ -6,14 +6,16 @@
 
 from importlib import metadata
 
-from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua import ODSC_MODEL_COMPARTMENT_OCID
+from ads.aqua.decorator import handle_exceptions
 from ads.aqua.exception import AquaResourceAccessError
+from ads.aqua.extension.base_handler import AquaAPIhandler
 
 
 class ADSVersionHandler(AquaAPIhandler):
     """The handler to get the current version of the ADS."""
 
+    @handle_exceptions
     def get(self):
         self.finish({"data": metadata.version("oracle_ads")})
 
@@ -21,6 +23,7 @@ class ADSVersionHandler(AquaAPIhandler):
 class CompatibilityCheckHandler(AquaAPIhandler):
     """The handler to check if the extension is compatible."""
 
+    @handle_exceptions
     def get(self):
         if ODSC_MODEL_COMPARTMENT_OCID:
             return self.finish(dict(status="ok"))

--- a/ads/aqua/extension/deployment_handler.py
+++ b/ads/aqua/extension/deployment_handler.py
@@ -7,10 +7,10 @@ from urllib.parse import urlparse
 
 from tornado.web import HTTPError
 
+from ads.aqua.decorator import handle_exceptions
 from ads.aqua.deployment import AquaDeploymentApp, MDInferenceResponse, ModelParams
 from ads.aqua.extension.base_handler import AquaAPIhandler, Errors
 from ads.config import COMPARTMENT_OCID, PROJECT_OCID
-from ads.aqua.decorator import handle_exceptions
 
 
 class AquaDeploymentHandler(AquaAPIhandler):
@@ -110,12 +110,10 @@ class AquaDeploymentHandler(AquaAPIhandler):
             )
         )
 
-    @handle_exceptions
     def read(self, id):
         """Read the information of an Aqua model deployment."""
         return self.finish(AquaDeploymentApp().get(model_deployment_id=id))
 
-    @handle_exceptions
     def list(self):
         """List Aqua models."""
         # If default is not specified,
@@ -129,14 +127,12 @@ class AquaDeploymentHandler(AquaAPIhandler):
             )
         )
 
-    @handle_exceptions
     def get_deployment_config(self, model_id):
         """Gets the deployment config for Aqua model."""
         return self.finish(AquaDeploymentApp().get_deployment_config(model_id=model_id))
 
 
 class AquaDeploymentInferenceHandler(AquaAPIhandler):
-    @staticmethod
     def validate_predict_url(endpoint):
         try:
             url = urlparse(endpoint)

--- a/ads/aqua/extension/deployment_handler.py
+++ b/ads/aqua/extension/deployment_handler.py
@@ -133,6 +133,7 @@ class AquaDeploymentHandler(AquaAPIhandler):
 
 
 class AquaDeploymentInferenceHandler(AquaAPIhandler):
+    @staticmethod
     def validate_predict_url(endpoint):
         try:
             url = urlparse(endpoint)

--- a/ads/aqua/extension/evaluation_handler.py
+++ b/ads/aqua/extension/evaluation_handler.py
@@ -5,11 +5,10 @@
 
 from urllib.parse import urlparse
 
-from requests import HTTPError
+from tornado.web import HTTPError
 
 from ads.aqua.decorator import handle_exceptions
 from ads.aqua.evaluation import AquaEvaluationApp, CreateAquaEvaluationDetails
-from ads.aqua.exception import AquaError
 from ads.aqua.extension.base_handler import AquaAPIhandler, Errors
 from ads.aqua.extension.utils import validate_function_parameters
 from ads.config import COMPARTMENT_OCID

--- a/ads/aqua/extension/finetune_handler.py
+++ b/ads/aqua/extension/finetune_handler.py
@@ -54,7 +54,6 @@ class AquaFineTuneHandler(AquaAPIhandler):
 
         self.finish(AquaFineTuningApp().create(CreateFineTuningDetails(**input_data)))
 
-    @handle_exceptions
     def get_finetuning_config(self, model_id):
         """Gets the finetuning config for Aqua model."""
         return self.finish(AquaFineTuningApp().get_finetuning_config(model_id=model_id))

--- a/ads/aqua/extension/ui_handler.py
+++ b/ads/aqua/extension/ui_handler.py
@@ -34,6 +34,7 @@ class AquaUIHandler(AquaAPIhandler):
     HTTPError: For various failure scenarios such as invalid input format, missing data, etc.
     """
 
+    @handle_exceptions
     def get(self, id=""):
         """Handle GET request."""
         url_parse = urlparse(self.request.path)
@@ -76,7 +77,6 @@ class AquaUIHandler(AquaAPIhandler):
         else:
             raise HTTPError(400, f"The request {self.request.path} is invalid.")
 
-    @handle_exceptions
     def list_log_groups(self, **kwargs):
         """Lists all log groups for the specified compartment or tenancy."""
         compartment_id = self.get_argument("compartment_id", default=COMPARTMENT_OCID)
@@ -84,22 +84,18 @@ class AquaUIHandler(AquaAPIhandler):
             AquaUIApp().list_log_groups(compartment_id=compartment_id, **kwargs)
         )
 
-    @handle_exceptions
     def list_logs(self, log_group_id: str, **kwargs):
         """Lists the specified log group's log objects."""
         return self.finish(AquaUIApp().list_logs(log_group_id=log_group_id, **kwargs))
 
-    @handle_exceptions
     def list_compartments(self):
         """Lists the compartments in a compartment specified by ODSC_MODEL_COMPARTMENT_OCID env variable."""
         return self.finish(AquaUIApp().list_compartments())
 
-    @handle_exceptions
     def get_default_compartment(self):
         """Returns user compartment ocid."""
         return self.finish(AquaUIApp().get_default_compartment())
 
-    @handle_exceptions
     def list_model_version_sets(self, **kwargs):
         """Lists all model version sets for the specified compartment or tenancy."""
 
@@ -112,7 +108,6 @@ class AquaUIHandler(AquaAPIhandler):
             )
         )
 
-    @handle_exceptions
     def list_experiments(self, **kwargs):
         """Lists all experiments for the specified compartment or tenancy."""
 
@@ -125,7 +120,6 @@ class AquaUIHandler(AquaAPIhandler):
             )
         )
 
-    @handle_exceptions
     def list_buckets(self, **kwargs):
         """Lists all model version sets for the specified compartment or tenancy."""
         compartment_id = self.get_argument("compartment_id", default=COMPARTMENT_OCID)
@@ -138,7 +132,6 @@ class AquaUIHandler(AquaAPIhandler):
             )
         )
 
-    @handle_exceptions
     def list_job_shapes(self, **kwargs):
         """Lists job shapes available in the specified compartment."""
         compartment_id = self.get_argument("compartment_id", default=COMPARTMENT_OCID)
@@ -146,7 +139,6 @@ class AquaUIHandler(AquaAPIhandler):
             AquaUIApp().list_job_shapes(compartment_id=compartment_id, **kwargs)
         )
 
-    @handle_exceptions
     def list_vcn(self, **kwargs):
         """Lists the virtual cloud networks (VCNs) in the specified compartment."""
         compartment_id = self.get_argument("compartment_id", default=COMPARTMENT_OCID)
@@ -154,7 +146,6 @@ class AquaUIHandler(AquaAPIhandler):
             AquaUIApp().list_vcn(compartment_id=compartment_id, **kwargs)
         )
 
-    @handle_exceptions
     def list_subnets(self, **kwargs):
         """Lists the subnets in the specified VCN and the specified compartment."""
         compartment_id = self.get_argument("compartment_id", default=COMPARTMENT_OCID)
@@ -165,7 +156,6 @@ class AquaUIHandler(AquaAPIhandler):
             )
         )
 
-    @handle_exceptions
     def get_shape_availability(self, **kwargs):
         """For a given compartmentId, resource limit name, and scope, returns the number of available resources associated
         with the given limit."""
@@ -178,7 +168,6 @@ class AquaUIHandler(AquaAPIhandler):
             )
         )
 
-    @handle_exceptions
     def is_bucket_versioned(self):
         """For a given compartmentId, resource limit name, and scope, returns the number of available resources associated
         with the given limit."""

--- a/ads/aqua/extension/utils.py
+++ b/ads/aqua/extension/utils.py
@@ -4,16 +4,16 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 from dataclasses import fields
 from typing import Dict, Optional
-from requests import HTTPError
+
+from tornado.web import HTTPError
 
 from ads.aqua.extension.base_handler import Errors
 
 
 def validate_function_parameters(data_class, input_data: Dict):
-    """Validates if the required parameters are provided in input data."""    
+    """Validates if the required parameters are provided in input data."""
     required_parameters = [
-        field.name for field in fields(data_class) 
-        if field.type != Optional[field.type]
+        field.name for field in fields(data_class) if field.type != Optional[field.type]
     ]
 
     for required_parameter in required_parameters:

--- a/tests/unitary/with_extras/aqua/test_decorator.py
+++ b/tests/unitary/with_extras/aqua/test_decorator.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*--
+
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+import json
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from notebook.base.handlers import IPythonHandler
+from oci.exceptions import (
+    CompositeOperationError,
+    ConfigFileNotFound,
+    ConnectTimeout,
+    MissingEndpointForNonRegionalServiceClientError,
+    MultipartUploadError,
+    RequestException,
+    ServiceError,
+)
+from parameterized import parameterized
+from tornado.web import HTTPError
+
+from ads.aqua.exception import AquaError
+from ads.aqua.extension.base_handler import AquaAPIhandler
+
+
+class TestDataset:
+    mock_request_id = "1234"
+    mock_service_error = dict(status=501, code="code", message="message", headers={})
+    mock_service_error_reply = {
+        "status": 404,
+        "message": "Authorization Failed: The resource you're looking for isn't accessible.",
+        "service_payload": {
+            "target_service": None,
+            "status": 404,
+            "code": "code",
+            "opc-request-id": None,
+            "message": "message",
+            "operation_name": None,
+            "timestamp": None,
+            "client_version": None,
+            "request_endpoint": None,
+            "logging_tips": "To get more info on the failing request, refer to https://docs.oracle.com/en-us/iaas/tools/python/latest/logging.html for ways to log the request/response details.",
+            "troubleshooting_tips": "See https://docs.oracle.com/iaas/Content/API/References/apierrors.htm#apierrors_404__404_code for more information about resolving this error. If you are unable to resolve this None issue, please contact Oracle support and provide them this full error message.",
+        },
+        "reason": "message",
+        "request_id": "1234",
+    }
+
+
+class TestAquaDecorators(TestCase):
+    """Tests the all aqua common decorators."""
+
+    @patch.object(IPythonHandler, "__init__")
+    def setUp(self, ipython_init_mock) -> None:
+        ipython_init_mock.return_value = None
+        self.test_instance = AquaAPIhandler(MagicMock(), MagicMock())
+        self.test_instance.finish = MagicMock()
+        self.test_instance.set_header = MagicMock()
+        self.test_instance.set_status = MagicMock()
+
+    @parameterized.expand(
+        [
+            (
+                ServiceError(status=501, code="code", message="message", headers={}),
+                {
+                    "status": 501,
+                    "message": "Unknown HTTP Error.",
+                    "service_payload": {
+                        "target_service": None,
+                        "status": 501,
+                        "code": "code",
+                        "opc-request-id": None,
+                        "message": "message",
+                        "operation_name": None,
+                        "timestamp": None,
+                        "client_version": None,
+                        "request_endpoint": None,
+                        "logging_tips": "To get more info on the failing request, refer to https://docs.oracle.com/en-us/iaas/tools/python/latest/logging.html for ways to log the request/response details.",
+                        "troubleshooting_tips": "See https://docs.oracle.com/iaas/Content/API/References/apierrors.htm#apierrors_501__501_code for more information about resolving this error. If you are unable to resolve this None issue, please contact Oracle support and provide them this full error message.",
+                    },
+                    "reason": "message",
+                    "request_id": "1234",
+                },
+            ),
+            (
+                ConfigFileNotFound(),
+                {
+                    "status": 400,
+                    "message": "Something went wrong with your request.",
+                    "service_payload": {},
+                    "reason": "ConfigFileNotFound: ",
+                    "request_id": TestDataset.mock_request_id,
+                },
+            ),
+            (
+                MissingEndpointForNonRegionalServiceClientError(
+                    "An endpoint must be provided for a non-regional service client"
+                ),
+                {
+                    "status": 400,
+                    "message": "Something went wrong with your request.",
+                    "service_payload": {},
+                    "reason": "MissingEndpointForNonRegionalServiceClientError: An endpoint must be provided for a non-regional service client",
+                    "request_id": TestDataset.mock_request_id,
+                },
+            ),
+            (
+                RequestException("An exception occurred when making the request"),
+                {
+                    "status": 400,
+                    "message": "Something went wrong with your request.",
+                    "service_payload": {},
+                    "reason": "RequestException: An exception occurred when making the request",
+                    "request_id": TestDataset.mock_request_id,
+                },
+            ),
+            (
+                ConnectTimeout(
+                    "The request timed out while trying to connect to the remote server."
+                ),
+                {
+                    "status": 408,
+                    "message": "Server is taking too long to response, please try again.",
+                    "service_payload": {},
+                    "reason": "ConnectTimeout: The request timed out while trying to connect to the remote server.",
+                    "request_id": TestDataset.mock_request_id,
+                },
+            ),
+            (
+                MultipartUploadError(),
+                {
+                    "status": 500,
+                    "message": "An error occurred while creating the resource.",
+                    "service_payload": {},
+                    "reason": "MultipartUploadError: MultipartUploadError exception has occured. Client Version: Oracle-PythonSDK/2.124.1, OS Version: macOS-14.3-arm64-arm-64bit, See https://docs.oracle.com/iaas/Content/API/Concepts/sdk_troubleshooting.htm for common issues and steps to resolve them. If you need to contact support, or file a GitHub issue, please include this full error message.",
+                    "request_id": TestDataset.mock_request_id,
+                },
+            ),
+            (
+                CompositeOperationError(),
+                {
+                    "status": 500,
+                    "message": "An error occurred while creating the resource.",
+                    "service_payload": {},
+                    "reason": "CompositeOperationError: ",
+                    "request_id": TestDataset.mock_request_id,
+                },
+            ),
+            (
+                AquaError(reason="This is test.", status=403, service_payload={}),
+                {
+                    "status": 403,
+                    "message": "We're having trouble processing your request with the information provided.",
+                    "service_payload": {},
+                    "reason": "This is test.",
+                    "request_id": TestDataset.mock_request_id,
+                },
+            ),
+            (
+                HTTPError(400, "The request `/test` is invalid."),
+                {
+                    "status": 400,
+                    "message": "The request `/test` is invalid.",
+                    "service_payload": {},
+                    "reason": "The request `/test` is invalid.",
+                    "request_id": TestDataset.mock_request_id,
+                },
+            ),
+            (
+                ValueError("This is test."),
+                {
+                    "status": 500,
+                    "message": "An error occurred while creating the resource.",
+                    "service_payload": {},
+                    "reason": "ValueError: This is test.",
+                    "request_id": TestDataset.mock_request_id,
+                },
+            ),
+        ]
+    )
+    @patch("uuid.uuid4")
+    def test_handle_exceptions(self, error, expected_reply, mock_uuid):
+        """Tests handling error decorator."""
+        from ads.aqua.decorator import handle_exceptions
+
+        mock_uuid.return_value = TestDataset.mock_request_id
+        expected_call = json.dumps(expected_reply)
+
+        @handle_exceptions
+        def mock_function(self):
+            raise error
+
+        mock_function(self.test_instance)
+
+        self.test_instance.finish.assert_called_with(expected_call)

--- a/tests/unitary/with_extras/aqua/test_decorator.py
+++ b/tests/unitary/with_extras/aqua/test_decorator.py
@@ -27,26 +27,6 @@ from ads.aqua.extension.base_handler import AquaAPIhandler
 
 class TestDataset:
     mock_request_id = "1234"
-    mock_service_error = dict(status=501, code="code", message="message", headers={})
-    mock_service_error_reply = {
-        "status": 404,
-        "message": "Authorization Failed: The resource you're looking for isn't accessible.",
-        "service_payload": {
-            "target_service": None,
-            "status": 404,
-            "code": "code",
-            "opc-request-id": None,
-            "message": "message",
-            "operation_name": None,
-            "timestamp": None,
-            "client_version": None,
-            "request_endpoint": None,
-            "logging_tips": "To get more info on the failing request, refer to https://docs.oracle.com/en-us/iaas/tools/python/latest/logging.html for ways to log the request/response details.",
-            "troubleshooting_tips": "See https://docs.oracle.com/iaas/Content/API/References/apierrors.htm#apierrors_404__404_code for more information about resolving this error. If you are unable to resolve this None issue, please contact Oracle support and provide them this full error message.",
-        },
-        "reason": "message",
-        "request_id": "1234",
-    }
 
 
 class TestAquaDecorators(TestCase):
@@ -81,7 +61,7 @@ class TestAquaDecorators(TestCase):
                         "troubleshooting_tips": "See https://docs.oracle.com/iaas/Content/API/References/apierrors.htm#apierrors_501__501_code for more information about resolving this error. If you are unable to resolve this None issue, please contact Oracle support and provide them this full error message.",
                     },
                     "reason": "message",
-                    "request_id": "1234",
+                    "request_id": TestDataset.mock_request_id,
                 },
             ),
             (
@@ -149,12 +129,12 @@ class TestAquaDecorators(TestCase):
                 },
             ),
             (
-                AquaError(reason="This is test.", status=403, service_payload={}),
+                AquaError(reason="Mocking AQUA error.", status=403, service_payload={}),
                 {
                     "status": 403,
                     "message": "We're having trouble processing your request with the information provided.",
                     "service_payload": {},
-                    "reason": "This is test.",
+                    "reason": "Mocking AQUA error.",
                     "request_id": TestDataset.mock_request_id,
                 },
             ),
@@ -169,12 +149,12 @@ class TestAquaDecorators(TestCase):
                 },
             ),
             (
-                ValueError("This is test."),
+                ValueError("Mocking ADS internal error."),
                 {
                     "status": 500,
                     "message": "An error occurred while creating the resource.",
                     "service_payload": {},
-                    "reason": "ValueError: This is test.",
+                    "reason": "ValueError: Mocking ADS internal error.",
                     "request_id": TestDataset.mock_request_id,
                 },
             ),

--- a/tests/unitary/with_extras/aqua/test_decorator.py
+++ b/tests/unitary/with_extras/aqua/test_decorator.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 from notebook.base.handlers import IPythonHandler
 from oci.exceptions import (
+    UPLOAD_MANAGER_DEBUG_INFORMATION_LOG,
     CompositeOperationError,
     ConfigFileNotFound,
     ConnectTimeout,
@@ -44,35 +45,40 @@ class TestAquaDecorators(TestCase):
         [
             [
                 "oci ServiceError",
-                ServiceError(status=501, code="code", message="message", headers={}),
+                ServiceError(
+                    status=500,
+                    code="InternalError",
+                    message="An internal error occurred.",
+                    headers={},
+                ),
                 {
-                    "status": 501,
-                    "message": "Unknown HTTP Error.",
+                    "status": 500,
+                    "message": "An internal error occurred.",
                     "service_payload": {
                         "target_service": None,
-                        "status": 501,
-                        "code": "code",
+                        "status": 500,
+                        "code": "InternalError",
                         "opc-request-id": None,
-                        "message": "message",
+                        "message": "An internal error occurred.",
                         "operation_name": None,
                         "timestamp": None,
                         "client_version": None,
                         "request_endpoint": None,
                         "logging_tips": "To get more info on the failing request, refer to https://docs.oracle.com/en-us/iaas/tools/python/latest/logging.html for ways to log the request/response details.",
-                        "troubleshooting_tips": "See https://docs.oracle.com/iaas/Content/API/References/apierrors.htm#apierrors_501__501_code for more information about resolving this error. If you are unable to resolve this None issue, please contact Oracle support and provide them this full error message.",
+                        "troubleshooting_tips": "See https://docs.oracle.com/iaas/Content/API/References/apierrors.htm#apierrors_500__500_internalerror for more information about resolving this error. If you are unable to resolve this None issue, please contact Oracle support and provide them this full error message.",
                     },
-                    "reason": "message",
+                    "reason": "An internal error occurred.",
                     "request_id": TestDataset.mock_request_id,
                 },
             ],
             [
                 "oci ClientError",
-                ConfigFileNotFound(),
+                ConfigFileNotFound("Could not find config file at the given path."),
                 {
                     "status": 400,
                     "message": "Something went wrong with your request.",
                     "service_payload": {},
-                    "reason": "ConfigFileNotFound: ",
+                    "reason": "ConfigFileNotFound: Could not find config file at the given path.",
                     "request_id": TestDataset.mock_request_id,
                 },
             ],
@@ -118,9 +124,9 @@ class TestAquaDecorators(TestCase):
                 MultipartUploadError(),
                 {
                     "status": 500,
-                    "message": "An error occurred while creating the resource.",
+                    "message": "Internal Server Error",
                     "service_payload": {},
-                    "reason": "MultipartUploadError: MultipartUploadError exception has occured. Client Version: Oracle-PythonSDK/2.124.1, OS Version: macOS-14.3-arm64-arm-64bit, See https://docs.oracle.com/iaas/Content/API/Concepts/sdk_troubleshooting.htm for common issues and steps to resolve them. If you need to contact support, or file a GitHub issue, please include this full error message.",
+                    "reason": f"MultipartUploadError: MultipartUploadError exception has occured. {UPLOAD_MANAGER_DEBUG_INFORMATION_LOG}",
                     "request_id": TestDataset.mock_request_id,
                 },
             ],
@@ -129,7 +135,7 @@ class TestAquaDecorators(TestCase):
                 CompositeOperationError(),
                 {
                     "status": 500,
-                    "message": "An error occurred while creating the resource.",
+                    "message": "Internal Server Error",
                     "service_payload": {},
                     "reason": "CompositeOperationError: ",
                     "request_id": TestDataset.mock_request_id,
@@ -162,7 +168,7 @@ class TestAquaDecorators(TestCase):
                 ValueError("Mocking ADS internal error."),
                 {
                     "status": 500,
-                    "message": "An error occurred while creating the resource.",
+                    "message": "Internal Server Error",
                     "service_payload": {},
                     "reason": "ValueError: Mocking ADS internal error.",
                     "request_id": TestDataset.mock_request_id,

--- a/tests/unitary/with_extras/aqua/test_decorator.py
+++ b/tests/unitary/with_extras/aqua/test_decorator.py
@@ -42,7 +42,8 @@ class TestAquaDecorators(TestCase):
 
     @parameterized.expand(
         [
-            (
+            [
+                "oci ServiceError",
                 ServiceError(status=501, code="code", message="message", headers={}),
                 {
                     "status": 501,
@@ -63,8 +64,9 @@ class TestAquaDecorators(TestCase):
                     "reason": "message",
                     "request_id": TestDataset.mock_request_id,
                 },
-            ),
-            (
+            ],
+            [
+                "oci ClientError",
                 ConfigFileNotFound(),
                 {
                     "status": 400,
@@ -73,8 +75,9 @@ class TestAquaDecorators(TestCase):
                     "reason": "ConfigFileNotFound: ",
                     "request_id": TestDataset.mock_request_id,
                 },
-            ),
-            (
+            ],
+            [
+                "oci MissingEndpointForNonRegionalServiceClientError",
                 MissingEndpointForNonRegionalServiceClientError(
                     "An endpoint must be provided for a non-regional service client"
                 ),
@@ -85,8 +88,9 @@ class TestAquaDecorators(TestCase):
                     "reason": "MissingEndpointForNonRegionalServiceClientError: An endpoint must be provided for a non-regional service client",
                     "request_id": TestDataset.mock_request_id,
                 },
-            ),
-            (
+            ],
+            [
+                "oci RequestException",
                 RequestException("An exception occurred when making the request"),
                 {
                     "status": 400,
@@ -95,8 +99,9 @@ class TestAquaDecorators(TestCase):
                     "reason": "RequestException: An exception occurred when making the request",
                     "request_id": TestDataset.mock_request_id,
                 },
-            ),
-            (
+            ],
+            [
+                "oci ConnectTimeout",
                 ConnectTimeout(
                     "The request timed out while trying to connect to the remote server."
                 ),
@@ -107,8 +112,9 @@ class TestAquaDecorators(TestCase):
                     "reason": "ConnectTimeout: The request timed out while trying to connect to the remote server.",
                     "request_id": TestDataset.mock_request_id,
                 },
-            ),
-            (
+            ],
+            [
+                "oci MultipartUploadError",
                 MultipartUploadError(),
                 {
                     "status": 500,
@@ -117,8 +123,9 @@ class TestAquaDecorators(TestCase):
                     "reason": "MultipartUploadError: MultipartUploadError exception has occured. Client Version: Oracle-PythonSDK/2.124.1, OS Version: macOS-14.3-arm64-arm-64bit, See https://docs.oracle.com/iaas/Content/API/Concepts/sdk_troubleshooting.htm for common issues and steps to resolve them. If you need to contact support, or file a GitHub issue, please include this full error message.",
                     "request_id": TestDataset.mock_request_id,
                 },
-            ),
-            (
+            ],
+            [
+                "oci CompositeOperationError",
                 CompositeOperationError(),
                 {
                     "status": 500,
@@ -127,8 +134,9 @@ class TestAquaDecorators(TestCase):
                     "reason": "CompositeOperationError: ",
                     "request_id": TestDataset.mock_request_id,
                 },
-            ),
-            (
+            ],
+            [
+                "AquaError",
                 AquaError(reason="Mocking AQUA error.", status=403, service_payload={}),
                 {
                     "status": 403,
@@ -137,8 +145,9 @@ class TestAquaDecorators(TestCase):
                     "reason": "Mocking AQUA error.",
                     "request_id": TestDataset.mock_request_id,
                 },
-            ),
-            (
+            ],
+            [
+                "HTTPError",
                 HTTPError(400, "The request `/test` is invalid."),
                 {
                     "status": 400,
@@ -147,8 +156,9 @@ class TestAquaDecorators(TestCase):
                     "reason": "The request `/test` is invalid.",
                     "request_id": TestDataset.mock_request_id,
                 },
-            ),
-            (
+            ],
+            [
+                "ADS Error",
                 ValueError("Mocking ADS internal error."),
                 {
                     "status": 500,
@@ -157,11 +167,11 @@ class TestAquaDecorators(TestCase):
                     "reason": "ValueError: Mocking ADS internal error.",
                     "request_id": TestDataset.mock_request_id,
                 },
-            ),
+            ],
         ]
     )
     @patch("uuid.uuid4")
-    def test_handle_exceptions(self, error, expected_reply, mock_uuid):
+    def test_handle_exceptions(self, name, error, expected_reply, mock_uuid):
         """Tests handling error decorator."""
         from ads.aqua.decorator import handle_exceptions
 

--- a/tests/unitary/with_extras/aqua/test_evaluation_handler.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation_handler.py
@@ -68,9 +68,6 @@ class TestEvaluationHandler(unittest.TestCase):
             (dict(return_value=None), 400, Errors.NO_INPUT_DATA),
         ]
     )
-    @unittest.skip(
-        "Need a fix in `handle_exceptions` decorator before enabling this test."
-    )
     def test_post_fail(
         self, mock_get_json_body_response, expected_status_code, expected_error_msg
     ):
@@ -87,6 +84,7 @@ class TestEvaluationHandler(unittest.TestCase):
             self.test_instance.write_error.call_args[1].get("status_code")
             == expected_status_code
         ), "Raised wrong status code."
+
         assert expected_error_msg in self.test_instance.write_error.call_args[1].get(
             "reason"
         ), "Error message is incorrect."


### PR DESCRIPTION
# Description
This PR aims to improve handling error. 

# Changed 
* Handle HTTPError in `handle_exception` decorator
* Add test for decorator
* Move decorator to GET/POST/PUT/DELETE method in handler
* Add name in each test for better tracing what being test
* As we are using tornado framework, tornado's HTTPError should be used instead of requests.HTTPError


# Test
<img width="1512" alt="Screenshot 2024-04-17 at 15 53 37" src="https://github.com/oracle/accelerated-data-science/assets/49049296/e7fac656-fd01-4065-98b8-fc89800c8b10">
<img width="1510" alt="Screenshot 2024-04-17 at 15 53 45" src="https://github.com/oracle/accelerated-data-science/assets/49049296/6dc245a2-51c4-4b7e-a964-aabfd48deb84">
