### PR TITLE
[ODSC-55947] Update CLI docstrings

### DIFF
--- a/ads/aqua/evaluation.py
+++ b/ads/aqua/evaluation.py
@@ -380,10 +380,31 @@ class AquaEvaluationApp(AquaApp):
         ----------
         create_aqua_evaluation_details: CreateAquaEvaluationDetails
             The CreateAquaEvaluationDetails data class which contains all
-            required and optional fields to create the aqua evaluation.
+            required and optional fields to create the aqua evaluation, if accessing via jupyter extension.
         kwargs:
-            The kwargs for creating CreateAquaEvaluationDetails instance if
-            no create_aqua_evaluation_details provided.
+            The kwargs for creating CreateAquaEvaluationDetails instance if accessing via CLI.\n
+            --evaluation_source_id [str]: The evaluation source id. Must be model deployment OCID.\n
+            --evaluation_name [str]: The name for evaluation.\n
+            --dataset_path [str]: The dataset path for the evaluation. Must be an object storage path.\n
+            --report_path [str]: The report path for the evaluation. Must be an object storage path.\n
+            --model_parameters [str]: The parameters for the evaluation.\n
+            --shape_name [str]: The shape name for the evaluation job infrastructure.\n
+            --block_storage_size [int]: The storage for the evaluation job infrastructure.\n
+            --metrics [list]: The metrics for the evaluation, currently BERTScore, ROGUE and BLEU are supported.\n
+            --compartment_id [Optional, str]: The compartment OCID where evaluation is to be created. If not provided,
+            then it defaults to user's compartment.\n
+            --project_id [Optional, str]: The project OCID where evaluation is to be created. If not provided, then it
+            defaults to user's project.\n
+            --evaluation_description [Optional, str]: The description of the evaluation. Defaults to None.\n
+            --memory_in_gbs [Optional, float]: The memory in gbs for the flexible shape selected.\n
+            --ocpus [Optional, float]: The ocpu count for the shape selected.\n
+            --experiment_id [Optional, str]: The evaluation model version set id. If provided, evaluation model will be
+            associated with it. Defaults to None.\n
+            --experiment_name [Optional, str]: The evaluation model version set name. If provided, the model version set
+             with the same name will be used if exists, otherwise a new model version set will be created with the name.\n
+            --experiment_description [Optional, str]: The description for the evaluation model version set.\n
+            --log_group_id [Optional, str]: The log group id for the evaluation job infrastructure. Defaults to None.\n
+            --log_id [Optional, str]: The log id for the evaluation job infrastructure. Defaults to None.\n
 
         Returns
         -------

--- a/ads/aqua/finetune.py
+++ b/ads/aqua/finetune.py
@@ -176,10 +176,34 @@ class AquaFineTuningApp(AquaApp):
         ----------
         create_fine_tuning_details: CreateFineTuningDetails
             The CreateFineTuningDetails data class which contains all
-            required and optional fields to create the aqua fine tuning.
+            required and optional fields to create the aqua fine-tuned model, if accessing via jupyter extension.
         kwargs:
-            The kwargs for creating CreateFineTuningDetails instance if
-            no create_fine_tuning_details provided.
+            The kwargs for creating CreateFineTuningDetails instance if accessing via CLI.\n
+            --ft_source_id [str]: The fine-tuning source id. Must be foundational model OCID.\n
+            --ft_name [str]: The name for the fine-tuned model.\n
+            --dataset_path [str]: The dataset path for the model fine-tuning. Must be an object storage path.\n
+            --report_path [str]: The report path of the fine-tuned model. Must be an object storage path.\n
+            --ft_parameters [dict]: The parameters for model fine-tuning. Currently, user can configure learning rate
+            and number of epochs.\n
+            --shape_name [str]: The shape name for the model fine-tuning job infrastructure.\n
+            --replica [int]: The replica count for the model fine-tuning job runtime.\n
+            --validation_set_size [float]: The validation set size for fine-tuning job. Must be a float in
+            between [0,1).\n
+            --compartment_id [Optional, str]: The compartment OCID where evaluation is to be created. If not provided,
+            then it defaults to user's compartment.\n
+            --project_id [Optional, str]: The project OCID where evaluation is to be created. If not provided,
+            then it defaults to user's project.\n
+            --ft_description [Optional, str]: The description of the fine-tuned model. Defaults to None.\n
+            --experiment_id [Optional, str]: The fine-tuned model version set id. If provided, evaluation model
+            will be associated with it. Defaults to None.\n
+            --experiment_name [Optional, str]: The fine-tuned model version set name. If provided, the
+            model version set with the same name will be used if exists, otherwise a new model version set will be
+            created with the name.\n
+            --experiment_description [Optional, str]: The description for the fine-tuned model version set.\n
+            --block_storage_size [Optional, int]: The storage for the model fine-tuning job infrastructure.\n
+            --subnet_id [Optional, str]: The custom egress for model fine-tuning job. Defaults to None.\n
+            --log_group_id [Optional, str]: The log group id for the evaluation job infrastructure. Defaults to None.\n
+            --log_id [Optional, str]: The log id for the evaluation job infrastructure. Defaults to None.\n
 
         Returns
         -------

--- a/ads/aqua/model.py
+++ b/ads/aqua/model.py
@@ -657,16 +657,17 @@ class AquaModelApp(AquaApp):
     ) -> List["AquaModelSummary"]:
         """Lists all Aqua models within a specified compartment and/or project.
         If `compartment_id` is not specified, the method defaults to returning
-        the service models within the pre-configured default compartment. By default, the list
-        of models in the service compartment are cached. Use clear_model_list_cache() to invalidate
+        the service models within the pre-configured default compartment. If accessing via jupyter extension,
+        the list of models in the service compartment are cached. Use clear_model_list_cache() to invalidate
         the cache.
 
         Parameters
         ----------
         compartment_id: (str, optional). Defaults to `None`.
-            The compartment OCID.
+            The ID of the compartment in which the aqua models are available. If not provided, resources are list
+             from the service compartment identified by the environment variable ODSC_MODEL_COMPARTMENT_OCID.
         project_id: (str, optional). Defaults to `None`.
-            The project OCID.
+            The ID of the project in which the aqua models are available.
         **kwargs:
             Additional keyword arguments that can be used to filter the results.
 


### PR DESCRIPTION
### Description
The current CLI docstrings were inadequate for evaluation and fine-tuning, we now add the additional params that will be accessible to the user when they use `--help` option with aqua CLI.


### Output
An example of fine_tuning create help command.
`ads aqua fine_tuning create --help`


```
NAME
    'ads aqua' fine_tuning create - Creates Aqua fine tuning for model.

SYNOPSIS
    'ads aqua' fine_tuning create <flags>

DESCRIPTION
    Creates Aqua fine tuning for model.

FLAGS
    -c, --create_fine_tuning_details=CREATE_FINE_TUNING_DETAILS
        Type: Optional[CreateFineTunin...
        Default: None
        The CreateFineTuningDetails data class which contains all required and optional fields to create the aqua fine-tuned model, if accessing via jupyter extension.
    Additional flags are accepted.
        The kwargs for creating CreateFineTuningDetails instance if accessing via CLI.

        --ft_source_id [str]: The fine-tuning source id. Must be foundational model OCID.

        --ft_name [str]: The name for the fine-tuned model.

        --dataset_path [str]: The dataset path for the model fine-tuning. Must be an object storage path.

        --report_path [str]: The report path of the fine-tuned model. Must be an object storage path.

        --ft_parameters [dict]: The parameters for model fine-tuning. Currently, user can configure learning rate and number of epochs.

        --shape_name [str]: The shape name for the model fine-tuning job infrastructure.

        --replica [int]: The replica count for the model fine-tuning job runtime.

        --validation_set_size [float]: The validation set size for fine-tuning job. Must be a float in between [0,1).

        --compartment_id [Optional, str]: The compartment OCID where evaluation is to be created. If not provided, then it defaults to user's compartment.

        --project_id [Optional, str]: The project OCID where evaluation is to be created. If not provided, then it defaults to user's project.

        --ft_description [Optional, str]: The description of the fine-tuned model. Defaults to None.

        --experiment_id [Optional, str]: The fine-tuned model version set id. If provided, evaluation model will be associated with it. Defaults to None.

        --experiment_name [Optional, str]: The fine-tuned model version set name. If provided, the model version set with the same name will be used if exists, otherwise a new model version set will be created with the name.

        --experiment_description [Optional, str]: The description for the fine-tuned model version set.

        --block_storage_size [Optional, int]: The storage for the model fine-tuning job infrastructure.

        --subnet_id [Optional, str]: The custom egress for model fine-tuning job. Defaults to None.

        --log_group_id [Optional, str]: The log group id for the evaluation job infrastructure. Defaults to None.

        --log_id [Optional, str]: The log id for the evaluation job infrastructure. Defaults to None.
```