### PR TITLE
Finetuning and MD default params dict

### DIFF
--- a/ads/aqua/finetuning/finetuning.py
+++ b/ads/aqua/finetuning/finetuning.py
@@ -6,8 +6,7 @@
 import json
 import os
 from dataclasses import asdict, fields
-from typing import Dict, List
-from collections import defaultdict
+from typing import Dict
 
 from oci.data_science.models import (
     Metadata,
@@ -575,7 +574,7 @@ class AquaFineTuningApp(AquaApp):
             Dict of parameters from the loaded from finetuning config json file. If config information is not available,
             then an empty dict is returned.
         """
-        default_params = defaultdict(dict)
+        default_params = {"params": {}}
         finetuning_config = self.get_finetuning_config(model_id)
         config_parameters = finetuning_config.get("configuration", UNKNOWN_DICT)
         dataclass_fields = {field.name for field in fields(AquaFineTuningParams)}

--- a/ads/aqua/finetuning/finetuning.py
+++ b/ads/aqua/finetuning/finetuning.py
@@ -571,9 +571,9 @@ class AquaFineTuningApp(AquaApp):
 
         Returns
         -------
-        List[str]:
-            List of parameters from the loaded from finetuning config json file. If config information is available,
-            then an empty list is returned.
+        Dict:
+            Dict of parameters from the loaded from finetuning config json file. If config information is not available,
+            then an empty dict is returned.
         """
         default_params = defaultdict(dict)
         finetuning_config = self.get_finetuning_config(model_id)

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -527,7 +527,7 @@ class AquaDeploymentApp(AquaApp):
         self,
         model_id: str,
         instance_shape: str,
-    ) -> Dict:
+    ) -> List[str]:
         """Gets the default params set in the deployment configs for the given model and instance shape.
 
         Parameters
@@ -546,8 +546,6 @@ class AquaDeploymentApp(AquaApp):
 
         """
         default_params = []
-        container_type = UNKNOWN
-
         model = DataScienceModel.from_id(model_id)
         try:
             container_type_key = model.custom_metadata_list.get(
@@ -572,12 +570,10 @@ class AquaDeploymentApp(AquaApp):
                     params = config_parameters.get(
                         InferenceContainerParamType.PARAM_TYPE_VLLM, UNKNOWN
                     )
-                    container_type = InferenceContainerType.CONTAINER_TYPE_VLLM
                 elif InferenceContainerType.CONTAINER_TYPE_TGI in container_type_key:
                     params = config_parameters.get(
                         InferenceContainerParamType.PARAM_TYPE_TGI, UNKNOWN
                     )
-                    container_type = InferenceContainerType.CONTAINER_TYPE_TGI
                 else:
                     params = UNKNOWN
                     logger.debug(
@@ -588,10 +584,7 @@ class AquaDeploymentApp(AquaApp):
                     # account for param that can have --arg but no values, e.g. --trust-remote-code
                     default_params.extend(get_params_list(params))
 
-        return dict(
-            container_type=container_type,
-            params=default_params,
-        )
+        return default_params
 
     def validate_deployment_params(
         self, model_id: str, params: List[str] = None

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -423,25 +423,21 @@ class TestAquaDeployment(unittest.TestCase):
         [
             (
                 "VLLM_PARAMS",
-                "vllm",
                 "odsc-vllm-serving",
                 ["--max-model-len 4096", "--seed 42", "--trust-remote-code"],
             ),
             (
                 "VLLM_PARAMS",
-                "vllm",
                 "odsc-vllm-serving",
                 [],
             ),
             (
                 "TGI_PARAMS",
-                "tgi",
                 "odsc-tgi-serving",
                 ["--sharded true", "--trust-remote-code"],
             ),
             (
                 "CUSTOM_PARAMS",
-                "",
                 "custom-container-key",
                 ["--max-model-len 4096", "--seed 42", "--trust-remote-code"],
             ),
@@ -449,12 +445,7 @@ class TestAquaDeployment(unittest.TestCase):
     )
     @patch("ads.model.datascience_model.DataScienceModel.from_id")
     def test_get_deployment_default_params(
-        self,
-        container_params_field,
-        container_type,
-        container_type_key,
-        params,
-        mock_from_id,
+        self, container_params_field, container_type_key, params, mock_from_id
     ):
         """Test for fetching config details for a given deployment."""
 
@@ -480,12 +471,10 @@ class TestAquaDeployment(unittest.TestCase):
         result = self.app.get_deployment_default_params(
             TestDataset.MODEL_ID, TestDataset.DEPLOYMENT_SHAPE_NAME
         )
-
-        assert result["container_type"] == container_type
         if container_params_field == "CUSTOM_PARAMS":
-            assert result["params"] == []
+            assert result == []
         else:
-            assert result["params"] == params
+            assert result == params
 
     @parameterized.expand(
         [

--- a/tests/unitary/with_extras/aqua/test_finetuning.py
+++ b/tests/unitary/with_extras/aqua/test_finetuning.py
@@ -262,7 +262,7 @@ class FineTuningTestCase(TestCase):
         # check when config json is not available
         self.app.get_finetuning_config = MagicMock(return_value={})
         result = self.app.get_finetuning_default_params(model_id="test_model_id")
-        assert result == {}
+        assert result == {"params": {}}
 
     @parameterized.expand(
         [

--- a/tests/unitary/with_extras/aqua/test_finetuning.py
+++ b/tests/unitary/with_extras/aqua/test_finetuning.py
@@ -237,32 +237,32 @@ class FineTuningTestCase(TestCase):
     def test_get_finetuning_default_params(self):
         """Test for fetching finetuning config params for a given model."""
 
+        params_dict = {
+            "params": {
+                "batch_size": 1,
+                "sequence_len": 2048,
+                "sample_packing": True,
+                "pad_to_sequence_len": True,
+                "learning_rate": 0.0002,
+                "lora_r": 32,
+                "lora_alpha": 16,
+                "lora_dropout": 0.05,
+                "lora_target_linear": True,
+                "lora_target_modules": ["q_proj", "k_proj"],
+            }
+        }
         config_json = os.path.join(self.curr_dir, "test_data/finetuning/ft_config.json")
         with open(config_json, "r") as _file:
             config = json.load(_file)
 
         self.app.get_finetuning_config = MagicMock(return_value=config)
         result = self.app.get_finetuning_default_params(model_id="test_model_id")
-        self.assertCountEqual(
-            result,
-            [
-                "--batch_size 1",
-                "--sequence_len 2048",
-                "--sample_packing true",
-                "--pad_to_sequence_len true",
-                "--learning_rate 0.0002",
-                "--lora_r 32",
-                "--lora_alpha 16",
-                "--lora_dropout 0.05",
-                "--lora_target_linear true",
-                "--lora_target_modules q_proj,k_proj",
-            ],
-        )
+        assert result == params_dict
 
         # check when config json is not available
         self.app.get_finetuning_config = MagicMock(return_value={})
         result = self.app.get_finetuning_default_params(model_id="test_model_id")
-        assert result == []
+        assert result == {}
 
     @parameterized.expand(
         [


### PR DESCRIPTION
### Description
Instead of returning a list of string parameters, the default FT params are returned as a dict. This ensures that UI does not have to understand the param type and validation becomes easier as well.


### Invoke the API

#### Request
```
http://localhost:8888/aqua/finetuning/ocid1.datasciencemodel.oc1.iad.<ocid>/params
```

#### Response
```
{
    "params": {
        "batch_size": 1,
        "sequence_len": 2048,
        "sample_packing": true,
        "pad_to_sequence_len": true,
        "learning_rate": 0.0002,
        "lora_r": 32,
        "lora_alpha": 16,
        "lora_dropout": 0.05,
        "lora_target_linear": true,
        "lora_target_modules": [
            "q_proj",
            "k_proj"
        ]
    }
}
```

### Tests
```
> python -m pytest -q tests/unitary/with_extras/aqua/test_finetuning.py
========================================= test session starts ==========================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 6 items

tests/unitary/with_extras/aqua/test_finetuning.py ......                                         [100%]

========================================== 6 passed in 4.25s ===========================================
> python -m pytest -q tests/unitary/with_extras/aqua/test_finetuning_handler.py
========================================= test session starts ==========================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 5 items

tests/unitary/with_extras/aqua/test_finetuning_handler.py .....                                  [100%]

========================================== 5 passed in 2.84s ===========================================
```