### PR TITLE
Get default configurations for Model Deployment

### DIFF
--- a/ads/aqua/data.py
+++ b/ads/aqua/data.py
@@ -52,3 +52,8 @@ class InferenceContainerType(ExtendedEnum):
 class InferenceContainerTypeKey(ExtendedEnum):
     AQUA_VLLM_CONTAINER_KEY = "odsc-vllm-serving"
     AQUA_TGI_CONTAINER_KEY = "odsc-tgi-serving"
+
+
+class InferenceContainerParamType(ExtendedEnum):
+    PARAM_TYPE_VLLM = "VLLM_PARAMS"
+    PARAM_TYPE_TGI = "TGI_PARAMS"

--- a/ads/aqua/data.py
+++ b/ads/aqua/data.py
@@ -5,7 +5,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
-
+from ads.common.extended_enum import ExtendedEnum
 from ads.common.serializer import DataClassSerializable
 
 
@@ -42,3 +42,13 @@ class Tags(Enum):
     READY_TO_FINE_TUNE = "ready_to_fine_tune"
     READY_TO_IMPORT = "ready_to_import"
     BASE_MODEL_CUSTOM = "aqua_custom_base_model"
+
+
+class InferenceContainerType(ExtendedEnum):
+    CONTAINER_TYPE_VLLM = "vllm"
+    CONTAINER_TYPE_TGI = "tgi"
+
+
+class InferenceContainerTypeKey(ExtendedEnum):
+    AQUA_VLLM_CONTAINER_KEY = "odsc-vllm-serving"
+    AQUA_TGI_CONTAINER_KEY = "odsc-tgi-serving"

--- a/ads/aqua/deployment.py
+++ b/ads/aqua/deployment.py
@@ -28,7 +28,11 @@ from ads.aqua.utils import (
     AQUA_MODEL_TYPE_SERVICE,
     AQUA_MODEL_TYPE_CUSTOM,
 )
-from ads.aqua.data import InferenceContainerType, InferenceContainerTypeKey
+from ads.aqua.data import (
+    InferenceContainerType,
+    InferenceContainerTypeKey,
+    InferenceContainerParamType,
+)
 from ads.aqua.finetune import FineTuneCustomMetadata
 from ads.aqua.data import AquaResourceIdentifier
 from ads.common.utils import get_console_link, get_log_links
@@ -656,12 +660,16 @@ class AquaDeploymentApp(AquaApp):
                         InferenceContainerType.CONTAINER_TYPE_VLLM.value
                         in container_type_key
                     ):
-                        params = config_parameters.get("VLLM_PARAMS", UNKNOWN)
+                        params = config_parameters.get(
+                            InferenceContainerParamType.PARAM_TYPE_VLLM.value, UNKNOWN
+                        )
                     elif (
                         InferenceContainerType.CONTAINER_TYPE_TGI.value
                         in container_type_key
                     ):
-                        params = config_parameters.get("TGI_PARAMS", UNKNOWN)
+                        params = config_parameters.get(
+                            InferenceContainerParamType.PARAM_TYPE_TGI.value, UNKNOWN
+                        )
                     else:
                         params = UNKNOWN
                         logger.debug(

--- a/ads/aqua/extension/deployment_handler.py
+++ b/ads/aqua/extension/deployment_handler.py
@@ -46,12 +46,6 @@ class AquaDeploymentHandler(AquaAPIhandler):
                     400, f"The request {self.request.path} requires model id."
                 )
             return self.get_deployment_config(id)
-        elif paths.startswith("aqua/deployments/params"):
-            if not id:
-                raise HTTPError(
-                    400, f"The request {self.request.path} requires model id."
-                )
-            return self.get_deployment_default_params(id)
         elif paths.startswith("aqua/deployments"):
             if not id:
                 return self.list()
@@ -137,15 +131,6 @@ class AquaDeploymentHandler(AquaAPIhandler):
         """Gets the deployment config for Aqua model."""
         return self.finish(AquaDeploymentApp().get_deployment_config(model_id=model_id))
 
-    def get_deployment_default_params(self, model_id):
-        """Gets the default deployment parameters for Aqua model."""
-        instance_shape = self.get_argument("instance_shape")
-        return self.finish(
-            AquaDeploymentApp().get_deployment_default_params(
-                model_id=model_id, instance_shape=instance_shape
-            )
-        )
-
 
 class AquaDeploymentInferenceHandler(AquaAPIhandler):
     @staticmethod
@@ -207,9 +192,30 @@ class AquaDeploymentInferenceHandler(AquaAPIhandler):
         )
 
 
+class AquaDeploymentParamsHandler(AquaAPIhandler):
+    """Handler for Aqua finetuning params REST APIs.
+
+    Methods
+    -------
+    get(self, model_id)
+        Retrieves a list of model deployment parameters.
+    """
+
+    @handle_exceptions
+    def get(self, model_id):
+        """Handle GET request."""
+        model_id = model_id.split("/")[0]
+        instance_shape = self.get_argument("instance_shape")
+        return self.finish(
+            AquaDeploymentApp().get_deployment_default_params(
+                model_id=model_id, instance_shape=instance_shape
+            )
+        )
+
+
 __handlers__ = [
     ("deployments/?([^/]*)", AquaDeploymentHandler),
     ("deployments/config/?([^/]*)", AquaDeploymentHandler),
-    ("deployments/params/?([^/]*)", AquaDeploymentHandler),
+    ("deployments/?([^/]*/params)", AquaDeploymentParamsHandler),
     ("inference", AquaDeploymentInferenceHandler),
 ]

--- a/ads/aqua/extension/deployment_handler.py
+++ b/ads/aqua/extension/deployment_handler.py
@@ -46,6 +46,12 @@ class AquaDeploymentHandler(AquaAPIhandler):
                     400, f"The request {self.request.path} requires model id."
                 )
             return self.get_deployment_config(id)
+        elif paths.startswith("aqua/deployments/params"):
+            if not id:
+                raise HTTPError(
+                    400, f"The request {self.request.path} requires model id."
+                )
+            return self.get_deployment_default_params(id)
         elif paths.startswith("aqua/deployments"):
             if not id:
                 return self.list()
@@ -131,6 +137,15 @@ class AquaDeploymentHandler(AquaAPIhandler):
         """Gets the deployment config for Aqua model."""
         return self.finish(AquaDeploymentApp().get_deployment_config(model_id=model_id))
 
+    def get_deployment_default_params(self, model_id):
+        """Gets the default deployment parameters for Aqua model."""
+        instance_shape = self.get_argument("instance_shape")
+        return self.finish(
+            AquaDeploymentApp().get_deployment_default_params(
+                model_id=model_id, instance_shape=instance_shape
+            )
+        )
+
 
 class AquaDeploymentInferenceHandler(AquaAPIhandler):
     @staticmethod
@@ -195,5 +210,6 @@ class AquaDeploymentInferenceHandler(AquaAPIhandler):
 __handlers__ = [
     ("deployments/?([^/]*)", AquaDeploymentHandler),
     ("deployments/config/?([^/]*)", AquaDeploymentHandler),
+    ("deployments/params/?([^/]*)", AquaDeploymentHandler),
     ("inference", AquaDeploymentInferenceHandler),
 ]

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -10,6 +10,7 @@ import unittest
 from dataclasses import asdict
 from importlib import reload
 from unittest.mock import MagicMock, patch
+from parameterized import parameterized
 import pytest
 import copy
 import yaml
@@ -27,6 +28,7 @@ from ads.aqua.deployment import (
 from ads.aqua.exception import AquaRuntimeError
 from ads.model.datascience_model import DataScienceModel
 from ads.model.deployment.model_deployment import ModelDeployment
+from ads.model.model_metadata import ModelCustomMetadata
 
 null = None
 
@@ -390,6 +392,64 @@ class TestAquaDeployment(unittest.TestCase):
         expected_result = copy.deepcopy(TestDataset.aqua_deployment_object)
         expected_result["state"] = "CREATING"
         assert actual_attributes == expected_result
+
+    @parameterized.expand(
+        [
+            (
+                "VLLM_PARAMS",
+                "odsc-vllm-serving",
+                ["--max-model-len 4096", "--seed 42", "--trust-remote-code"],
+            ),
+            (
+                "VLLM_PARAMS",
+                "odsc-vllm-serving",
+                [],
+            ),
+            (
+                "TGI_PARAMS",
+                "odsc-tgi-serving",
+                ["--sharded true", "--trust-remote-code"],
+            ),
+            (
+                "CUSTOM_PARAMS",
+                "custom-container-key",
+                ["--max-model-len 4096", "--seed 42", "--trust-remote-code"],
+            ),
+        ]
+    )
+    def test_get_deployment_default_params(
+        self, container_params_field, container_type_key, params
+    ):
+        """Test for fetching config details for a given deployment."""
+
+        config_json = os.path.join(
+            self.curr_dir, "test_data/deployment/deployment_config.json"
+        )
+        with open(config_json, "r") as _file:
+            config = json.load(_file)
+        # update config params for testing
+        config["configuration"][TestDataset.DEPLOYMENT_SHAPE_NAME]["parameters"][
+            container_params_field
+        ] = " ".join(params)
+
+        self.app.get_deployment_config = MagicMock(return_value=config)
+
+        mock_model = MagicMock()
+        mock_model.data = MagicMock(
+            id=TestDataset.MODEL_ID,
+            custom_metadata_list=[
+                MagicMock(key="deployment-container", value=container_type_key)
+            ],
+        )
+        self.app.ds_client.get_model = MagicMock(return_value=mock_model)
+
+        result = self.app.get_deployment_default_params(
+            TestDataset.MODEL_ID, TestDataset.DEPLOYMENT_SHAPE_NAME
+        )
+        if container_params_field == "CUSTOM_PARAMS":
+            assert result == []
+        else:
+            assert result == params
 
 
 class TestMDInferenceResponse(unittest.TestCase):


### PR DESCRIPTION
### Description
This PR covers the code changes to return a list of deployment parameters from the deployment_config.json. The validation of these parameters prior to model deployment will be covered in a separate PR.

### Invoke the API

For the below test config file
```
{
    "shape": [
        "VM.GPU.A10.1"
    ],
    "configuration": {
        "VM.GPU.A10.1": {
            "parameters": {
                "VLLM_PARAMS": "--max-model-len 4096 --seed 42 --trust-remote-code"
            }
        }
    }
}
```
#### Request
```
http://localhost:8888/aqua/deployments/ocid1.datasciencemodel.oc1.iad.<ocid>/params?instance_shape=VM.GPU.A10.1

```
#### Response
```
{
    "data": [
        "--max-model-len 4096", "--seed 42", "--trust-remote-code"
    ]
}
```

### Unit Tests

```
> python -m pytest tests/unitary/with_extras/aqua/test_deployment.py -k "test_get_deployment_default_params"
========================================= test session starts ==========================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0 -- /Users/user/miniconda3/envs/ads-local-v38/bin/python
cachedir: .pytest_cache
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 11 items / 7 deselected / 4 selected

tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_0_VLLM_PARAMS PASSED [ 25%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_1_VLLM_PARAMS PASSED [ 50%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_2_TGI_PARAMS PASSED [ 75%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_3_CUSTOM_PARAMS PASSED [100%]

=================================== 4 passed, 7 deselected in 3.33s ====================================
```
Changes to test_deployment_handler.py are pending. Also, a couple tests in test_deployment.py are failing due to changes from a previous update, they'll be fixed in the subsequent PR. 