### PR TITLE
skip prompt when file is already uploaded to os

### DIFF
--- a/ads/aqua/common/utils.py
+++ b/ads/aqua/common/utils.py
@@ -739,7 +739,7 @@ def upload_folder(os_path: str, local_dir: str, model_name: str) -> str:
         raise ValueError(f"Version is not enabled at object storage location {os_path}")
     auth_state = AuthState()
     object_path = os_details.filepath.rstrip("/") + "/" + model_name + "/"
-    command = f"oci os object bulk-upload --src-dir {local_dir} --prefix {object_path} -bn {os_details.bucket} -ns {os_details.namespace} --auth {auth_state.oci_iam_type} --profile {auth_state.oci_key_profile}"
+    command = f"oci os object bulk-upload --src-dir {local_dir} --prefix {object_path} -bn {os_details.bucket} -ns {os_details.namespace} --auth {auth_state.oci_iam_type} --profile {auth_state.oci_key_profile} --no-overwrite"
     try:
         logger.info(f"Running: {command}")
         subprocess.check_call(shlex.split(command))

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -613,7 +613,7 @@ class TestAquaModel:
                 mock_copy_file.assert_called()
             mock_subprocess.assert_called_with(
                 shlex.split(
-                    f"oci os object bulk-upload --src-dir {str(tmpdir)}/{hf_model} --prefix prefix/path/{hf_model}/ -bn aqua-bkt -ns aqua-ns --auth api_key --profile DEFAULT"
+                    f"oci os object bulk-upload --src-dir {str(tmpdir)}/{hf_model} --prefix prefix/path/{hf_model}/ -bn aqua-bkt -ns aqua-ns --auth api_key --profile DEFAULT --no-overwrite"
                 )
             )
             ds_freeform_tags.pop(
@@ -818,7 +818,7 @@ class TestAquaModel:
                 )
                 mock_subprocess.assert_called_with(
                     shlex.split(
-                        f"oci os object bulk-upload --src-dir {str(tmpdir)}/{hf_model} --prefix prefix/path/{hf_model}/ -bn aqua-bkt -ns aqua-ns --auth api_key --profile DEFAULT"
+                        f"oci os object bulk-upload --src-dir {str(tmpdir)}/{hf_model} --prefix prefix/path/{hf_model}/ -bn aqua-bkt -ns aqua-ns --auth api_key --profile DEFAULT --no-overwrite"
                     )
                 )
                 assert model.freeform_tags == {
@@ -934,7 +934,7 @@ class TestAquaModel:
                 )
                 mock_subprocess.assert_called_with(
                     shlex.split(
-                        f"oci os object bulk-upload --src-dir {str(tmpdir)}/{hf_model} --prefix prefix/path/{hf_model}/ -bn aqua-bkt -ns aqua-ns --auth api_key --profile DEFAULT"
+                        f"oci os object bulk-upload --src-dir {str(tmpdir)}/{hf_model} --prefix prefix/path/{hf_model}/ -bn aqua-bkt -ns aqua-ns --auth api_key --profile DEFAULT --no-overwrite"
                     )
                 )
                 assert model.freeform_tags == {


### PR DESCRIPTION
Adding a --no-overwrite flag to the `oci os bulk-upload` command to avoid asking for user input when the file was already uploaded to the location. 