### PR TITLE
Add ready_to_import for list API

### DIFF
--- a/ads/aqua/constants.py
+++ b/ads/aqua/constants.py
@@ -6,6 +6,7 @@
 from enum import Enum
 
 UNKNOWN_VALUE = ""
+READY_TO_IMPORT_STATUS = "TRUE"
 
 
 class RqsAdditionalDetails:

--- a/ads/aqua/data.py
+++ b/ads/aqua/data.py
@@ -40,4 +40,5 @@ class Tags(Enum):
     AQUA_EVALUATION = "aqua_evaluation"
     AQUA_FINE_TUNING = "aqua_finetuning"
     READY_TO_FINE_TUNE = "ready_to_fine_tune"
+    READY_TO_IMPORT = "ready_to_import"
     BASE_MODEL_CUSTOM = "aqua_custom_base_model"

--- a/ads/aqua/model.py
+++ b/ads/aqua/model.py
@@ -24,6 +24,7 @@ from ads.aqua.constants import (
     VALIDATION_METRICS,
     VALIDATION_METRICS_FINAL,
     FineTuningDefinedMetadata,
+    READY_TO_IMPORT_STATUS,
 )
 from ads.aqua.data import AquaResourceIdentifier, Tags
 from ads.aqua.exception import AquaRuntimeError
@@ -120,6 +121,7 @@ class AquaModelSummary(DataClassSerializable):
     search_text: str = None
     ready_to_deploy: bool = True
     ready_to_finetune: bool = False
+    ready_to_import: bool = False
 
 
 @dataclass(repr=False)
@@ -654,6 +656,10 @@ class AquaModelApp(AquaApp):
             freeform_tags.get(Tags.READY_TO_FINE_TUNE.value, "").upper()
             == READY_TO_FINE_TUNE_STATUS
         )
+        ready_to_import = (
+            freeform_tags.get(Tags.READY_TO_IMPORT.value, "").upper()
+            == READY_TO_IMPORT_STATUS
+        )
 
         return dict(
             compartment_id=model.compartment_id,
@@ -670,6 +676,7 @@ class AquaModelApp(AquaApp):
             search_text=search_text,
             ready_to_deploy=ready_to_deploy,
             ready_to_finetune=ready_to_finetune,
+            ready_to_import=ready_to_import,
         )
 
     @telemetry(entry_point="plugin=model&action=list", name="aqua")
@@ -918,6 +925,8 @@ class AquaModelApp(AquaApp):
 
         model = (
             model.with_custom_metadata_list(metadata)
+            .with_compartment_id(COMPARTMENT_OCID)
+            .with_project_id(PROJECT_OCID)
             .with_artifact(os_path)
             .with_display_name(os.path.basename(model_name))
             .with_freeform_tags(**tags)

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -56,11 +56,28 @@ class TestDataset:
             "defined_tags": {},
             "display_name": "Model1",
             "freeform_tags": {
-                "OCI_AQUA": "",
+                "OCI_AQUA": "active",
                 "aqua_service_model": "ocid1.datasciencemodel.oc1.iad.<OCID>#Model1",
                 "license": "UPL",
                 "organization": "Oracle AI",
                 "task": "text_generation",
+            },
+            "id": "ocid1.datasciencemodel.oc1.iad.<OCID>",
+            "lifecycle_state": "ACTIVE",
+            "project_id": "ocid1.datascienceproject.oc1.iad.<OCID>",
+            "time_created": "2024-01-19T17:57:39.158000+00:00",
+        },
+        {
+            "compartment_id": "ocid1.compartment.oc1..<OCID>",
+            "created_by": "ocid1.datasciencenotebooksession.oc1.iad.<OCID>",
+            "defined_tags": {},
+            "display_name": "ShadowModel",
+            "freeform_tags": {
+                "OCI_AQUA": "",
+                "license": "UPL",
+                "organization": "Oracle AI",
+                "task": "text_generation",
+                "ready_to_import": "true",
             },
             "id": "ocid1.datasciencemodel.oc1.iad.<OCID>",
             "lifecycle_state": "ACTIVE",
@@ -240,6 +257,7 @@ class TestAquaModel:
             "project_id": f"{ds_model.project_id}",
             "ready_to_deploy": True,
             "ready_to_finetune": False,
+            "ready_to_import": False,
             "search_text": "ACTIVE,test_license,test_organization,test_task",
             "tags": ds_model.freeform_tags,
             "task": f'{ds_model.freeform_tags["task"]}',
@@ -377,6 +395,7 @@ class TestAquaModel:
             "project_id": f"{ds_model.project_id}",
             "ready_to_deploy": True,
             "ready_to_finetune": False,
+            "ready_to_import": False,
             "search_text": "ACTIVE,test_license,test_organization,test_task,test_finetuned_model",
             "shape_info": {
                 "instance_shape": f"{job_infrastructure_configuration_details.shape_name}",
@@ -745,7 +764,7 @@ class TestAquaModel:
         received_args = self.app.list_resource.call_args.kwargs
         assert received_args.get("compartment_id") == TestDataset.SERVICE_COMPARTMENT_ID
 
-        assert len(results) == 1
+        assert len(results) == 2
 
         attributes = AquaModelSummary.__annotations__.keys()
         for r in results:


### PR DESCRIPTION
### Description

This PR covers the following:
1. Adds ready_to_import to `AquaModelSummary` that is set as True if  the models in the service compartments have the freeform tag `ready_to_import :  true`. 
2. create() model fails if project and compartment id are not set, updated the code since tests were failing. This might be changed later on to accommodate user provided compartment and project id as parameters.

### Jira Ticket
List Imported Models API - [ODSC-56561](https://jira.oci.oraclecorp.com/browse/ODSC-56561)
Shadow models data setup - [ODSC-56857](https://jira.oci.oraclecorp.com/browse/ODSC-56857)

### Results
The Phi-3-mini-128k-instruct added to the service compartment with ready_to_import freeform tag set ass true, whereas the others would not have this tag. 

`http://localhost:8888/aqua/model`

```
{
    "data": [
        {
            "compartment_id": "ocid1.compartment.oc1..<ocid>",
            "icon": "",
            "id": "ocid1.datasciencemodel.oc1.iad.<ocid>",
            "is_fine_tuned_model": false,
            "license": "MIT",
            "name": "Phi-3-mini-128k-instruct",
            "organization": "Microsoft",
            "project_id": "",
            "tags": {
                "license": "MIT",
                "ready_to_import": "true",
                "task": "text_generation",
                "OCI_AQUA": "",
                "organization": "Microsoft"
            },
            "task": "text_generation",
            "time_created": "2024-05-08 00:48:06.751000+00:00",
            "console_link": [
                "https://cloud.oracle.com/data-science/models/ocid1.datasciencemodel.oc1.iad.<ocid>?region=us-ashburn-1"
            ],
            "search_text": "MIT,true,text_generation,,Microsoft",
            "ready_to_deploy": false,
            "ready_to_finetune": false,
            "ready_to_import": true
        },
       ...
        {
            "compartment_id": "ocid1.compartment.oc1..<ocid>",
            "icon": "",
            "id": "ocid1.datasciencemodel.oc1.iad.<ocid>",
            "is_fine_tuned_model": false,
            "license": "llama2",
            "name": "CodeLlama-13b-Instruct-hf",
            "organization": "Meta",
            "project_id": "",
            "tags": {
                "license": "llama2",
                "task": "code_synthesis",
                "OCI_AQUA": "active",
                "organization": "Meta",
                "ready_to_fine_tune": "true"
            },
            "task": "code_synthesis",
            "time_created": "2024-03-13 08:21:25.728000+00:00",
            "console_link": [
                "https://cloud.oracle.com/data-science/models/ocid1.datasciencemodel.oc1.iad.<ocid>?region=us-ashburn-1"
            ],
            "search_text": "llama2,code_synthesis,active,Meta,true",
            "ready_to_deploy": true,
            "ready_to_finetune": true,
            "ready_to_import": false
        },
...
    ]
}

```


### Unit Tests
One test to check the value of ready_to_import was added when get API is called.

```
> python -m pytest -q tests/unitary/with_extras/aqua/test_model.py
========================================= test session starts ==========================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/vmascarenhas/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 13 items

tests/unitary/with_extras/aqua/test_model.py .............                                       [100%]

========================================== 13 passed in 2.33s ==========================================
```