### PR TITLE
Copy verified configs for imported models

### DIFF
--- a/ads/aqua/common/utils.py
+++ b/ads/aqua/common/utils.py
@@ -100,23 +100,6 @@ LIFECYCLE_DETAILS_MAPPING = {
     JobRun.LIFECYCLE_STATE_NEEDS_ATTENTION: "Missing jobrun information.",
 }
 
-CONSOLE_LINK_RESOURCE_TYPE_MAPPING = dict(
-    datasciencemodel="models",
-    datasciencemodeldeployment="model-deployments",
-    datasciencemodeldeploymentdev="model-deployments",
-    datasciencemodeldeploymentint="model-deployments",
-    datasciencemodeldeploymentpre="model-deployments",
-    datasciencejob="jobs",
-    datasciencejobrun="job-runs",
-    datasciencejobrundev="job-runs",
-    datasciencejobrunint="job-runs",
-    datasciencejobrunpre="job-runs",
-    datasciencemodelversionset="model-version-sets",
-    datasciencemodelversionsetpre="model-version-sets",
-    datasciencemodelversionsetint="model-version-sets",
-    datasciencemodelversionsetdev="model-version-sets",
-)
-
 
 def random_color_generator(word: str):
     seed = sum([ord(c) for c in word]) % 13

--- a/ads/aqua/constants.py
+++ b/ads/aqua/constants.py
@@ -41,3 +41,20 @@ VALIDATION_METRICS = "validation_metrics"
 SERVICE_MANAGED_CONTAINER_URI_SCHEME = "dsmc://"
 SUPPORTED_FILE_FORMATS = ["jsonl"]
 MODEL_BY_REFERENCE_OSS_PATH_KEY = "artifact_location"
+
+CONSOLE_LINK_RESOURCE_TYPE_MAPPING = dict(
+    datasciencemodel="models",
+    datasciencemodeldeployment="model-deployments",
+    datasciencemodeldeploymentdev="model-deployments",
+    datasciencemodeldeploymentint="model-deployments",
+    datasciencemodeldeploymentpre="model-deployments",
+    datasciencejob="jobs",
+    datasciencejobrun="job-runs",
+    datasciencejobrundev="job-runs",
+    datasciencejobrunint="job-runs",
+    datasciencejobrunpre="job-runs",
+    datasciencemodelversionset="model-version-sets",
+    datasciencemodelversionsetpre="model-version-sets",
+    datasciencemodelversionsetint="model-version-sets",
+    datasciencemodelversionsetdev="model-version-sets",
+)

--- a/ads/aqua/evaluation/evaluation.py
+++ b/ads/aqua/evaluation/evaluation.py
@@ -50,6 +50,7 @@ from ads.aqua.constants import (
     JOB_INFRASTRUCTURE_TYPE_DEFAULT_NETWORKING,
     NB_SESSION_IDENTIFIER,
     UNKNOWN,
+    CONSOLE_LINK_RESOURCE_TYPE_MAPPING,
 )
 from ads.aqua.evaluation.constants import *
 from ads.aqua.evaluation.entities import *
@@ -1344,7 +1345,7 @@ class AquaEvaluationApp(AquaApp):
     ) -> AquaResourceIdentifier:
         """Constructs AquaResourceIdentifier based on the given ocid and display name."""
         try:
-            resource_type = utils.CONSOLE_LINK_RESOURCE_TYPE_MAPPING.get(
+            resource_type = CONSOLE_LINK_RESOURCE_TYPE_MAPPING.get(
                 utils.get_resource_type(id)
             )
 

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -21,6 +21,7 @@ from ads.aqua.common.utils import (
     is_service_managed_container,
     read_file,
     upload_folder,
+    copy_model_config,
 )
 from ads.aqua.constants import (
     LICENSE_TXT,
@@ -660,11 +661,17 @@ class AquaModelApp(AquaApp):
 
         try:
             # If verified model already has a artifact json, use that.
-            metadata.get(MODEL_BY_REFERENCE_OSS_PATH_KEY)
+            artifact_path = metadata.get(MODEL_BY_REFERENCE_OSS_PATH_KEY).value
             logger.info(
                 f"Found model artifact in the service bucket. "
                 f"Using artifact from service bucket instead of {os_path}"
             )
+
+            # copy model config from artifact path to user bucket
+            copy_model_config(
+                artifact_path=artifact_path, os_path=os_path, auth=self._auth
+            )
+
         except:
             # Add artifact from user bucket
             metadata.add(

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -667,6 +667,7 @@ class AquaModelApp(AquaApp):
                 f"Using artifact from service bucket instead of {os_path}"
             )
 
+            # todo: implement generic copy_folder method
             # copy model config from artifact path to user bucket
             copy_model_config(
                 artifact_path=artifact_path, os_path=os_path, auth=self._auth


### PR DESCRIPTION
### Description

This PR covers the following:
1. CONSOLE_LINK_RESOURCE_TYPE_MAPPING was missing in utils.py after code refactor.
2. is_valid_ocid now checks if input begins with ocid instead of regex check.
3. If container_index is not accessible, then print debug logs instead of error.
4. `copy_model_config` util function added which copies config json from artifact path of verified models to user bucket.

### Tests

```
> python -m pytest -q tests/unitary/with_extras/aqua/test_model.py
==================================================== test session starts =====================================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 17 items

tests/unitary/with_extras/aqua/test_model.py .................                                                         [100%]

===================================================== 17 passed in 4.42s =====================================================

```