### PR TITLE
Updates on Job Run API

### DIFF
--- a/ads/jobs/builders/infrastructure/dsc_job.py
+++ b/ads/jobs/builders/infrastructure/dsc_job.py
@@ -9,6 +9,7 @@ import datetime
 import inspect
 import logging
 import os
+import re
 import time
 import traceback
 import uuid
@@ -581,6 +582,25 @@ class DataScienceJobRun(
         return OCILog(
             id=self.log_id, log_group_id=self.log_details.log_group_id, **auth
         )
+
+    @property
+    def exit_code(self):
+        """The exit code of the job run from the lifecycle details.
+        Note that,
+        None will be returned if the job run is not finished or failed without exit code.
+        0 will be returned if job run succeeded.
+        """
+        if self.lifecycle_state == self.LIFECYCLE_STATE_SUCCEEDED:
+            return 0
+        if not self.lifecycle_details:
+            return None
+        match = re.search(r"exit code (\d+)", self.lifecycle_details)
+        if not match:
+            return None
+        try:
+            return int(match.group(1))
+        except Exception:
+            return None
 
     @staticmethod
     def _format_log(message: str, date_time: datetime.datetime) -> dict:

--- a/ads/jobs/builders/infrastructure/dsc_job.py
+++ b/ads/jobs/builders/infrastructure/dsc_job.py
@@ -655,6 +655,22 @@ class DataScienceJobRun(
             print(f"{timestamp} - {status}")
         return status
 
+    def wait(self, interval: float = SLEEP_INTERVAL):
+        """Waits for the job run until if finishes.
+
+        Parameters
+        ----------
+        interval : float
+            Time interval in seconds between each request to update the logs.
+            Defaults to 3 (seconds).
+
+        """
+        self.sync()
+        while self.status not in self.TERMINAL_STATES:
+            time.sleep(interval)
+            self.sync()
+        return self
+
     def watch(
         self,
         interval: float = SLEEP_INTERVAL,

--- a/ads/jobs/builders/infrastructure/dsc_job.py
+++ b/ads/jobs/builders/infrastructure/dsc_job.py
@@ -376,12 +376,13 @@ class DSCJob(OCIDataScienceMixin, oci.data_science.models.Job):
         """
         runs = self.run_list()
         for run in runs:
-            if run.lifecycle_state in [
-                DataScienceJobRun.LIFECYCLE_STATE_ACCEPTED,
-                DataScienceJobRun.LIFECYCLE_STATE_IN_PROGRESS,
-                DataScienceJobRun.LIFECYCLE_STATE_NEEDS_ATTENTION,
-            ]:
-                run.cancel(wait_for_completion=True)
+            if force_delete:
+                if run.lifecycle_state in [
+                    DataScienceJobRun.LIFECYCLE_STATE_ACCEPTED,
+                    DataScienceJobRun.LIFECYCLE_STATE_IN_PROGRESS,
+                    DataScienceJobRun.LIFECYCLE_STATE_NEEDS_ATTENTION,
+                ]:
+                    run.cancel(wait_for_completion=True)
             run.delete()
         self.client.delete_job(self.id)
         return self
@@ -865,6 +866,12 @@ class DataScienceJobRun(
         """
         self.job.download(to_dir)
         return self
+
+    def delete(self, force_delete: bool = False):
+        if force_delete:
+            self.cancel(wait_for_completion=True)
+        super().delete()
+        return
 
 
 # This is for backward compatibility

--- a/tests/unitary/default_setup/jobs/test_jobs_run.py
+++ b/tests/unitary/default_setup/jobs/test_jobs_run.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/up
+"""Contains tests for DataScienceJobRun class."""
+
+from unittest import TestCase, mock
+
+import oci
+from ads.jobs import DataScienceJobRun
+
+
+class JobRunTestCase(TestCase):
+    """Contains test cases for Job runs."""
+
+    @mock.patch("ads.jobs.builders.infrastructure.dsc_job.DataScienceJobRun.sync")
+    def test_job_run_wait(self, *args):
+        """Test waiting for job run."""
+        run = DataScienceJobRun()
+        run.lifecycle_state = oci.data_science.models.JobRun.LIFECYCLE_STATE_IN_PROGRESS
+
+        # Mock time.sleep to change the job run lifecycle state.
+        def mock_sleep(*args, **kwargs):
+            run.lifecycle_state = (
+                oci.data_science.models.JobRun.LIFECYCLE_STATE_SUCCEEDED
+            )
+
+        with mock.patch("time.sleep", wraps=mock_sleep):
+            run.wait()
+
+        self.assertEqual(
+            run.lifecycle_state,
+            oci.data_science.models.JobRun.LIFECYCLE_STATE_SUCCEEDED,
+        )
+
+    def test_job_run_exit_code(self):
+        """Tests job run exit code."""
+        run = DataScienceJobRun()
+        self.assertEqual(run.exit_code, None)
+        run.lifecycle_state = run.LIFECYCLE_STATE_SUCCEEDED
+        self.assertEqual(run.exit_code, 0)
+        run.lifecycle_state = run.LIFECYCLE_STATE_IN_PROGRESS
+        run.lifecycle_details = "Job run in progress."
+        self.assertEqual(run.exit_code, None)
+        run.lifecycle_state = run.LIFECYCLE_STATE_FAILED
+        run.lifecycle_details = "Job run artifact execution failed with exit code 21."
+        self.assertEqual(run.exit_code, 21)


### PR DESCRIPTION
This PR adds the following for job run:

- `wait()` method, which will wait until the job run finishes without printing the logs (while `watch()`) prints the logs.
- `exit_code` property, which extracts the exit code from the lifecycle details.
- `force_delete` option to the `delete()` method, which will cancel the job run when it is set to `True`.

This PR also fixes the bug that `force_delete` is available in job.delete() but it is not actually used. 