### PR TITLE
AQUA CLI: Improve handling error and Add new flags 

### DIFF
--- a/ads/aqua/cli.py
+++ b/ads/aqua/cli.py
@@ -93,7 +93,9 @@ class AquaCommand:
                     f"Aqua is not available for the notebook session {NB_SESSION_OCID}. For more information, "
                     f"please refer to the documentation."
                 )
-            sys.exit(1)
+            raise AquaCLIError(
+                "ODSC_MODEL_COMPARTMENT_OCID environment variable is not set for Aqua."
+            )
 
     @staticmethod
     def _validate_value(flag, value):

--- a/ads/aqua/cli.py
+++ b/ads/aqua/cli.py
@@ -4,7 +4,6 @@
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 import os
-import sys
 
 from ads.aqua import (
     ENV_VAR_LOG_LEVEL,
@@ -14,14 +13,11 @@ from ads.aqua import (
 )
 from ads.aqua.deployment import AquaDeploymentApp
 from ads.aqua.evaluation import AquaEvaluationApp
+from ads.aqua.exception import AquaCLIError, AquaConfigError
 from ads.aqua.finetune import AquaFineTuningApp
 from ads.aqua.model import AquaModelApp
 from ads.common.utils import LOG_LEVELS
 from ads.config import NB_SESSION_OCID
-
-
-class AquaCLIError(Exception):
-    exit_code = 1
 
 
 class AquaCommand:
@@ -57,16 +53,18 @@ class AquaCommand:
             Sets the logging level for the application to `DEBUG`.
         verbose (bool):
             Sets the logging level for the application to `INFO`.
+
+        Raises
+        ------
+        AquaCLIError:
+            When `--verbose` and `--debug` being used together.
+            When missing required `ODSC_MODEL_COMPARTMENT_OCID` env var.
         """
         if verbose is not None and debug is not None:
-            logger.error(
+            raise AquaCLIError(
                 "Cannot use `--debug` and `--verbose` at the same time. "
                 "Please select either `--debug` for `DEBUG` level logging or "
                 "`--verbose` for `INFO` level logging."
-            )
-            # Raise exception? then use decorator in fire.Fire() to catch error and exit with corresponding code.
-            raise AquaCLIError(
-                "Cannot use `--debug` and `--verbose` at the same time. "
             )
         elif verbose is not None:
             self._validate_value("--verbose", verbose)
@@ -76,36 +74,36 @@ class AquaCommand:
             aqua_log_level = "DEBUG"
         else:
             if log_level.upper() not in LOG_LEVELS:
-                logger.error(
+                logger.warning(
                     f"Log level should be one of {LOG_LEVELS}. Setting default to ERROR."
                 )
                 log_level = "ERROR"
             aqua_log_level = log_level
 
         set_log_level(aqua_log_level)
-        # gracefully exit if env var is not set
+
         if not ODSC_MODEL_COMPARTMENT_OCID:
-            logger.debug(
-                "ODSC_MODEL_COMPARTMENT_OCID environment variable is not set for Aqua."
-            )
             if NB_SESSION_OCID:
-                logger.error(
+                raise AquaConfigError(
                     f"Aqua is not available for the notebook session {NB_SESSION_OCID}. For more information, "
                     f"please refer to the documentation."
                 )
-            raise AquaCLIError(
+            raise AquaConfigError(
                 "ODSC_MODEL_COMPARTMENT_OCID environment variable is not set for Aqua."
             )
 
     @staticmethod
     def _validate_value(flag, value):
-        """Check if the given value for bool flag is valid."""
+        """Check if the given value for bool flag is valid.
+
+        Raises
+        ------
+        AquaCLIError:
+            When the given value for bool flag is invalid.
+        """
         if value not in [True, False]:
-            logger.error(
+            raise AquaCLIError(
                 f"Invalid input `{value}` for flag: {flag}, a boolean value is required. "
                 "If you intend to chain a function call to the result, please separate the "
                 "flag and the subsequent function call with separator `-`."
-            )
-            raise AquaCLIError(
-                f"Invalid input `{value}` for flag: {flag}, A boolean value is required. "
             )

--- a/ads/aqua/cli.py
+++ b/ads/aqua/cli.py
@@ -8,16 +8,16 @@ import sys
 
 from ads.aqua import (
     ENV_VAR_LOG_LEVEL,
-    set_log_level,
     ODSC_MODEL_COMPARTMENT_OCID,
     logger,
+    set_log_level,
 )
 from ads.aqua.deployment import AquaDeploymentApp
 from ads.aqua.evaluation import AquaEvaluationApp
 from ads.aqua.finetune import AquaFineTuningApp
 from ads.aqua.model import AquaModelApp
-from ads.config import NB_SESSION_OCID
 from ads.common.utils import LOG_LEVELS
+from ads.config import NB_SESSION_OCID
 
 
 class AquaCommand:
@@ -44,7 +44,7 @@ class AquaCommand:
         -----
         log_level (str):
             Sets the logging level for the application.
-            Default is retrieved from environment variable `LOG_LEVEL`,
+            Default is retrieved from environment variable `ADS_AQUA_LOG_LEVEL`,
             or 'ERROR' if not set. Example values include 'DEBUG', 'INFO',
             'WARNING', 'ERROR', and 'CRITICAL'.
         """

--- a/ads/aqua/cli.py
+++ b/ads/aqua/cli.py
@@ -20,6 +20,10 @@ from ads.common.utils import LOG_LEVELS
 from ads.config import NB_SESSION_OCID
 
 
+class AquaCLIError(Exception):
+    exit_code = 1
+
+
 class AquaCommand:
     """Contains the command groups for project Aqua.
 
@@ -35,6 +39,8 @@ class AquaCommand:
 
     def __init__(
         self,
+        debug: bool = None,
+        verbose: bool = None,
         log_level: str = os.environ.get(ENV_VAR_LOG_LEVEL, "ERROR").upper(),
     ):
         """
@@ -47,13 +53,36 @@ class AquaCommand:
             Default is retrieved from environment variable `ADS_AQUA_LOG_LEVEL`,
             or 'ERROR' if not set. Example values include 'DEBUG', 'INFO',
             'WARNING', 'ERROR', and 'CRITICAL'.
+        debug (bool):
+            Sets the logging level for the application to `DEBUG`.
+        verbose (bool):
+            Sets the logging level for the application to `INFO`.
         """
-        if log_level.upper() not in LOG_LEVELS:
+        if verbose is not None and debug is not None:
             logger.error(
-                f"Log level should be one of {LOG_LEVELS}. Setting default to ERROR."
+                "Cannot use `--debug` and `--verbose` at the same time. "
+                "Please select either `--debug` for `DEBUG` level logging or "
+                "`--verbose` for `INFO` level logging."
             )
-            log_level = "ERROR"
-        set_log_level(log_level)
+            # Raise exception? then use decorator in fire.Fire() to catch error and exit with corresponding code.
+            raise AquaCLIError(
+                "Cannot use `--debug` and `--verbose` at the same time. "
+            )
+        elif verbose is not None:
+            self._validate_value("--verbose", verbose)
+            aqua_log_level = "INFO"
+        elif debug is not None:
+            self._validate_value("--debug", debug)
+            aqua_log_level = "DEBUG"
+        else:
+            if log_level.upper() not in LOG_LEVELS:
+                logger.error(
+                    f"Log level should be one of {LOG_LEVELS}. Setting default to ERROR."
+                )
+                log_level = "ERROR"
+            aqua_log_level = log_level
+
+        set_log_level(aqua_log_level)
         # gracefully exit if env var is not set
         if not ODSC_MODEL_COMPARTMENT_OCID:
             logger.debug(
@@ -65,3 +94,16 @@ class AquaCommand:
                     f"please refer to the documentation."
                 )
             sys.exit(1)
+
+    @staticmethod
+    def _validate_value(flag, value):
+        """Check if the given value for bool flag is valid."""
+        if value not in [True, False]:
+            logger.error(
+                f"Invalid input `{value}` for flag: {flag}, a boolean value is required. "
+                "If you intend to chain a function call to the result, please separate the "
+                "flag and the subsequent function call with separator `-`."
+            )
+            raise AquaCLIError(
+                f"Invalid input `{value}` for flag: {flag}, A boolean value is required. "
+            )

--- a/ads/aqua/cli.py
+++ b/ads/aqua/cli.py
@@ -78,7 +78,7 @@ class AquaCommand:
                     f"Log level should be one of {LOG_LEVELS}. Setting default to ERROR."
                 )
                 log_level = "ERROR"
-            aqua_log_level = log_level
+            aqua_log_level = log_level.upper()
 
         set_log_level(aqua_log_level)
 

--- a/ads/aqua/exception.py
+++ b/ads/aqua/exception.py
@@ -105,3 +105,6 @@ class AquaCLIError(AquaError):
     """Exception raised when AQUA CLI encounter error."""
 
     exit_code = ExitCode.COMMON_ERROR.value
+
+    def __init__(self, reason, status=None, service_payload=None):
+        super().__init__(reason, status, service_payload)

--- a/ads/aqua/exception.py
+++ b/ads/aqua/exception.py
@@ -10,6 +10,14 @@ aqua.exception
 This module contains the set of Aqua exceptions.
 """
 
+from ads.common.extended_enum import ExtendedEnum
+
+
+class ExitCode(ExtendedEnum):
+    SUCCESS = 0
+    COMMON_ERROR = 1
+    INVALID_CONFIG = 10
+
 
 class AquaError(Exception):
     """AquaError
@@ -17,6 +25,8 @@ class AquaError(Exception):
     The base exception from which all exceptions raised by Aqua
     will inherit.
     """
+
+    exit_code = 1
 
     def __init__(
         self,
@@ -80,3 +90,18 @@ class AquaResourceAccessError(AquaError):
 
     def __init__(self, reason, status=404, service_payload=None):
         super().__init__(reason, status, service_payload)
+
+
+class AquaConfigError(AquaError):
+    """Exception raised when config for AQUA is invalid."""
+
+    exit_code = ExitCode.INVALID_CONFIG.value
+
+    def __init__(self, reason, status=404, service_payload=None):
+        super().__init__(reason, status, service_payload)
+
+
+class AquaCLIError(AquaError):
+    """Exception raised when AQUA CLI encounter error."""
+
+    exit_code = ExitCode.COMMON_ERROR.value

--- a/ads/cli.py
+++ b/ads/cli.py
@@ -123,7 +123,7 @@ def exit_program(ex: Exception, logger: "logging.Logger") -> None:
     """
 
     logger.debug(traceback.format_exc())
-    logger.error(ex)
+    logger.error(str(ex))
 
     exit_code = getattr(ex, "exit_code", 1)
     logger.error(f"Exit code: {exit_code}")

--- a/ads/cli.py
+++ b/ads/cli.py
@@ -4,19 +4,21 @@
 # Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-import traceback
 import sys
+import traceback
+from dataclasses import is_dataclass
 
 import fire
-from dataclasses import is_dataclass
+
 from ads.common import logger
 
 try:
     import click
-    import ads.opctl.cli
+
     import ads.jobs.cli
-    import ads.pipeline.cli
+    import ads.opctl.cli
     import ads.opctl.operator.cli
+    import ads.pipeline.cli
 except Exception as ex:
     print(
         "Please run `pip install oracle-ads[opctl]` to install "
@@ -32,6 +34,7 @@ if sys.version_info >= (3, 8):
     from importlib import metadata
 else:
     import importlib_metadata as metadata
+
 
 ADS_VERSION = metadata.version("oracle_ads")
 
@@ -88,11 +91,14 @@ def serialize(data):
 
 def cli():
     if len(sys.argv) > 1 and sys.argv[1] == "aqua":
-        from ads.aqua.cli import AquaCommand
+        from ads.aqua.cli import AquaCLIError, AquaCommand
 
-        fire.Fire(
-            AquaCommand, command=sys.argv[2:], name="ads aqua", serialize=serialize
-        )
+        try:
+            fire.Fire(
+                AquaCommand, command=sys.argv[2:], name="ads aqua", serialize=serialize
+            )
+        except AquaCLIError as e:
+            sys.exit(e.exit_code)
     else:
         click_cli()
 

--- a/ads/cli.py
+++ b/ads/cli.py
@@ -89,16 +89,58 @@ def serialize(data):
         print(str(data))
 
 
+def exit_program(ex: Exception, logger: "logging.Logger") -> None:
+    """
+    Logs the exception and exits the program with a specific exit code.
+
+    This function logs the full traceback and the exception message, then terminates
+    the program with an exit code. If the exception object has an 'exit_code' attribute,
+    it uses that as the exit code; otherwise, it defaults to 1.
+
+    Parameters
+    ----------
+    ex (Exception):
+        The exception that triggered the program exit. This exception
+        should ideally contain an 'exit_code' attribute, but it is not mandatory.
+    logger (Logger):
+        A logging.Logger instance used to log the traceback and the error message.
+
+    Returns
+    -------
+    None:
+        This function does not return anything because it calls sys.exit,
+        terminating the process.
+
+    Examples
+    --------
+
+    >>> import logging
+    >>> logger = logging.getLogger('ExampleLogger')
+    >>> try:
+    ...     raise ValueError("An error occurred")
+    ... except Exception as e:
+    ...     exit_program(e, logger)
+    """
+
+    logger.debug(traceback.format_exc())
+    logger.error(ex)
+
+    exit_code = getattr(ex, "exit_code", 1)
+    logger.error(f"Exit code: {exit_code}")
+    sys.exit(exit_code)
+
+
 def cli():
     if len(sys.argv) > 1 and sys.argv[1] == "aqua":
-        from ads.aqua.cli import AquaCLIError, AquaCommand
+        from ads.aqua import logger as aqua_logger
+        from ads.aqua.cli import AquaCommand
 
         try:
             fire.Fire(
                 AquaCommand, command=sys.argv[2:], name="ads aqua", serialize=serialize
             )
-        except AquaCLIError as e:
-            sys.exit(e.exit_code)
+        except Exception as err:
+            exit_program(err, aqua_logger)
     else:
         click_cli()
 

--- a/tests/unitary/with_extras/aqua/test_cli.py
+++ b/tests/unitary/with_extras/aqua/test_cli.py
@@ -4,17 +4,19 @@
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-import os
 import logging
+import os
 import subprocess
-from unittest import TestCase
-from unittest.mock import patch
 from importlib import reload
+from unittest import TestCase
+from unittest.mock import call, patch
+
 from parameterized import parameterized
 
 import ads.aqua
 import ads.config
 from ads.aqua.cli import AquaCommand
+from ads.aqua.exception import AquaCLIError, AquaConfigError
 
 
 class TestAquaCLI(TestCase):
@@ -38,56 +40,137 @@ class TestAquaCLI(TestCase):
     @parameterized.expand(
         [
             ("default", None, DEFAULT_AQUA_CLI_LOGGING_LEVEL),
-            ("set logging level", "info", "info"),
+            ("set logging level", dict(log_level="info"), "INFO"),
+            ("debug", dict(debug=True), "DEBUG"),
+            ("verbose", dict(verbose=True), "INFO"),
+            ("flag_priority", dict(debug=True, log_level="info"), "DEBUG"),
         ]
+    )
+    @patch.dict(
+        os.environ, {"ODSC_MODEL_COMPARTMENT_OCID": SERVICE_COMPARTMENT_ID}, clear=True
     )
     def test_aquacommand(self, name, arg, expected):
         """Tests aqua command initialization."""
-        with patch.dict(
-            os.environ,
-            {"ODSC_MODEL_COMPARTMENT_OCID": TestAquaCLI.SERVICE_COMPARTMENT_ID},
-        ):
-            reload(ads.config)
-            reload(ads.aqua)
-            reload(ads.aqua.cli)
-            with patch("ads.aqua.cli.set_log_level") as mock_setting_log:
-                if arg:
-                    AquaCommand(arg)
-                else:
-                    AquaCommand()
-                mock_setting_log.assert_called_with(expected)
+
+        reload(ads.config)
+        reload(ads.aqua)
+        reload(ads.aqua.cli)
+        with patch("ads.aqua.cli.set_log_level") as mock_setting_log:
+            if arg:
+                AquaCommand(**arg)
+            else:
+                AquaCommand()
+            mock_setting_log.assert_called_with(expected)
 
     @parameterized.expand(
         [
-            ("default", None),
-            ("using jupyter instance", "nb-session-ocid"),
+            ("conflict", dict(debug=True, verbose=True)),
+            ("invalid_value", dict(debug="abc")),
+            ("invalid_value", dict(verbose="abc")),
         ]
     )
-    def test_aqua_command_without_compartment_env_var(self, name, session_ocid):
-        """Test whether exit is called when ODSC_MODEL_COMPARTMENT_OCID is not set. Also check if NB_SESSION_OCID is
-        set then log the appropriate message."""
+    @patch.dict(
+        os.environ, {"ODSC_MODEL_COMPARTMENT_OCID": SERVICE_COMPARTMENT_ID}, clear=True
+    )
+    def test_aquacommand_flag(self, name, arg):
+        """Tests aqua command initialization with wrong flag."""
 
-        with patch("sys.exit") as mock_exit:
-            env_dict = {"ODSC_MODEL_COMPARTMENT_OCID": ""}
-            if session_ocid:
-                env_dict.update({"NB_SESSION_OCID": session_ocid})
-            with patch.dict(os.environ, env_dict):
-                reload(ads.config)
-                reload(ads.aqua)
-                reload(ads.aqua.cli)
-                with patch("ads.aqua.cli.set_log_level") as mock_setting_log:
-                    with patch("ads.aqua.logger.error") as mock_logger_error:
-                        with patch("ads.aqua.logger.debug") as mock_logger_debug:
-                            AquaCommand()
-                            mock_setting_log.assert_called_with(
-                                TestAquaCLI.DEFAULT_AQUA_CLI_LOGGING_LEVEL
-                            )
-                            mock_logger_debug.assert_any_call(
-                                "ODSC_MODEL_COMPARTMENT_OCID environment variable is not set for Aqua."
-                            )
-                            if session_ocid:
-                                mock_logger_error.assert_any_call(
-                                    f"Aqua is not available for the notebook session {session_ocid}. For more information, "
-                                    f"please refer to the documentation."
-                                )
-                            mock_exit.assert_called_with(1)
+        reload(ads.config)
+        reload(ads.aqua)
+        reload(ads.aqua.cli)
+        with self.assertRaises(AquaCLIError):
+            AquaCommand(**arg)
+
+    @parameterized.expand(
+        [
+            (
+                "default",
+                {"ODSC_MODEL_COMPARTMENT_OCID": ""},
+                "ODSC_MODEL_COMPARTMENT_OCID environment variable is not set for Aqua.",
+            ),
+            (
+                "using jupyter instance",
+                {
+                    "ODSC_MODEL_COMPARTMENT_OCID": "",
+                    "NB_SESSION_OCID": "nb-session-ocid",
+                },
+                "Aqua is not available for the notebook session nb-session-ocid. For more information, please refer to the documentation.",
+            ),
+        ]
+    )
+    def test_aqua_command_without_compartment_env_var(
+        self, name, mock_env_dict, expected_msg
+    ):
+        """Test whether exit is called when ODSC_MODEL_COMPARTMENT_OCID is not set.
+        Also check if NB_SESSION_OCID is set then log the appropriate message."""
+
+        with patch.dict(os.environ, mock_env_dict):
+            reload(ads.config)
+            reload(ads.aqua)
+            reload(ads.aqua.cli)
+            with self.assertRaises(AquaConfigError) as cm:
+                AquaCommand()
+
+            self.assertEqual(str(cm.exception), expected_msg)
+
+    @patch("sys.argv", ["ads", "aqua", "--some-option"])
+    @patch("ads.cli.serialize")
+    @patch("fire.Fire")
+    @patch("ads.aqua.cli.AquaCommand")
+    @patch("ads.aqua.logger")
+    def test_aqua_cli(self, mock_logger, mock_aqua_command, mock_fire, mock_serialize):
+        """Tests when Aqua Cli being invoked."""
+        from ads.cli import cli
+
+        cli()
+        mock_fire.assert_called_once()
+        mock_fire.assert_called_with(
+            mock_aqua_command,
+            command=["--some-option"],
+            name="ads aqua",
+            serialize=mock_serialize,
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "with_defined_exit_code",
+                AquaConfigError("test error"),
+                AquaConfigError.exit_code,
+                "test error",
+            ),
+            (
+                "without_defined_exit_code",
+                ValueError("general error"),
+                1,
+                "general error",
+            ),
+        ]
+    )
+    @patch("sys.argv", ["ads", "aqua", "--error-option"])
+    @patch("fire.Fire")
+    @patch("ads.aqua.cli.AquaCommand")
+    @patch("ads.aqua.logger.error")
+    @patch("sys.exit")
+    def test_aqua_cli_with_error(
+        self,
+        name,
+        mock_side_effect,
+        expected_code,
+        expected_logging_message,
+        mock_exit,
+        mock_logger_error,
+        mock_aqua_command,
+        mock_fire,
+    ):
+        """Tests when Aqua Cli gracefully exit when error raised."""
+        mock_fire.side_effect = mock_side_effect
+        from ads.cli import cli
+
+        cli()
+        calls = [
+            call(expected_logging_message),
+            call(f"Exit code: {expected_code}"),
+        ]
+        mock_logger_error.assert_has_calls(calls)
+        mock_exit.assert_called_with(expected_code)


### PR DESCRIPTION
# Description
This PR aims to:
* provide the --verbose and --debug flag to set aqua logging level to `INFO` and `DEBUG` respectively.
* Improve CLI error handling: gracefully exit when encounter error.
* Improve CLI test

# User experience
```
ads aqua model get <ocid> --verbose
ads aqua model get <ocid> --debug
```



If user provide two flags together, it will no proceed. e.g.:
```
ads aqua model get <ocid> --debug --verbose

>>> ERROR:ads:Cannot use `--debug` and `--verbose` at the same time. Please select either `--debug` for `DEBUG` level logging or `--verbose` for `INFO` level logging.
```

## Priority betweem --verbose/--debug and --log-level
When user explicitly use --verbose/--debug flag, CLI will take the flag to set the logging level. `--log-level` can be use without --verbose/--debug.


# Test
<img width="1512" alt="Screenshot 2024-04-29 at 18 30 18" src="https://github.com/oracle/accelerated-data-science/assets/49049296/c8ebf1a0-4594-4979-88aa-75b6602ba382">

# Future work
Define exit_code for each AquaError. We need to have a table to show the mapping for AquaError with Http status code and cli exit code.