### PR TITLE
Upgraded oci version to support md custom egress.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
   "jinja2>=2.11.2",
   "matplotlib>=3.1.3",
   "numpy>=1.19.2",
-  "oci>=2.113.0",
+  "oci>=2.125.3",
   "ocifs>=1.1.3",
   "pandas>1.2.1; python_version<'3.9'", # starting pandas v2.1.0 requires-python = '>=3.9'
   "pandas>=2.2.0; python_version>='3.9'",


### PR DESCRIPTION
### Upgraded oci version to support md custom egress

- Upgraded oci version to [2.125.3](https://github.com/oracle/oci-python-sdk/releases/tag/v2.125.3)