### PR TITLE
Fix UI handler and deployment tests

### DIFF
--- a/tests/unitary/with_extras/aqua/test_data/ui/container_index.json
+++ b/tests/unitary/with_extras/aqua/test_data/ui/container_index.json
@@ -1,4 +1,25 @@
 {
+  "containerSpec": {
+    "odsc-vllm-serving": {
+      "cliParam": "--served-model-name $(python -c 'import os; print(os.environ.get(\"ODSC_SERVED_MODEL_NAME\",\"odsc-llm\"))') --seed 42 ",
+      "envVars": [
+        {
+          "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions"
+        },
+        {
+          "MODEL_DEPLOY_ENABLE_STREAMING": "true"
+        },
+        {
+          "PORT": "8080"
+        },
+        {
+          "HEALTH_CHECK_PORT": "8080"
+        }
+      ],
+      "healthCheckPort": "8080",
+      "serverPort": "8080"
+    }
+  },
   "odsc-llm-evaluate": [
     {
       "name": "dsmc://odsc-llm-evaluate",

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -274,11 +274,16 @@ class TestAquaDeployment(unittest.TestCase):
         result = self.app.get_deployment_config(TestDataset.MODEL_ID)
         assert result == config
 
+    @patch("ads.aqua.deployment.get_container_config")
     @patch("ads.aqua.model.AquaModelApp.create")
     @patch("ads.aqua.deployment.get_container_image")
     @patch("ads.model.deployment.model_deployment.ModelDeployment.deploy")
     def test_create_deployment_for_foundation_model(
-        self, mock_deploy, mock_get_container_image, mock_create
+        self,
+        mock_deploy,
+        mock_get_container_image,
+        mock_create,
+        mock_get_container_config,
     ):
         """Test to create a deployment for foundational model"""
         aqua_model = os.path.join(
@@ -292,6 +297,14 @@ class TestAquaDeployment(unittest.TestCase):
             config = json.load(_file)
 
         self.app.get_deployment_config = MagicMock(return_value=config)
+
+        container_index_json = os.path.join(
+            self.curr_dir, "test_data/ui/container_index.json"
+        )
+        with open(container_index_json, "r") as _file:
+            container_index_config = json.load(_file)
+        mock_get_container_config.return_value = container_index_config
+
         mock_get_container_image.return_value = TestDataset.DEPLOYMENT_IMAGE_NAME
         aqua_deployment = os.path.join(
             self.curr_dir, "test_data/deployment/aqua_create_deployment.yaml"
@@ -326,11 +339,16 @@ class TestAquaDeployment(unittest.TestCase):
         expected_result["state"] = "CREATING"
         assert actual_attributes == expected_result
 
+    @patch("ads.aqua.deployment.get_container_config")
     @patch("ads.aqua.model.AquaModelApp.create")
     @patch("ads.aqua.deployment.get_container_image")
     @patch("ads.model.deployment.model_deployment.ModelDeployment.deploy")
     def test_create_deployment_for_fine_tuned_model(
-        self, mock_deploy, mock_get_container_image, mock_create
+        self,
+        mock_deploy,
+        mock_get_container_image,
+        mock_create,
+        mock_get_container_config,
     ):
         """Test to create a deployment for fine-tuned model"""
 
@@ -359,6 +377,14 @@ class TestAquaDeployment(unittest.TestCase):
             config = json.load(_file)
 
         self.app.get_deployment_config = MagicMock(return_value=config)
+
+        container_index_json = os.path.join(
+            self.curr_dir, "test_data/ui/container_index.json"
+        )
+        with open(container_index_json, "r") as _file:
+            container_index_config = json.load(_file)
+        mock_get_container_config.return_value = container_index_config
+
         mock_get_container_image.return_value = TestDataset.DEPLOYMENT_IMAGE_NAME
         aqua_deployment = os.path.join(
             self.curr_dir, "test_data/deployment/aqua_create_deployment.yaml"

--- a/tests/unitary/with_extras/aqua/test_ui_handler.py
+++ b/tests/unitary/with_extras/aqua/test_ui_handler.py
@@ -14,7 +14,6 @@ import ads.config
 import ads.aqua
 from notebook.base.handlers import IPythonHandler
 from ads.aqua.extension.ui_handler import AquaUIHandler
-from ads.aqua.ui import AquaUIApp
 from ads.aqua.data import Tags
 
 
@@ -48,7 +47,7 @@ class TestAquaUIHandler(unittest.TestCase):
         reload(ads.aqua)
         reload(ads.aqua.extension.ui_handler)
 
-    @patch.object(AquaUIApp, "list_log_groups")
+    @patch("ads.aqua.ui.AquaUIApp.list_log_groups")
     def test_list_log_groups(self, mock_list_log_groups):
         """Test get method to fetch log groups"""
         self.ui_handler.request.path = "aqua/logging"
@@ -57,35 +56,35 @@ class TestAquaUIHandler(unittest.TestCase):
             compartment_id=TestDataset.USER_COMPARTMENT_ID
         )
 
-    @patch.object(AquaUIApp, "list_logs")
+    @patch("ads.aqua.ui.AquaUIApp.list_logs")
     def test_list_logs(self, mock_list_logs):
         """Test get method to fetch logs for a given log group."""
         self.ui_handler.request.path = "aqua/logging"
         self.ui_handler.get(id="mock-log-id")
         mock_list_logs.assert_called_with(log_group_id="mock-log-id")
 
-    @patch.object(AquaUIApp, "list_compartments")
+    @patch("ads.aqua.ui.AquaUIApp.list_compartments")
     def test_list_compartments(self, mock_list_compartments):
         """Test get method to fetch list of compartments."""
         self.ui_handler.request.path = "aqua/compartments"
         self.ui_handler.get()
         mock_list_compartments.assert_called()
 
-    @patch.object(AquaUIApp, "list_containers")
+    @patch("ads.aqua.ui.AquaUIApp.list_containers")
     def test_list_containers(self, mock_list_containers):
         """Test get method to fetch list of containers."""
         self.ui_handler.request.path = "aqua/containers"
         self.ui_handler.get()
         mock_list_containers.assert_called()
 
-    @patch.object(AquaUIApp, "get_default_compartment")
+    @patch("ads.aqua.ui.AquaUIApp.get_default_compartment")
     def test_get_default_compartment(self, mock_get_default_compartment):
         """Test get method to fetch default compartment."""
         self.ui_handler.request.path = "aqua/compartments/default"
         self.ui_handler.get()
         mock_get_default_compartment.assert_called()
 
-    @patch.object(AquaUIApp, "list_model_version_sets")
+    @patch("ads.aqua.ui.AquaUIApp.list_model_version_sets")
     def test_list_experiments(self, mock_list_experiments):
         """Test get method to fetch list of experiments."""
         self.ui_handler.request.path = "aqua/experiment"
@@ -95,7 +94,7 @@ class TestAquaUIHandler(unittest.TestCase):
             target_tag=Tags.AQUA_EVALUATION.value,
         )
 
-    @patch.object(AquaUIApp, "list_model_version_sets")
+    @patch("ads.aqua.ui.AquaUIApp.list_model_version_sets")
     def test_list_model_version_sets(self, mock_list_model_version_sets):
         """Test get method to fetch version sets."""
         self.ui_handler.request.path = "aqua/versionsets"
@@ -106,7 +105,7 @@ class TestAquaUIHandler(unittest.TestCase):
         )
 
     @parameterized.expand(["true", ""])
-    @patch.object(AquaUIApp, "list_buckets")
+    @patch("ads.aqua.ui.AquaUIApp.list_buckets")
     def test_list_buckets(self, versioned, mock_list_buckets):
         """Test get method to fetch list of buckets."""
         self.ui_handler.request.path = "aqua/buckets"
@@ -120,7 +119,7 @@ class TestAquaUIHandler(unittest.TestCase):
             versioned=True if versioned == "true" else False,
         )
 
-    @patch.object(AquaUIApp, "list_job_shapes")
+    @patch("ads.aqua.ui.AquaUIApp.list_job_shapes")
     def test_list_job_shapes(self, mock_list_job_shapes):
         """Test get method to fetch jobs shapes list."""
         self.ui_handler.request.path = "aqua/job/shapes"
@@ -129,14 +128,14 @@ class TestAquaUIHandler(unittest.TestCase):
             compartment_id=TestDataset.USER_COMPARTMENT_ID
         )
 
-    @patch.object(AquaUIApp, "list_vcn")
+    @patch("ads.aqua.ui.AquaUIApp.list_vcn")
     def test_list_vcn(self, mock_list_vcn):
         """Test get method to fetch list of vcns."""
         self.ui_handler.request.path = "aqua/vcn"
         self.ui_handler.get()
         mock_list_vcn.assert_called_with(compartment_id=TestDataset.USER_COMPARTMENT_ID)
 
-    @patch.object(AquaUIApp, "list_subnets")
+    @patch("ads.aqua.ui.AquaUIApp.list_subnets")
     def test_list_subnets(self, mock_list_subnets):
         """Test the get method to fetch list of subnets."""
         self.ui_handler.request.path = "aqua/subnets"
@@ -149,7 +148,7 @@ class TestAquaUIHandler(unittest.TestCase):
             compartment_id=TestDataset.USER_COMPARTMENT_ID, vcn_id="mock-vcn-id"
         )
 
-    @patch.object(AquaUIApp, "get_shape_availability")
+    @patch("ads.aqua.ui.AquaUIApp.get_shape_availability")
     def test_get_shape_availability(self, mock_get_shape_availability):
         """Test get shape availability."""
         self.ui_handler.request.path = "aqua/shapes/limit"
@@ -163,7 +162,7 @@ class TestAquaUIHandler(unittest.TestCase):
             instance_shape=TestDataset.DEPLOYMENT_SHAPE_NAME,
         )
 
-    @patch.object(AquaUIApp, "is_bucket_versioned")
+    @patch("ads.aqua.ui.AquaUIApp.is_bucket_versioned")
     def test_is_bucket_versioned(self, mock_is_bucket_versioned):
         """Test get method to check if a bucket is versioned."""
         self.ui_handler.request.path = "aqua/bucket/versioning"


### PR DESCRIPTION
### Description

UI Handler Unit test are failing on GH although they work fine locally. The error isn't evident as the tests are timing out before errors get printed. Testing the changes in this PR to check if the way we patch the mocks are causing any issue.

Also, a couple deployment tests were failing due to an additional config file loaded during creation. This has been fixed in this PR.


### Tests
```
> python -m pytest -q tests/unitary/with_extras/aqua/test_ui_handler.py
========================================= test session starts ==========================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 14 items

tests/unitary/with_extras/aqua/test_ui_handler.py ..............                                 [100%]

========================================== 14 passed in 5.77s ==========================================

> python -m pytest -q tests/unitary/with_extras/aqua/test_deployment.py
========================================= test session starts ==========================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 11 items

tests/unitary/with_extras/aqua/test_deployment.py ...........                                    [100%]

========================================== 11 passed in 4.55s ==========================================
```