### PR TITLE
Add test cases for checking content decoding

### DIFF
--- a/tests/unitary/with_extras/aqua/test_data/valid_eval_artifact/report.html
+++ b/tests/unitary/with_extras/aqua/test_data/valid_eval_artifact/report.html
@@ -1,1 +1,2 @@
 This is a sample evaluation report.html.
+Standard deviation (σ)

--- a/tests/unitary/with_extras/aqua/test_evaluation.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation.py
@@ -624,9 +624,10 @@ class TestAquaEvaluation(unittest.TestCase):
         mock_dsc_model_from_id.assert_called_with(TestDataset.EVAL_ID)
         self.print_expected_response(response, "DOWNLOAD REPORT")
         self.assert_payload(response, AquaEvalReport)
-        read_content = base64.b64decode(response.content)
+        read_content = base64.b64decode(response.content).decode()
         assert (
-            read_content == b"This is a sample evaluation report.html.\n"
+            read_content
+            == "This is a sample evaluation report.html.\nStandard deviation (σ)"
         ), read_content
         assert self.app._report_cache.currsize == 1
 

--- a/tests/unitary/with_extras/aqua/test_evaluation.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation.py
@@ -627,7 +627,7 @@ class TestAquaEvaluation(unittest.TestCase):
         read_content = base64.b64decode(response.content).decode()
         assert (
             read_content
-            == "This is a sample evaluation report.html.\nStandard deviation (σ)"
+            == "This is a sample evaluation report.html.\nStandard deviation (σ)\n"
         ), read_content
         assert self.app._report_cache.currsize == 1
 


### PR DESCRIPTION
Add test case for evaluation download_report based on the finding from investigating evaluation report rendering error. Validating that special character can also be handled well. 