### PR TITLE
Minor changes for Verified Models

### DIFF
--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -189,7 +189,7 @@ class AquaHuggingFaceHandler(AquaAPIhandler):
                 "Please select a model with a compatible pipeline tag."
             )
 
-        # Check if it is a service/shadow model
+        # Check if it is a service/verified model
         aqua_model_info: AquaModelSummary = self._find_matching_aqua_model(
             model_id=hf_model_info.id
         )


### PR DESCRIPTION
### Description

This PR covers the following:
1. Rename shadow models to verified models.
2. use model_name instead of base path name for registered models.
3. Remove `local_dir_use_symlinks` param while downloading model from huggingface.
4. Remove `inference_container` check when registered models.
5. Remove unused imports.

### Tests

```
> python -m pytest -q tests/unitary/with_extras/aqua/test_model.py
==================================================== test session starts =====================================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 16 items

tests/unitary/with_extras/aqua/test_model.py ................                                                          [100%]

===================================================== 16 passed in 3.29s =====================================================
> python -m pytest -q tests/unitary/with_extras/aqua/test_model_handler.py
==================================================== test session starts =====================================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 13 items

tests/unitary/with_extras/aqua/test_model_handler.py .............                                                     [100%]

===================================================== 13 passed in 3.53s =====================================================
```