### PR TITLE
Graceful exit for aqua cli

### DIFF
--- a/ads/aqua/__init__.py
+++ b/ads/aqua/__init__.py
@@ -41,4 +41,3 @@ if not ODSC_MODEL_COMPARTMENT_OCID:
         logger.error(
             f"Aqua is not available for this notebook session {NB_SESSION_OCID}."
         )
-    exit()

--- a/ads/aqua/cli.py
+++ b/ads/aqua/cli.py
@@ -5,7 +5,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 import os
 
-from ads.aqua import ENV_VAR_LOG_LEVEL, set_log_level
+from ads.aqua import ENV_VAR_LOG_LEVEL, set_log_level, ODSC_MODEL_COMPARTMENT_OCID
 from ads.aqua.deployment import AquaDeploymentApp
 from ads.aqua.evaluation import AquaEvaluationApp
 from ads.aqua.finetune import AquaFineTuningApp
@@ -41,3 +41,6 @@ class AquaCommand:
             'WARNING', 'ERROR', and 'CRITICAL'.
         """
         set_log_level(log_level)
+        # gracefully exit if env var is not set
+        if not ODSC_MODEL_COMPARTMENT_OCID:
+            exit()


### PR DESCRIPTION
### Description

Calling `exit()` in `__init__.py` of AquaCommand causes issues while running independent tests and loading modules, hence `exit()` is moved to AquaCommand.

### Testing
1. Env var is set 
```
> ads aqua model list
{
    "compartment_id": "ocid1.compartment.oc1..<OCID>",
    "icon": "",
...
...
```

2. Env var is not set but `fetch_default_compartment()` picks up default compartment id in the backend.
```
> ODSC_MODEL_COMPARTMENT_OCID="" ads aqua model list
{
    "compartment_id": "ocid1.compartment.oc1..<OCID>",
    "icon": "",
...
...
```

3. Env var is not set and service bucket is set incorrectly, i.e. ODSC_MODEL_COMPARTMENT_OCID is `None`.
```
> ODSC_MODEL_COMPARTMENT_OCID="" AQUA_SERVICE_MODELS_BUCKET="test" ads aqua model list
ERROR:ads.aqua:ODSC_MODEL_COMPARTMENT_OCID environment variable is not set for Aqua.
```



### Unit Tests
```
> python3 -m pytest tests/unitary/with_extras/aqua/test_cli.py
===================================================== test session starts ======================================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0 -- /Users/vmascarenhas/miniconda3/envs/ads-local-v38/bin/python3
cachedir: .pytest_cache
rootdir: /Users/vmascarenhas/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 4 items

tests/unitary/with_extras/aqua/test_cli.py::TestAquaCLI::test_aqua_command_without_compartment_env_var PASSED            [ 25%]
tests/unitary/with_extras/aqua/test_cli.py::TestAquaCLI::test_aquacommand_0_default PASSED                               [ 50%]
tests/unitary/with_extras/aqua/test_cli.py::TestAquaCLI::test_aquacommand_1_set_logging_level PASSED                     [ 75%]
tests/unitary/with_extras/aqua/test_cli.py::TestAquaCLI::test_entrypoint PASSED                                          [100%]

====================================================== 4 passed in 4.80s =======================================================
```