### PR TITLE
Set default FT configs for unverified models and update validation API

### DIFF
--- a/ads/aqua/config/config.py
+++ b/ads/aqua/config/config.py
@@ -4,6 +4,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 
+# TODO: move this to global config.json in object storage
 def get_finetuning_config_defaults():
     """Generate and return the fine-tuning default configuration dictionary."""
     return {

--- a/ads/aqua/config/config.py
+++ b/ads/aqua/config/config.py
@@ -2,3 +2,16 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+
+def get_finetuning_config_defaults():
+    """Generate and return the fine-tuning default configuration dictionary."""
+    return {
+        "shape": {
+            "VM.GPU.A10.1": {"batch_size": 1, "replica": "1-10"},
+            "VM.GPU.A10.2": {"batch_size": 1, "replica": "1-10"},
+            "BM.GPU.A10.4": {"batch_size": 1, "replica": 1},
+            "BM.GPU4.8": {"batch_size": 4, "replica": 1},
+            "BM.GPU.A100-v2.8": {"batch_size": 6, "replica": 1},
+        }
+    }

--- a/ads/aqua/finetuning/finetuning.py
+++ b/ads/aqua/finetuning/finetuning.py
@@ -21,7 +21,6 @@ from ads.aqua.common.errors import AquaFileExistsError, AquaValueError
 from ads.aqua.common.utils import (
     get_container_image,
     upload_local_to_os,
-    get_params_dict,
 )
 from ads.aqua.constants import (
     DEFAULT_FT_BATCH_SIZE,
@@ -32,6 +31,7 @@ from ads.aqua.constants import (
     UNKNOWN,
     UNKNOWN_DICT,
 )
+from ads.aqua.config.config import get_finetuning_config_defaults
 from ads.aqua.data import AquaResourceIdentifier
 from ads.aqua.finetuning.constants import *
 from ads.aqua.finetuning.entities import *
@@ -553,7 +553,11 @@ class AquaFineTuningApp(AquaApp):
             A dict of allowed finetuning configs.
         """
 
-        return self.get_config(model_id, AQUA_MODEL_FINETUNING_CONFIG)
+        config = self.get_config(model_id, AQUA_MODEL_FINETUNING_CONFIG)
+        if not config:
+            logger.info(f"Fetching default fine-tuning config for model: {model_id}")
+            config = get_finetuning_config_defaults()
+        return config
 
     @telemetry(
         entry_point="plugin=finetuning&action=get_finetuning_default_params",

--- a/tests/unitary/with_extras/aqua/test_finetuning.py
+++ b/tests/unitary/with_extras/aqua/test_finetuning.py
@@ -26,6 +26,7 @@ from ads.jobs.ads_job import Job
 from ads.model.datascience_model import DataScienceModel
 from ads.model.model_metadata import ModelCustomMetadata
 from ads.aqua.common.errors import AquaValueError
+from ads.aqua.config.config import get_finetuning_config_defaults
 
 
 class FineTuningTestCase(TestCase):
@@ -233,6 +234,21 @@ class FineTuningTestCase(TestCase):
             oci_launch_cmd
             == f"--training_data {dataset_path} --output_dir {report_path} --val_set_size {val_set_size} --num_epochs {parameters.epochs} --learning_rate {parameters.learning_rate} --sample_packing {parameters.sample_packing} --micro_batch_size {parameters.batch_size} --sequence_len {parameters.sequence_len} --lora_target_modules q_proj,k_proj {finetuning_params}"
         )
+
+    def test_get_finetuning_config(self):
+        """Test for fetching config details for a given model to be finetuned."""
+
+        config_json = os.path.join(self.curr_dir, "test_data/finetuning/ft_config.json")
+        with open(config_json, "r") as _file:
+            config = json.load(_file)
+
+        self.app.get_config = MagicMock(return_value=config)
+        result = self.app.get_finetuning_config(model_id="test-model-id")
+        assert result == config
+
+        self.app.get_config = MagicMock(return_value=None)
+        result = self.app.get_finetuning_config(model_id="test-model-id")
+        assert result == get_finetuning_config_defaults()
 
     def test_get_finetuning_default_params(self):
         """Test for fetching finetuning config params for a given model."""

--- a/tests/unitary/with_extras/aqua/test_finetuning.py
+++ b/tests/unitary/with_extras/aqua/test_finetuning.py
@@ -267,28 +267,28 @@ class FineTuningTestCase(TestCase):
     @parameterized.expand(
         [
             (
-                [
-                    "--batch_size 1",
-                    "--sequence_len 2048",
-                    "--sample_packing true",
-                    "--pad_to_sequence_len true",
-                    "--learning_rate 0.0002",
-                    "--lora_r 32",
-                    "--lora_alpha 16",
-                    "--lora_dropout 0.05",
-                    "--lora_target_linear true",
-                    "--lora_target_modules q_proj,k_proj",
-                ],
+                {
+                    "epochs": 1,
+                    "learning_rate": 0.0002,
+                    "batch_size": 1,
+                    "sequence_len": 2048,
+                    "sample_packing": True,
+                    "pad_to_sequence_len": True,
+                    "lora_alpha": 16,
+                    "lora_dropout": 0.05,
+                    "lora_target_linear": True,
+                    "lora_target_modules": ["q_proj", " k_proj"],
+                },
                 True,
             ),
             (
-                [
-                    "--micro_batch_size 1",
-                    "--max_sequence_len 2048",
-                    "--flash_attention true",
-                    "--pad_to_sequence_len true",
-                    "--lr_scheduler cosine",
-                ],
+                {
+                    "micro_batch_size": 1,
+                    "max_sequence_len": 2048,
+                    "flash_attention": True,
+                    "pad_to_sequence_len": True,
+                    "lr_scheduler": "cosine",
+                },
                 False,
             ),
         ]


### PR DESCRIPTION
### Description

This PR covers the following changes:
1. Add default configuration for Finetuning for unverified models
2. Update FT parameters validation API to accept dict instead of string params to avoid double conversion on the UI side.

### Usage

1. FT default config API
#### Request
` GET http://localhost:8888/aqua/finetuning/config/ocid1.datasciencemodel.oc1.iad.<unverified-model-ocid>`

#### Response
```
{
    "shape": {
        "VM.GPU.A10.1": {
            "batch_size": 1,
            "replica": "1-10"
        },
        "VM.GPU.A10.2": {
            "batch_size": 1,
            "replica": "1-10"
        },
        "BM.GPU.A10.4": {
            "batch_size": 1,
            "replica": 1
        },
        "BM.GPU4.8": {
            "batch_size": 4,
            "replica": 1
        },
        "BM.GPU.A100-v2.8": {
            "batch_size": 6,
            "replica": 1
        }
    }
}
```

2. FT param validation API

#### Request
```
POST http://localhost:8888/aqua/finetuning/params

{
    "params": {
        "learning_rate": 0.0002,
        "batch_size": 1,
        "sequence_len": 2048,
        "sample_packing": true,
        "pad_to_sequence_len": true,
        "lora_alpha": 16,
        "lora_dropout": 0.05,
        "lora_target_linear": true,
        "lora_target_modules": ["q_proj"," k_proj"]
    }
}
```

#### Response
```
{
    "status": 403,
    "message": "We're having trouble processing your request with the information provided.",
    "service_payload": {},
    "reason": "Invalid fine tuning parameters. Allowable parameters are: epochs (required), learning_rate, sample_packing, batch_size, sequence_len, pad_to_sequence_len, lora_r, lora_alpha, lora_dropout, lora_target_linear, lora_target_modules.",
    "request_id": "123456781-1234-1234-1234-123456781"
}
```


### Unit Tests

```
> python -m pytest -q tests/unitary/with_extras/aqua/test_finetuning*.py
==================================================== test session starts =====================================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 12 items

tests/unitary/with_extras/aqua/test_finetuning.py .......                                                              [ 58%]
tests/unitary/with_extras/aqua/test_finetuning_handler.py .....                                                        [100%]

===================================================== 12 passed in 4.29s =====================================================
```