### PR TITLE
Refactor base handler

### DIFF
--- a/ads/aqua/common/enums.py
+++ b/ads/aqua/common/enums.py
@@ -24,11 +24,6 @@ class Resource(str, metaclass=ExtendedEnumMeta):
     MODEL_VERSION_SET = "model-version-sets"
 
 
-class DataScienceResource(str, metaclass=ExtendedEnumMeta):
-    MODEL_DEPLOYMENT = "datasciencemodeldeployment"
-    MODEL = "datasciencemodel"
-
-
 class Tags(str, metaclass=ExtendedEnumMeta):
     TASK = "task"
     LICENSE = "license"

--- a/ads/aqua/extension/base_handler.py
+++ b/ads/aqua/extension/base_handler.py
@@ -137,10 +137,3 @@ class AquaAPIhandler(APIHandler):
             return messages[status_code]
         else:
             return default_msg
-
-
-# todo: remove after error handler is implemented
-class Errors(str):
-    INVALID_INPUT_DATA_FORMAT = "Invalid format of input data."
-    NO_INPUT_DATA = "No input data provided."
-    MISSING_REQUIRED_PARAMETER = "Missing required parameter: '{}'"

--- a/ads/aqua/extension/deployment_handler.py
+++ b/ads/aqua/extension/deployment_handler.py
@@ -8,7 +8,8 @@ from urllib.parse import urlparse
 from tornado.web import HTTPError
 
 from ads.aqua.common.decorator import handle_exceptions
-from ads.aqua.extension.base_handler import AquaAPIhandler, Errors
+from ads.aqua.extension.errors import Errors
+from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua.modeldeployment import AquaDeploymentApp, MDInferenceResponse
 from ads.aqua.modeldeployment.entities import ModelParams
 from ads.config import COMPARTMENT_OCID, PROJECT_OCID

--- a/ads/aqua/extension/errors.py
+++ b/ads/aqua/extension/errors.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+
+class Errors(str):
+    INVALID_INPUT_DATA_FORMAT = "Invalid format of input data."
+    NO_INPUT_DATA = "No input data provided."
+    MISSING_REQUIRED_PARAMETER = "Missing required parameter: '{}'"

--- a/ads/aqua/extension/evaluation_handler.py
+++ b/ads/aqua/extension/evaluation_handler.py
@@ -10,7 +10,8 @@ from tornado.web import HTTPError
 from ads.aqua.common.decorator import handle_exceptions
 from ads.aqua.evaluation import AquaEvaluationApp
 from ads.aqua.evaluation.entities import CreateAquaEvaluationDetails
-from ads.aqua.extension.base_handler import AquaAPIhandler, Errors
+from ads.aqua.extension.errors import Errors
+from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua.extension.utils import validate_function_parameters
 from ads.config import COMPARTMENT_OCID
 

--- a/ads/aqua/extension/finetune_handler.py
+++ b/ads/aqua/extension/finetune_handler.py
@@ -9,7 +9,8 @@ from urllib.parse import urlparse
 from tornado.web import HTTPError
 
 from ads.aqua.common.decorator import handle_exceptions
-from ads.aqua.extension.base_handler import AquaAPIhandler, Errors
+from ads.aqua.extension.errors import Errors
+from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua.extension.utils import validate_function_parameters
 from ads.aqua.finetuning import AquaFineTuningApp
 from ads.aqua.finetuning.entities import CreateFineTuningDetails

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -18,7 +18,8 @@ from tornado.web import HTTPError
 
 from ads.aqua.common.decorator import handle_exceptions
 from ads.aqua.common.errors import AquaRuntimeError
-from ads.aqua.extension.base_handler import AquaAPIhandler, Errors
+from ads.aqua.extension.errors import Errors
+from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua.model import AquaModelApp
 from ads.aqua.model.constants import ModelTask
 from ads.aqua.model.entities import AquaModelSummary, HFModelSummary

--- a/ads/aqua/extension/ui_handler.py
+++ b/ads/aqua/extension/ui_handler.py
@@ -10,7 +10,8 @@ from tornado.web import HTTPError
 
 from ads.aqua.common.decorator import handle_exceptions
 from ads.aqua.common.enums import Tags
-from ads.aqua.extension.base_handler import AquaAPIhandler, Errors
+from ads.aqua.extension.errors import Errors
+from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua.extension.utils import validate_function_parameters
 from ads.aqua.model.entities import ImportModelDetails
 from ads.aqua.ui import AquaUIApp

--- a/ads/aqua/extension/utils.py
+++ b/ads/aqua/extension/utils.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 
 from tornado.web import HTTPError
 
-from ads.aqua.extension.base_handler import Errors
+from ads.aqua.extension.errors import Errors
 
 
 def validate_function_parameters(data_class, input_data: Dict):

--- a/tests/unitary/with_extras/aqua/test_deployment_handler.py
+++ b/tests/unitary/with_extras/aqua/test_deployment_handler.py
@@ -136,9 +136,7 @@ class AquaDeploymentParamsHandlerTestCase(unittest.TestCase):
         self.test_instance = AquaDeploymentParamsHandler(MagicMock(), MagicMock())
 
     @patch("notebook.base.handlers.APIHandler.finish")
-    @patch(
-        "ads.aqua.modeldeployment.deployment.AquaDeploymentApp.get_deployment_default_params"
-    )
+    @patch("ads.aqua.modeldeployment.AquaDeploymentApp.get_deployment_default_params")
     def test_get_deployment_default_params(
         self, mock_get_deployment_default_params, mock_finish
     ):
@@ -159,9 +157,7 @@ class AquaDeploymentParamsHandlerTestCase(unittest.TestCase):
         )
 
     @patch("notebook.base.handlers.APIHandler.finish")
-    @patch(
-        "ads.aqua.modeldeployment.deployment.AquaDeploymentApp.validate_deployment_params"
-    )
+    @patch("ads.aqua.modeldeployment.AquaDeploymentApp.validate_deployment_params")
     def test_validate_deployment_params(
         self, mock_validate_deployment_params, mock_finish
     ):

--- a/tests/unitary/with_extras/aqua/test_evaluation_handler.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation_handler.py
@@ -11,7 +11,7 @@ from parameterized import parameterized
 
 from ads.aqua.evaluation import AquaEvaluationApp
 from ads.aqua.evaluation.entities import CreateAquaEvaluationDetails
-from ads.aqua.extension.base_handler import Errors
+from ads.aqua.extension.errors import Errors
 from ads.aqua.extension.evaluation_handler import AquaEvaluationHandler
 from tests.unitary.with_extras.aqua.utils import HandlerTestDataset as TestDataset
 


### PR DESCRIPTION
### Description

This PR covers the following:
1. Move Error class from `ads/aqua/extension/base_handler.py` to `ads/aqua/extension/errors.py`. 
2. Remove duplicate DataScienceResource enum in `ads/aqua/common/enums.py`.


### Tests

```
> python -m pytest -q tests/unitary/with_extras/aqua/test_*handler.py
==================================================== test session starts =====================================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 56 items

tests/unitary/with_extras/aqua/test_common_handler.py ...                                                              [  5%]
tests/unitary/with_extras/aqua/test_deployment_handler.py ..s.....                                                     [ 19%]
tests/unitary/with_extras/aqua/test_evaluation_handler.py .........                                                    [ 35%]
tests/unitary/with_extras/aqua/test_finetuning_handler.py .....                                                        [ 44%]
tests/unitary/with_extras/aqua/test_model_handler.py .............                                                     [ 67%]
tests/unitary/with_extras/aqua/test_ui_handler.py ..............                                                       [ 92%]
tests/unitary/with_extras/aqua/test_ui_websocket_handler.py ....                                                       [100%]

=============================================== 55 passed, 1 skipped in 11.57s ===============================================
```