### PR TITLE
Fix version of HF hub in ads

### DIFF
--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -771,8 +771,7 @@ class AquaModelApp(AquaApp):
         os.makedirs(local_dir, exist_ok=True)
         # Copy the model from the cache to destination
         snapshot_download(
-            repo_id=model_name,
-            local_dir=local_dir,
+            repo_id=model_name, local_dir=local_dir, local_dir_use_symlinks=False
         )
         # Upload to object storage
         model_artifact_path = upload_folder(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ opctl = [
   "rich",
   "fire",
   "cachetools",
-  "huggingface_hub"
+  "huggingface_hub==0.22.2"
 ]
 optuna = ["optuna==2.9.0", "oracle_ads[viz]"]
 spark = ["pyspark>=3.0.0"]

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -577,6 +577,7 @@ class TestAquaModel:
             mock_snapshot_download.assert_called_with(
                 repo_id=hf_model,
                 local_dir=f"{str(tmpdir)}/{hf_model}",
+                local_dir_use_symlinks=False,
             )
             mock_subprocess.assert_called_with(
                 shlex.split(
@@ -779,6 +780,7 @@ class TestAquaModel:
                 mock_snapshot_download.assert_called_with(
                     repo_id=hf_model,
                     local_dir=f"{str(tmpdir)}/{hf_model}",
+                    local_dir_use_symlinks=False,
                 )
                 mock_subprocess.assert_called_with(
                     shlex.split(
@@ -894,6 +896,7 @@ class TestAquaModel:
                 mock_snapshot_download.assert_called_with(
                     repo_id=hf_model,
                     local_dir=f"{str(tmpdir)}/{hf_model}",
+                    local_dir_use_symlinks=False,
                 )
                 mock_subprocess.assert_called_with(
                     shlex.split(


### PR DESCRIPTION
### Description

This PR fixes the huggingface-hub version to 0.22.2 in ads. We can remove `local_dir_use_symlinks` reference from ads once huggingface-hub is updated to 0.23.*.

### Unit Tests
```
> python -m pytest -q tests/unitary/with_extras/aqua/test_model.py
==================================================== test session starts =====================================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 16 items

tests/unitary/with_extras/aqua/test_model.py ................                                                          [100%]

===================================================== 16 passed in 2.04s =====================================================
```