### PR TITLE
Signer exception fix v2.11.9

### DIFF
--- a/ads/aqua/utils.py
+++ b/ads/aqua/utils.py
@@ -582,7 +582,7 @@ def fetch_service_compartment() -> Union[str, None]:
             file_path=config_file_name,
             config_file_name=CONTAINER_INDEX,
         )
-    except AquaFileNotFoundError:
+    except Exception:
         logger.error(
             f"Config file {config_file_name}/{CONTAINER_INDEX} to fetch service compartment OCID could not be found."
         )

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,13 @@
 Release Notes
 =============
 
+2.11.9
+------
+Release date: April 24, 2024
+
+* Fixed bugs and introduced enhancements following our recent release.
+
+
 2.11.8
 ------
 Release date: April 24, 2024

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "flit_core.buildapi"
 
 # Required
 name = "oracle_ads" # the install (PyPI) name; name for local build in [tool.flit.module] section below
-version = "2.11.8"
+version = "2.11.9"
 
 # Optional
 description = "Oracle Accelerated Data Science SDK"


### PR DESCRIPTION
### Description

The jupyter build fails as the default_signer() throws an `oci.exceptions.ConfigFileNotFound`. The `load_config` inside `fetch_service_compartment` has been updated to catch all generic exceptions.

