### PR TITLE
Update get and list model API

### DIFF
--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -54,7 +54,11 @@ class AquaModelHandler(AquaAPIhandler):
         project_id = self.get_argument("project_id", default=None)
         model_type = self.get_argument("model_type", default=None)
         return self.finish(
-            AquaModelApp().list(compartment_id, project_id, model_type=model_type)
+            AquaModelApp().list(
+                compartment_id=compartment_id,
+                project_id=project_id,
+                model_type=model_type,
+            )
         )
 
 

--- a/tests/unitary/with_extras/aqua/test_model_handler.py
+++ b/tests/unitary/with_extras/aqua/test_model_handler.py
@@ -64,7 +64,9 @@ class ModelHandlerTestCase(TestCase):
         self.model_handler.list()
 
         self.model_handler.finish.assert_called_with(mock_list.return_value)
-        mock_list.assert_called_with(None, None, model_type=None)
+        mock_list.assert_called_with(
+            compartment_id=None, project_id=None, model_type=None
+        )
 
 
 class ModelLicenseHandlerTestCase(TestCase):


### PR DESCRIPTION
### Description

The list and get API were failing due to a couple reasons:
1. model_type was passed as kwargs, which would be passed along to the datascience client's list_models API  when compartment id is not set. This would fail as this param is not an acceptable param for list_models as keyword args. 
2. is_shadow_type was defined after it was used, and aqua_model_attributes variable had a typo.

We now add a new param model_type to list_api instead of passing as kwargs. 

### Tests
```
> python -m pytest -q tests/unitary/with_extras/aqua/test_model.py
========================================= test session starts ==========================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 16 items

tests/unitary/with_extras/aqua/test_model.py ................                                    [100%]

========================================== 16 passed in 2.52s ==========================================


> python -m pytest -q tests/unitary/with_extras/aqua/test_model_handler.py
========================================= test session starts ==========================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 13 items

tests/unitary/with_extras/aqua/test_model_handler.py .............                               [100%]

========================================== 13 passed in 4.02s ========================================== 

```