### PR TITLE
Ability to disable packing of dataset in CLI

### DIFF
--- a/ads/aqua/finetune.py
+++ b/ads/aqua/finetune.py
@@ -69,6 +69,7 @@ class FineTuneCustomMetadata(Enum):
 class AquaFineTuningParams(DataClassSerializable):
     epochs: int = None
     learning_rate: float = None
+    sample_packing: str = "True"
 
 
 @dataclass(repr=False)
@@ -562,7 +563,7 @@ class AquaFineTuningApp(AquaApp):
                         }
                     ),
                     "OCI__LAUNCH_CMD": (
-                        f"--micro_batch_size {batch_size} --num_epochs {parameters.epochs} --learning_rate {parameters.learning_rate} --training_data {dataset_path} --output_dir {report_path} --val_set_size {val_set_size} "
+                        f"--micro_batch_size {batch_size} --num_epochs {parameters.epochs} --learning_rate {parameters.learning_rate} --training_data {dataset_path} --output_dir {report_path} --val_set_size {val_set_size} --sample_packing {parameters.sample_packing} "
                         + (f"{finetuning_params}" if finetuning_params else "")
                     ),
                     "CONDA_BUCKET_NS": CONDA_BUCKET_NS,


### PR DESCRIPTION
In certain datasets, the packing of dataset can cause failure during Fine Tuning. By allowing for turning off this option, we can unblock the cases where this occurs. We will enable only CLI for now. We can add more options on UI under advanced section.
We have to move batch_size to AquaFineTuningParms class. 
We also need a method on the dataclass that can automatically turn the parameters to cmd arguments and avoid hard-coding.

Usage - 
```
ads aqua fine_tuning create \
		--ft_source_id $(MODEL_SOURCE) \
		--ft_name $(NAME)-FT \
		--dataset_path  $(DATASET)\
		--report_path $(OUTPUT) \
		--ft_parameters '{"epochs": $(EPOCH), "learning_rate": 0.0002, "sample_packing": "$(SMP_PKG)"}' \
		--shape_name $(SHAPE) \
		--replica $(REPLICA) \
		--validation_set_size 0.1 \
		--subnet_id $(SUBNET)\
		--log_group_id $(LOGGRP) \
		--log_id $(LOG) \
		--experiment_id $(MVS) \
		--compartment_id $(COMPARTMENT)```