### PR TITLE
Get default configurations for Model FineTuning

### DIFF
--- a/ads/aqua/extension/finetune_handler.py
+++ b/ads/aqua/extension/finetune_handler.py
@@ -59,7 +59,20 @@ class AquaFineTuneHandler(AquaAPIhandler):
         return self.finish(AquaFineTuningApp().get_finetuning_config(model_id=model_id))
 
 
+class AquaFineTuneParamsHandler(AquaAPIhandler):
+    """Handler for Aqua finetuning params REST APIs."""
+
+    @handle_exceptions
+    def get(self, model_id):
+        """Handle GET request."""
+        model_id = model_id.split("/")[0]
+        return self.finish(
+            AquaFineTuningApp().get_finetuning_default_params(model_id=model_id)
+        )
+
+
 __handlers__ = [
     ("finetuning/?([^/]*)", AquaFineTuneHandler),
     ("finetuning/config/?([^/]*)", AquaFineTuneHandler),
+    ("finetuning/?([^/]*/params)", AquaFineTuneParamsHandler),
 ]

--- a/ads/aqua/extension/finetune_handler.py
+++ b/ads/aqua/extension/finetune_handler.py
@@ -65,7 +65,6 @@ class AquaFineTuneParamsHandler(AquaAPIhandler):
     @handle_exceptions
     def get(self, model_id):
         """Handle GET request."""
-        model_id = model_id.split("/")[0]
         return self.finish(
             AquaFineTuningApp().get_finetuning_default_params(model_id=model_id)
         )
@@ -74,5 +73,5 @@ class AquaFineTuneParamsHandler(AquaAPIhandler):
 __handlers__ = [
     ("finetuning/?([^/]*)", AquaFineTuneHandler),
     ("finetuning/config/?([^/]*)", AquaFineTuneHandler),
-    ("finetuning/?([^/]*/params)", AquaFineTuneParamsHandler),
+    ("finetuning/([^/]*)/params", AquaFineTuneParamsHandler),
 ]

--- a/ads/aqua/finetune.py
+++ b/ads/aqua/finetune.py
@@ -671,8 +671,8 @@ class AquaFineTuningApp(AquaApp):
         Returns
         -------
         List[str]:
-            List of parameters from the loaded from finetuning config json file. If not available, then an empty list
-            is returned.
+            List of parameters from the loaded from finetuning config json file. If config information is available,
+            then an empty list is returned.
         """
         default_params = []
         finetuning_config = self.get_finetuning_config(model_id)

--- a/ads/aqua/finetune.py
+++ b/ads/aqua/finetune.py
@@ -71,7 +71,9 @@ class AquaFineTuningParams(DataClassSerializable):
     epochs: int
     learning_rate: Optional[float] = None
     sample_packing: Optional[bool] = "auto"
-    batch_size: Optional[int] = None # make it batch_size for user, but internally this is micro_batch_size
+    batch_size: Optional[
+        int
+    ] = None  # make it batch_size for user, but internally this is micro_batch_size
     sequence_len: Optional[int] = None
     pad_to_sequence_len: Optional[bool] = None
     lora_r: Optional[int] = None
@@ -199,9 +201,9 @@ class AquaFineTuningApp(AquaApp):
             try:
                 create_fine_tuning_details = CreateFineTuningDetails(**kwargs)
             except:
-                allowed_create_fine_tuning_details = (
-                    ', '.join(field.name for field in fields(CreateFineTuningDetails)).rstrip()
-                )
+                allowed_create_fine_tuning_details = ", ".join(
+                    field.name for field in fields(CreateFineTuningDetails)
+                ).rstrip()
                 raise AquaValueError(
                     "Invalid create fine tuning parameters. Allowable parameters are: "
                     f"{allowed_create_fine_tuning_details}."
@@ -259,9 +261,9 @@ class AquaFineTuningApp(AquaApp):
                 **create_fine_tuning_details.ft_parameters,
             )
         except:
-            allowed_fine_tuning_parameters = (
-                ', '.join(field.name for field in fields(AquaFineTuningParams)).rstrip()
-            )
+            allowed_fine_tuning_parameters = ", ".join(
+                field.name for field in fields(AquaFineTuningParams)
+            ).rstrip()
             raise AquaValueError(
                 "Invalid fine tuning parameters. Fine tuning parameters should "
                 f"be a dictionary with keys: {allowed_fine_tuning_parameters}."
@@ -554,7 +556,9 @@ class AquaFineTuningApp(AquaApp):
                 finetuning_experiment_id=experiment_model_version_set_id,
             ),
             parameters={
-                key: value for key, value in asdict(ft_parameters).items() if value is not None
+                key: value
+                for key, value in asdict(ft_parameters).items()
+                if value is not None
             },
         )
 
@@ -629,7 +633,7 @@ class AquaFineTuningApp(AquaApp):
                 else:
                     oci_launch_cmd += f"--{key} {value} "
 
-        oci_launch_cmd += (f"{finetuning_params}" if finetuning_params else "")
+        oci_launch_cmd += f"{finetuning_params}" if finetuning_params else ""
         return oci_launch_cmd.rstrip()
 
     @telemetry(
@@ -650,3 +654,36 @@ class AquaFineTuningApp(AquaApp):
         """
 
         return self.get_config(model_id, AQUA_MODEL_FINETUNING_CONFIG)
+
+    @telemetry(
+        entry_point="plugin=finetuning&action=get_finetuning_default_params",
+        name="aqua",
+    )
+    def get_finetuning_default_params(self, model_id: str) -> List[str]:
+        """Gets the default params set in the finetuning configs for the given model. Only the fields that are
+        available in AquaFineTuningParams will be accessible for user overrides.
+
+        Parameters
+        ----------
+        model_id: str
+            The OCID of the Aqua model.
+
+        Returns
+        -------
+        List[str]:
+            List of parameters from the loaded from finetuning config json file. If not available, then an empty list
+            is returned.
+        """
+        default_params = []
+        finetuning_config = self.get_finetuning_config(model_id)
+        config_parameters = finetuning_config.get("configuration", UNKNOWN_DICT)
+        dataclass_fields = {field.name for field in fields(AquaFineTuningParams)}
+        for name, value in config_parameters.items():
+            if name == "micro_batch_size":
+                name = "batch_size"
+            if name == "lora_target_modules":
+                value = ",".join(str(k) for k in value)
+            if name in dataclass_fields:
+                default_params.append(f"--{name} {str(value).lower()}")
+
+        return default_params

--- a/tests/unitary/with_extras/aqua/test_data/finetuning/ft_config.json
+++ b/tests/unitary/with_extras/aqua/test_data/finetuning/ft_config.json
@@ -1,0 +1,34 @@
+{
+  "configuration": {
+    "adapter": "lora",
+    "bf16": true,
+    "flash_attention": true,
+    "fp16": false,
+    "gradient_accumulation_steps": 1,
+    "gradient_checkpointing": true,
+    "learning_rate": 0.0002,
+    "logging_steps": 1,
+    "lora_alpha": 16,
+    "lora_dropout": 0.05,
+    "lora_r": 32,
+    "lora_target_linear": true,
+    "lora_target_modules": [
+      "q_proj",
+      "k_proj"
+    ],
+    "lr_scheduler": "cosine",
+    "micro_batch_size": 1,
+    "optimizer": "adamw_torch",
+    "pad_to_sequence_len": true,
+    "sample_packing": true,
+    "sequence_len": 2048,
+    "tf32": false,
+    "val_set_size": 0.1
+  },
+  "shape": {
+    "VM.GPU.A10.2": {
+      "batch_size": 2,
+      "replica": 1
+    }
+  }
+}

--- a/tests/unitary/with_extras/aqua/test_finetuning.py
+++ b/tests/unitary/with_extras/aqua/test_finetuning.py
@@ -242,18 +242,21 @@ class FineTuningTestCase(TestCase):
 
         self.app.get_finetuning_config = MagicMock(return_value=config)
         result = self.app.get_finetuning_default_params(model_id="test_model_id")
-        assert result == [
-            "--batch_size 1",
-            "--sequence_len 2048",
-            "--sample_packing true",
-            "--pad_to_sequence_len true",
-            "--learning_rate 0.0002",
-            "--lora_r 32",
-            "--lora_alpha 16",
-            "--lora_dropout 0.05",
-            "--lora_target_linear true",
-            "--lora_target_modules q_proj,k_proj",
-        ]
+        self.assertCountEqual(
+            result,
+            [
+                "--batch_size 1",
+                "--sequence_len 2048",
+                "--sample_packing true",
+                "--pad_to_sequence_len true",
+                "--learning_rate 0.0002",
+                "--lora_r 32",
+                "--lora_alpha 16",
+                "--lora_dropout 0.05",
+                "--lora_target_linear true",
+                "--lora_target_modules q_proj,k_proj",
+            ],
+        )
 
         # check when config json is not available
         self.app.get_finetuning_config = MagicMock(return_value={})

--- a/tests/unitary/with_extras/aqua/test_finetuning.py
+++ b/tests/unitary/with_extras/aqua/test_finetuning.py
@@ -7,6 +7,7 @@
 from dataclasses import asdict
 from importlib import reload
 import os
+import json
 from unittest import TestCase
 from unittest.mock import MagicMock, PropertyMock
 
@@ -18,7 +19,7 @@ from ads.aqua.base import AquaApp
 from ads.aqua.finetune import (
     AquaFineTuningApp,
     AquaFineTuningParams,
-    FineTuneCustomMetadata
+    FineTuneCustomMetadata,
 )
 from ads.aqua.model import AquaFineTuneModel
 from ads.jobs.ads_job import Job
@@ -34,6 +35,7 @@ class FineTuningTestCase(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.curr_dir = os.path.dirname(os.path.abspath(__file__))
         os.environ["ODSC_MODEL_COMPARTMENT_OCID"] = cls.SERVICE_COMPARTMENT_ID
         reload(ads.config)
         reload(ads.aqua)
@@ -41,6 +43,7 @@ class FineTuningTestCase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        cls.curr_dir = None
         os.environ.pop("ODSC_MODEL_COMPARTMENT_OCID", None)
         reload(ads.config)
         reload(ads.aqua)
@@ -123,7 +126,7 @@ class FineTuningTestCase(TestCase):
             ft_parameters={
                 "epochs": 1,
                 "learning_rate": 0.02,
-                "lora_target_linear": False
+                "lora_target_linear": False,
             },
             shape_name="VM.GPU.A10.1",
             replica=1,
@@ -155,7 +158,7 @@ class FineTuningTestCase(TestCase):
                 "learning_rate": 0.02,
                 "sample_packing": "auto",
                 "batch_size": 1,
-                "lora_target_linear": False
+                "lora_target_linear": False,
             },
             "source": {
                 "id": f"{ft_source.id}",
@@ -205,24 +208,54 @@ class FineTuningTestCase(TestCase):
         )
 
     def test_build_oci_launch_cmd(self):
-        dataset_path="oci://ds_bucket@namespace/prefix/dataset.jsonl"
-        report_path="oci://report_bucket@namespace/prefix/"
-        val_set_size=0.1
-        parameters=AquaFineTuningParams(
+        dataset_path = "oci://ds_bucket@namespace/prefix/dataset.jsonl"
+        report_path = "oci://report_bucket@namespace/prefix/"
+        val_set_size = 0.1
+        parameters = AquaFineTuningParams(
             batch_size=1,
             epochs=1,
             sample_packing="True",
             learning_rate=0.01,
             sequence_len=2,
-            lora_target_modules=["q_proj","k_proj"]
+            lora_target_modules=["q_proj", "k_proj"],
         )
-        finetuning_params="--trust_remote_code True"
+        finetuning_params = "--trust_remote_code True"
         oci_launch_cmd = self.app._build_oci_launch_cmd(
             dataset_path=dataset_path,
             report_path=report_path,
             val_set_size=val_set_size,
             parameters=parameters,
-            finetuning_params=finetuning_params
+            finetuning_params=finetuning_params,
         )
 
-        assert oci_launch_cmd == f"--training_data {dataset_path} --output_dir {report_path} --val_set_size {val_set_size} --num_epochs {parameters.epochs} --learning_rate {parameters.learning_rate} --sample_packing {parameters.sample_packing} --micro_batch_size {parameters.batch_size} --sequence_len {parameters.sequence_len} --lora_target_modules q_proj,k_proj {finetuning_params}"
+        assert (
+            oci_launch_cmd
+            == f"--training_data {dataset_path} --output_dir {report_path} --val_set_size {val_set_size} --num_epochs {parameters.epochs} --learning_rate {parameters.learning_rate} --sample_packing {parameters.sample_packing} --micro_batch_size {parameters.batch_size} --sequence_len {parameters.sequence_len} --lora_target_modules q_proj,k_proj {finetuning_params}"
+        )
+
+    def test_get_finetuning_default_params(self):
+        """Test for fetching finetuning config params for a given model."""
+
+        config_json = os.path.join(self.curr_dir, "test_data/finetuning/ft_config.json")
+        with open(config_json, "r") as _file:
+            config = json.load(_file)
+
+        self.app.get_finetuning_config = MagicMock(return_value=config)
+        result = self.app.get_finetuning_default_params(model_id="test_model_id")
+        assert result == [
+            "--batch_size 1",
+            "--sequence_len 2048",
+            "--sample_packing true",
+            "--pad_to_sequence_len true",
+            "--learning_rate 0.0002",
+            "--lora_r 32",
+            "--lora_alpha 16",
+            "--lora_dropout 0.05",
+            "--lora_target_linear true",
+            "--lora_target_modules q_proj,k_proj",
+        ]
+
+        # check when config json is not available
+        self.app.get_finetuning_config = MagicMock(return_value={})
+        result = self.app.get_finetuning_default_params(model_id="test_model_id")
+        assert result == []

--- a/tests/unitary/with_extras/aqua/test_finetuning_handler.py
+++ b/tests/unitary/with_extras/aqua/test_finetuning_handler.py
@@ -108,6 +108,6 @@ class AquaFineTuneParamsHandlerTestCase(TestCase):
         mock_finish.side_effect = lambda x: x
 
         result = self.test_instance.get(model_id="test_model_id")
+        self.assertCountEqual(result["data"], default_params)
 
-        assert result["data"] == default_params
         mock_get_finetuning_default_params.assert_called_with(model_id="test_model_id")

--- a/tests/unitary/with_extras/aqua/test_finetuning_handler.py
+++ b/tests/unitary/with_extras/aqua/test_finetuning_handler.py
@@ -8,8 +8,11 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 from mock import patch
 
-from notebook.base.handlers import IPythonHandler
-from ads.aqua.extension.finetune_handler import AquaFineTuneHandler
+from notebook.base.handlers import IPythonHandler, APIHandler
+from ads.aqua.extension.finetune_handler import (
+    AquaFineTuneHandler,
+    AquaFineTuneParamsHandler,
+)
 from ads.aqua.finetune import AquaFineTuningApp, CreateFineTuningDetails
 
 
@@ -19,10 +22,7 @@ class TestDataset:
         ft_name="test_ft_name",
         dataset_path="oci://ds_bucket@namespace/prefix/dataset.jsonl",
         report_path="oci://report_bucket@namespace/prefix/",
-        ft_parameters={
-            "epochs":1,
-            "learning_rate":0.02
-        },
+        ft_parameters={"epochs": 1, "learning_rate": 0.02},
         shape_name="VM.GPU.A10.1",
         replica=1,
         validation_set_size=0.2,
@@ -32,16 +32,12 @@ class TestDataset:
 
     mock_finetuning_config = {
         "shape": {
-            "VM.GPU.A10.1": {
-                "batch_size": 1,
-                "replica": 1
-            },
+            "VM.GPU.A10.1": {"batch_size": 1, "replica": 1},
         }
     }
 
 
 class FineTuningHandlerTestCase(TestCase):
-
     @patch.object(IPythonHandler, "__init__")
     def setUp(self, ipython_init_mock) -> None:
         ipython_init_mock.return_value = None
@@ -65,13 +61,11 @@ class FineTuningHandlerTestCase(TestCase):
     @patch.object(AquaFineTuningApp, "create")
     def test_post(self, mock_create):
         self.test_instance.get_json_body = MagicMock(
-            return_value = TestDataset.mock_valid_input
+            return_value=TestDataset.mock_valid_input
         )
         self.test_instance.post()
 
-        self.test_instance.finish.assert_called_with(
-            mock_create.return_value
-        )
+        self.test_instance.finish.assert_called_with(mock_create.return_value)
         mock_create.assert_called_with(
             CreateFineTuningDetails(**TestDataset.mock_valid_input)
         )
@@ -82,9 +76,38 @@ class FineTuningHandlerTestCase(TestCase):
 
         self.test_instance.get_finetuning_config(model_id="test_model_id")
 
-        self.test_instance.finish.assert_called_with(
-            TestDataset.mock_finetuning_config
-        )
-        mock_get_finetuning_config.assert_called_with(
-            model_id="test_model_id"
-        )
+        self.test_instance.finish.assert_called_with(TestDataset.mock_finetuning_config)
+        mock_get_finetuning_config.assert_called_with(model_id="test_model_id")
+
+
+class AquaFineTuneParamsHandlerTestCase(TestCase):
+    @patch.object(IPythonHandler, "__init__")
+    def setUp(self, ipython_init_mock) -> None:
+        ipython_init_mock.return_value = None
+        self.test_instance = AquaFineTuneParamsHandler(MagicMock(), MagicMock())
+
+    @patch.object(APIHandler, "finish")
+    @patch.object(AquaFineTuningApp, "get_finetuning_default_params")
+    def test_get_finetuning_default_params(
+        self, mock_get_finetuning_default_params, mock_finish
+    ):
+        default_params = [
+            "--batch_size 1",
+            "--sequence_len 2048",
+            "--sample_packing true",
+            "--pad_to_sequence_len true",
+            "--learning_rate 0.0002",
+            "--lora_r 32",
+            "--lora_alpha 16",
+            "--lora_dropout 0.05",
+            "--lora_target_linear true",
+            "--lora_target_modules q_proj,k_proj",
+        ]
+
+        mock_get_finetuning_default_params.return_value = default_params
+        mock_finish.side_effect = lambda x: x
+
+        result = self.test_instance.get(model_id="test_model_id")
+
+        assert result["data"] == default_params
+        mock_get_finetuning_default_params.assert_called_with(model_id="test_model_id")


### PR DESCRIPTION
### Description
This PR is built on top of changes made in [PR-827](https://github.com/oracle/accelerated-data-science/pull/827). 
We add a new API that returns the default params used for a fine tuning job. These params are read from ft_config.json but only those that are available in `AquaFineTuningParams` dataclass will be made available to the user. 


### Usage

#### Request
```
http://localhost:8888/aqua/finetuning/ocid1.datasciencemodel.oc1.iad.<ocid>/params
```
#### Response
```
{
    "data": [
        "--batch_size 1",
        "--sequence_len 2048",
        "--sample_packing true",
        "--pad_to_sequence_len true",
        "--learning_rate 0.0002",
        "--lora_r 32",
        "--lora_alpha 16",
        "--lora_dropout 0.05",
        "--lora_target_linear true",
        "--lora_target_modules q_proj,k_proj"
    ]
}
```
If ft_config.json is not available for the given model is, then the response will be:
```
{
    "data": []
}

```


### Tests
```
> python -m pytest -q tests/unitary/with_extras/aqua/test_finetuning.py
========================================= test session starts ==========================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 4 items

tests/unitary/with_extras/aqua/test_finetuning.py ....                                           [100%]

========================================== 4 passed in 3.67s ===========================================


> python -m pytest -q tests/unitary/with_extras/aqua/test_finetuning_handler.py
========================================= test session starts ==========================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 4 items

tests/unitary/with_extras/aqua/test_finetuning_handler.py ....                                   [100%]

========================================== 4 passed in 2.98s ===========================================
```