### PR TITLE
AQUA. Enhance error message generated by HF.

### DIFF
--- a/tests/unitary/with_extras/aqua/test_model_handler.py
+++ b/tests/unitary/with_extras/aqua/test_model_handler.py
@@ -13,6 +13,7 @@ from huggingface_hub.utils import GatedRepoError
 from notebook.base.handlers import IPythonHandler
 from tornado.web import HTTPError
 
+from ads.aqua.common.errors import AquaRuntimeError
 from ads.aqua.extension.model_handler import (
     AquaHuggingFaceHandler,
     AquaModelHandler,
@@ -179,7 +180,7 @@ class TestAquaHuggingFaceHandler:
             return_value={"model_id": "test_model_id"}
         )
         self.mock_handler._format_custom_error_message = MagicMock(
-            return_value="test error message"
+            side_effect=AquaRuntimeError("test error message")
         )
         with patch.object(HfApi, "model_info") as mock_model_info:
             mock_model_info.side_effect = GatedRepoError(message="test message")


### PR DESCRIPTION
## Description
This update improves the error message displayed by Hugging Face when searching for a model.

```
{
  "status": 400,
  "message": "Something went wrong with your request.",
  "service_payload": {
    "error": "RepositoryNotFoundError"
  },
  "reason": "Failed to access `https://huggingface.co/api/models/codellama/CodeLlama-7b-Instruct-hf_err.`. Please check if the provided repository name is correct. If the repo is private, make sure you are authenticated and have a valid HF token registered. To register your token, run this command in your terminal: `huggingface-cli login`",
  "request_id": "b5d25729-b38c-4fc0-91f4-63f2d34c32df"
}
```