### PR TITLE
Accept container family as input for model creation and param validation

### DIFF
--- a/ads/aqua/common/enums.py
+++ b/ads/aqua/common/enums.py
@@ -40,6 +40,10 @@ class Tags(str, metaclass=ExtendedEnumMeta):
     AQUA_EVALUATION_MODEL_ID = "evaluation_model_id"
 
 
+class HuggingFaceTags(str, metaclass=ExtendedEnumMeta):
+    TEXT_GENERATION_INFERENCE = "text-generation-inference"
+
+
 class RqsAdditionalDetails(str, metaclass=ExtendedEnumMeta):
     METADATA = "metadata"
     CREATED_BY = "createdBy"

--- a/ads/aqua/common/enums.py
+++ b/ads/aqua/common/enums.py
@@ -40,6 +40,21 @@ class Tags(str, metaclass=ExtendedEnumMeta):
     AQUA_EVALUATION_MODEL_ID = "evaluation_model_id"
 
 
+class InferenceContainerType(str, metaclass=ExtendedEnumMeta):
+    CONTAINER_TYPE_VLLM = "vllm"
+    CONTAINER_TYPE_TGI = "tgi"
+
+
+class InferenceContainerTypeFamily(str, metaclass=ExtendedEnumMeta):
+    AQUA_VLLM_CONTAINER_FAMILY = "odsc-vllm-serving"
+    AQUA_TGI_CONTAINER_FAMILY = "odsc-tgi-serving"
+
+
+class InferenceContainerParamType(str, metaclass=ExtendedEnumMeta):
+    PARAM_TYPE_VLLM = "VLLM_PARAMS"
+    PARAM_TYPE_TGI = "TGI_PARAMS"
+
+
 class HuggingFaceTags(str, metaclass=ExtendedEnumMeta):
     TEXT_GENERATION_INFERENCE = "text-generation-inference"
 

--- a/ads/aqua/extension/deployment_handler.py
+++ b/ads/aqua/extension/deployment_handler.py
@@ -99,6 +99,7 @@ class AquaDeploymentHandler(AquaAPIhandler):
         server_port = input_data.get("server_port")
         health_check_port = input_data.get("health_check_port")
         env_var = input_data.get("env_var")
+        container_family = input_data.get("container_family")
 
         self.finish(
             AquaDeploymentApp().create(
@@ -117,6 +118,7 @@ class AquaDeploymentHandler(AquaAPIhandler):
                 server_port=server_port,
                 health_check_port=health_check_port,
                 env_var=env_var,
+                container_family=container_family,
             )
         )
 
@@ -245,10 +247,12 @@ class AquaDeploymentParamsHandler(AquaAPIhandler):
             raise HTTPError(400, Errors.MISSING_REQUIRED_PARAMETER.format("model_id"))
 
         params = input_data.get("params")
+        container_family = input_data.get("container_family")
         return self.finish(
             AquaDeploymentApp().validate_deployment_params(
                 model_id=model_id,
                 params=params,
+                container_family=container_family,
             )
         )
 

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -38,6 +38,7 @@ from ads.aqua.constants import (
 )
 from ads.aqua.model.constants import *
 from ads.aqua.model.entities import *
+from ads.aqua.modeldeployment.enums import InferenceContainerTypeKey
 from ads.common.auth import default_signer
 from ads.common.oci_resource import SEARCH_TYPE, OCIResource
 from ads.common.utils import get_console_link
@@ -621,7 +622,15 @@ class AquaModelApp(AquaApp):
                 )
             else:
                 logger.warn(
-                    f"Require Inference container information. Model: {model_name} does not have associated inference container defaults. Check docs for more information on how to pass inference container. Proceeding with model registration without the fine-tuning container information. This model will not be available for fine tuning."
+                    f"Proceeding with model registration without the fine-tuning container information. "
+                    f"This model will not be available for fine tuning."
+                )
+
+            if not inference_container:
+                inference_container = InferenceContainerTypeKey.AQUA_TGI_CONTAINER_KEY
+                logger.info(
+                    f"Model: {model_name} does not have associated inference container defaults. "
+                    f"{inference_container} will be used instead."
                 )
             metadata.add(
                 key=AQUA_DEPLOYMENT_CONTAINER_METADATA_NAME,

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -13,7 +13,7 @@ from oci.data_science.models import JobRun, Model
 
 from ads.aqua import ODSC_MODEL_COMPARTMENT_OCID
 from ads.aqua.app import AquaApp
-from ads.aqua.common.enums import Tags
+from ads.aqua.common.enums import Tags, HuggingFaceTags
 from ads.aqua.common.errors import AquaRuntimeError
 from ads.aqua.common.utils import (
     create_word_icon,
@@ -627,7 +627,13 @@ class AquaModelApp(AquaApp):
                 )
 
             if not inference_container:
-                inference_container = InferenceContainerTypeKey.AQUA_TGI_CONTAINER_KEY
+                inference_container = (
+                    InferenceContainerTypeKey.AQUA_TGI_CONTAINER_KEY
+                    if model_info
+                    and model_info.tags
+                    and HuggingFaceTags.TEXT_GENERATION_INFERENCE in model_info.tags
+                    else InferenceContainerTypeKey.AQUA_VLLM_CONTAINER_KEY
+                )
                 logger.info(
                     f"Model: {model_name} does not have associated inference container defaults. "
                     f"{inference_container} will be used instead."

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -13,7 +13,7 @@ from oci.data_science.models import JobRun, Model
 
 from ads.aqua import ODSC_MODEL_COMPARTMENT_OCID
 from ads.aqua.app import AquaApp
-from ads.aqua.common.enums import Tags, HuggingFaceTags
+from ads.aqua.common.enums import Tags, HuggingFaceTags, InferenceContainerTypeFamily
 from ads.aqua.common.errors import AquaRuntimeError
 from ads.aqua.common.utils import (
     create_word_icon,
@@ -38,7 +38,6 @@ from ads.aqua.constants import (
 )
 from ads.aqua.model.constants import *
 from ads.aqua.model.entities import *
-from ads.aqua.modeldeployment.enums import InferenceContainerTypeKey
 from ads.common.auth import default_signer
 from ads.common.oci_resource import SEARCH_TYPE, OCIResource
 from ads.common.utils import get_console_link
@@ -628,11 +627,11 @@ class AquaModelApp(AquaApp):
 
             if not inference_container:
                 inference_container = (
-                    InferenceContainerTypeKey.AQUA_TGI_CONTAINER_KEY
+                    InferenceContainerTypeFamily.AQUA_TGI_CONTAINER_FAMILY
                     if model_info
                     and model_info.tags
                     and HuggingFaceTags.TEXT_GENERATION_INFERENCE in model_info.tags
-                    else InferenceContainerTypeKey.AQUA_VLLM_CONTAINER_KEY
+                    else InferenceContainerTypeFamily.AQUA_VLLM_CONTAINER_FAMILY
                 )
                 logger.info(
                     f"Model: {model_name} does not have associated inference container defaults. "

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -788,7 +788,7 @@ class AquaModelApp(AquaApp):
                 break
         if i == retry:
             raise Exception(
-                "Could not download the model {model_name} from https://huggingface.co with message {huggingface_download}"
+                f"Could not download the model {model_name} from https://huggingface.co with message {huggingface_download_err_message}"
             )
         os.makedirs(local_dir, exist_ok=True)
         # Copy the model from the cache to destination

--- a/ads/aqua/modeldeployment/constants.py
+++ b/ads/aqua/modeldeployment/constants.py
@@ -10,4 +10,5 @@ aqua.modeldeployment.constants
 This module contains constants used in Aqua Model Deployment.
 """
 
-VLLMInferenceRestrictedParams = {"tensor-parallel-size"}
+VLLMInferenceRestrictedParams = {"--tensor-parallel-size"}
+TGIInferenceRestrictedParams = {"--port"}

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -10,7 +10,12 @@ from typing import Dict, List, Union
 from oci.data_science.models import ModelDeployment
 
 from ads.aqua.app import AquaApp, logger
-from ads.aqua.common.enums import Tags
+from ads.aqua.common.enums import (
+    Tags,
+    InferenceContainerParamType,
+    InferenceContainerType,
+    InferenceContainerTypeFamily,
+)
 from ads.aqua.common.errors import AquaRuntimeError, AquaValueError
 from ads.aqua.common.utils import (
     get_container_config,
@@ -41,11 +46,6 @@ from ads.aqua.modeldeployment.entities import (
 from ads.aqua.modeldeployment.constants import (
     VLLMInferenceRestrictedParams,
     TGIInferenceRestrictedParams,
-)
-from ads.aqua.modeldeployment.enums import (
-    InferenceContainerParamType,
-    InferenceContainerType,
-    InferenceContainerTypeKey,
 )
 from ads.common.object_storage_details import ObjectStorageDetails
 from ads.common.utils import get_log_links
@@ -241,7 +241,7 @@ class AquaDeploymentApp(AquaApp):
             if not container_family:
                 raise AquaValueError(
                     f"{message}. For unverified Aqua models, container_family parameter should be "
-                    f"set and value can be one of {', '.join(InferenceContainerTypeKey.values())}."
+                    f"set and value can be one of {', '.join(InferenceContainerTypeFamily.values())}."
                 )
             container_type_key = container_family
         try:
@@ -572,7 +572,7 @@ class AquaDeploymentApp(AquaApp):
 
         if container_type_key:
             container_type_key = container_type_key.lower()
-            if container_type_key in InferenceContainerTypeKey.values():
+            if container_type_key in InferenceContainerTypeFamily.values():
                 deployment_config = self.get_deployment_config(model_id)
                 config_parameters = (
                     deployment_config.get("configuration", UNKNOWN_DICT)
@@ -639,7 +639,7 @@ class AquaDeploymentApp(AquaApp):
                 if not container_family:
                     raise AquaValueError(
                         f"{message}. For unverified Aqua models, container_family parameter should be "
-                        f"set and value can be one of {', '.join(InferenceContainerTypeKey.values())}."
+                        f"set and value can be one of {', '.join(InferenceContainerTypeFamily.values())}."
                     )
                 container_type_key = container_family
 

--- a/ads/aqua/modeldeployment/enums.py
+++ b/ads/aqua/modeldeployment/enums.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*--
-
-# Copyright (c) 2024 Oracle and/or its affiliates.
-# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/

--- a/ads/aqua/modeldeployment/enums.py
+++ b/ads/aqua/modeldeployment/enums.py
@@ -3,20 +3,3 @@
 
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
-
-from ads.common.extended_enum import ExtendedEnumMeta
-
-
-class InferenceContainerType(str, metaclass=ExtendedEnumMeta):
-    CONTAINER_TYPE_VLLM = "vllm"
-    CONTAINER_TYPE_TGI = "tgi"
-
-
-class InferenceContainerTypeKey(str, metaclass=ExtendedEnumMeta):
-    AQUA_VLLM_CONTAINER_KEY = "odsc-vllm-serving"
-    AQUA_TGI_CONTAINER_KEY = "odsc-tgi-serving"
-
-
-class InferenceContainerParamType(str, metaclass=ExtendedEnumMeta):
-    PARAM_TYPE_VLLM = "VLLM_PARAMS"
-    PARAM_TYPE_TGI = "TGI_PARAMS"

--- a/tests/unitary/with_extras/aqua/test_deployment_handler.py
+++ b/tests/unitary/with_extras/aqua/test_deployment_handler.py
@@ -8,6 +8,7 @@ import os
 import unittest
 from importlib import reload
 from unittest.mock import MagicMock, patch
+from parameterized import parameterized
 
 from notebook.base.handlers import IPythonHandler
 
@@ -124,6 +125,7 @@ class TestAquaDeploymentHandler(unittest.TestCase):
             server_port=None,
             health_check_port=None,
             env_var=None,
+            container_family=None,
         )
 
 
@@ -156,21 +158,33 @@ class AquaDeploymentParamsHandlerTestCase(unittest.TestCase):
             model_id="test_model_id", instance_shape=TestDataset.INSTANCE_SHAPE
         )
 
+    @parameterized.expand(
+        [
+            None,
+            "container-family-name",
+        ]
+    )
     @patch("notebook.base.handlers.APIHandler.finish")
     @patch("ads.aqua.modeldeployment.AquaDeploymentApp.validate_deployment_params")
     def test_validate_deployment_params(
-        self, mock_validate_deployment_params, mock_finish
+        self, container_family_value, mock_validate_deployment_params, mock_finish
     ):
         mock_validate_deployment_params.return_value = dict(valid=True)
         mock_finish.side_effect = lambda x: x
 
         self.test_instance.get_json_body = MagicMock(
-            return_value=dict(model_id="test-model-id", params=self.default_params)
+            return_value=dict(
+                model_id="test-model-id",
+                params=self.default_params,
+                container_family=container_family_value,
+            )
         )
         result = self.test_instance.post()
         assert result["valid"] is True
         mock_validate_deployment_params.assert_called_with(
-            model_id="test-model-id", params=self.default_params
+            model_id="test-model-id",
+            params=self.default_params,
+            container_family=container_family_value,
         )
 
 


### PR DESCRIPTION
### Description

This PR includes the changes for:
1. When user registers the model and inference container is not set, then set default as `odsc-tgi-serving`.
2. When deployment is created, accept container_family as input when user deploys unverified models. 
3. When model params are being validated, accept container_family as input when user validates params for unverified models.

### Unit Tests

```
> python -m pytest -q tests/unitary/with_extras/aqua/test_deployment*.py
==================================================== test session starts =====================================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 29 items

tests/unitary/with_extras/aqua/test_deployment.py ....................                                                 [ 68%]
tests/unitary/with_extras/aqua/test_deployment_handler.py ..s......                                                    [100%]

=============================================== 28 passed, 1 skipped in 7.69s ================================================

```