### PR TITLE
Update model description attribute map

### DIFF
--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -238,7 +238,7 @@ class DataScienceModel(Builder):
         CONST_MODEL_VERSION_ID: "version_id",
         CONST_TIME_CREATED: "time_created",
         CONST_LIFECYCLE_STATE: "lifecycle_state",
-        CONST_MODEL_FILE_DESCRIPTION: "model_file_description",
+        CONST_MODEL_FILE_DESCRIPTION: "model_description",
     }
 
     def __init__(self, spec: Dict = None, **kwargs) -> None:


### PR DESCRIPTION
### Description

When loading DataScienceModel from yaml, the model_file_description attribute remains empty since the attribute map value is incorrect. There were no breaking changes before as this property was set when create() is called. 

This PR updates the attribute mapping value from `model_file_description` to `model_description`, without updating the property name.

### Example
```
yaml_model = DataScienceModel.from_yaml(uri="tests/unitary/with_extras/aqua/test_data/deployment/aqua_finetuned_model.yaml")

print(yaml_model.model_file_description)
{'models': [{'bucketName': 'service-managed-models',
   'namespace': 'namespace',
   'objects': [{'name': 'service_models/model-name/commit-id/artifact/README.md',
     'sizeInBytes': 3836,
     'version': '5707cfc1-499b-4ce0-aeec-32e2336c5195'},
    {'name': 'service_models/model-name/commit-id/artifact/config.json',
     'sizeInBytes': 596,
...
...
```

### Tests

```
> python -m pytest -q tests/unitary/default_setup/model/test_datascience_model.py
============================================ test session starts =============================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/vmascarenhas/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 35 items

tests/unitary/default_setup/model/test_datascience_model.py ...................................        [100%]

============================================= 35 passed in 3.79s =============================================
```
