### PR TITLE
Model creation from Object Storage

### DIFF
--- a/ads/aqua/common/utils.py
+++ b/ads/aqua/common/utils.py
@@ -10,8 +10,6 @@ import logging
 import os
 import random
 import re
-import shlex
-import subprocess
 from functools import wraps
 from pathlib import Path
 from string import Template
@@ -29,7 +27,7 @@ from ads.aqua.common.errors import (
 )
 from ads.aqua.constants import *
 from ads.aqua.data import AquaResourceIdentifier
-from ads.common.auth import AuthState, default_signer
+from ads.common.auth import default_signer
 from ads.common.extended_enum import ExtendedEnumMeta
 from ads.common.object_storage_details import ObjectStorageDetails
 from ads.common.oci_resource import SEARCH_TYPE, OCIResource
@@ -722,33 +720,6 @@ def get_ocid_substring(ocid: str, key_len: int) -> str:
     """This helper function returns the last n characters of the ocid specified by key_len parameter.
     If ocid is None or length is less than key_len, it returns an empty string."""
     return ocid[-key_len:] if ocid and len(ocid) > key_len else ""
-
-
-def upload_folder(os_path: str, local_dir: str, model_name: str) -> str:
-    """Upload the local folder to the object storage
-
-    Args:
-        os_path (str): object storage URI with prefix. This is the path to upload
-        local_dir (str): Local directory where the object is downloaded
-        model_name (str): Name of the huggingface model
-    Retuns:
-        str: Object name inside the bucket
-    """
-    os_details: ObjectStorageDetails = ObjectStorageDetails.from_path(os_path)
-    if not os_details.is_bucket_versioned():
-        raise ValueError(f"Version is not enabled at object storage location {os_path}")
-    auth_state = AuthState()
-    object_path = os_details.filepath.rstrip("/") + "/" + model_name + "/"
-    command = f"oci os object bulk-upload --src-dir {local_dir} --prefix {object_path} -bn {os_details.bucket} -ns {os_details.namespace} --auth {auth_state.oci_iam_type} --profile {auth_state.oci_key_profile} --no-overwrite"
-    try:
-        logger.info(f"Running: {command}")
-        subprocess.check_call(shlex.split(command))
-    except subprocess.CalledProcessError as e:
-        logger.error(
-            f"Error uploading the object. Exit code: {e.returncode} with error {e.stdout}"
-        )
-
-    return f"oci://{os_details.bucket}@{os_details.namespace}" + "/" + object_path
 
 
 def is_service_managed_container(container):

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -100,8 +100,6 @@ class AquaModelLicenseHandler(AquaAPIhandler):
     @handle_exceptions
     def get(self, model_id):
         """Handle GET request."""
-
-        model_id = model_id.split("/")[0]
         return self.finish(AquaModelApp().load_license(model_id))
 
 

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -7,22 +7,11 @@ import re
 from typing import Optional
 from urllib.parse import urlparse
 
-from huggingface_hub import HfApi
-from huggingface_hub.utils import (
-    GatedRepoError,
-    HfHubHTTPError,
-    RepositoryNotFoundError,
-    RevisionNotFoundError,
-)
 from tornado.web import HTTPError
-
-from ads.aqua.common.decorator import handle_exceptions
-from ads.aqua.common.errors import AquaRuntimeError
 from ads.aqua.extension.errors import Errors
+from ads.aqua.common.decorator import handle_exceptions
 from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua.model import AquaModelApp
-from ads.aqua.model.constants import ModelTask
-from ads.aqua.model.entities import AquaModelSummary, HFModelSummary
 
 
 class AquaModelHandler(AquaAPIhandler):
@@ -63,6 +52,47 @@ class AquaModelHandler(AquaAPIhandler):
             )
         )
 
+    @handle_exceptions
+    def post(self, *args, **kwargs):
+        """
+        Handles post request for the registering any Aqua model.
+        Raises
+        ------
+        HTTPError
+            Raises HTTPError if inputs are missing or are invalid
+        """
+        try:
+            input_data = self.get_json_body()
+        except Exception:
+            raise HTTPError(400, Errors.INVALID_INPUT_DATA_FORMAT)
+
+        if not input_data:
+            raise HTTPError(400, Errors.NO_INPUT_DATA)
+
+        # required input parameters
+        model = input_data.get("model")
+        if not model:
+            raise HTTPError(400, Errors.MISSING_REQUIRED_PARAMETER.format("model"))
+        os_path = input_data.get("os_path")
+        if not os_path:
+            raise HTTPError(400, Errors.MISSING_REQUIRED_PARAMETER.format("os_path"))
+
+        inference_container = input_data.get("inference_container")
+        finetuning_container = input_data.get("finetuning_container")
+        compartment_id = input_data.get("compartment_id")
+        project_id = input_data.get("project_id")
+
+        return self.finish(
+            AquaModelApp().register(
+                model=model,
+                os_path=os_path,
+                inference_container=inference_container,
+                finetuning_container=finetuning_container,
+                compartment_id=compartment_id,
+                project_id=project_id,
+            )
+        )
+
 
 class AquaModelLicenseHandler(AquaAPIhandler):
     """Handler for Aqua Model license REST APIs."""
@@ -75,140 +105,7 @@ class AquaModelLicenseHandler(AquaAPIhandler):
         return self.finish(AquaModelApp().load_license(model_id))
 
 
-class AquaHuggingFaceHandler(AquaAPIhandler):
-    """Handler for Aqua Hugging Face REST APIs."""
-
-    def _find_matching_aqua_model(self, model_id: str) -> Optional[AquaModelSummary]:
-        """
-        Finds a matching model in AQUA based on the model ID from Hugging Face.
-
-        Parameters
-        ----------
-        model_id (str): The Hugging Face model ID to match.
-
-        Returns
-        -------
-        Optional[AquaModelSummary]
-            Returns the matching AquaModelSummary object if found, else None.
-        """
-        # Convert the Hugging Face model ID to lowercase once
-        model_id_lower = model_id.lower()
-
-        aqua_model_app = AquaModelApp()
-        model_ocid = aqua_model_app._find_matching_aqua_model(model_id=model_id_lower)
-        if model_ocid:
-            return aqua_model_app.get(model_ocid, load_model_card=False)
-
-        return None
-
-    def _format_custom_error_message(self, error: HfHubHTTPError) -> AquaRuntimeError:
-        """
-        Formats a custom error message based on the Hugging Face error response.
-
-        Parameters
-        ----------
-        error (HfHubHTTPError): The caught exception.
-
-        Raises
-        ------
-        AquaRuntimeError: A user-friendly error message.
-        """
-        # Extract the repository URL from the error message if present
-        match = re.search(r"(https://huggingface.co/[^\s]+)", str(error))
-        url = match.group(1) if match else "the requested Hugging Face URL."
-
-        if isinstance(error, RepositoryNotFoundError):
-            raise AquaRuntimeError(
-                reason=f"Failed to access `{url}`. Please check if the provided repository name is correct. "
-                "If the repo is private, make sure you are authenticated and have a valid HF token registered. "
-                "To register your token, run this command in your terminal: `huggingface-cli login`",
-                service_payload={"error": "RepositoryNotFoundError"},
-            )
-
-        if isinstance(error, GatedRepoError):
-            raise AquaRuntimeError(
-                reason=f"Access denied to `{url}` "
-                "This repository is gated. Access is restricted to authorized users. "
-                "Please request access or check with the repository administrator. "
-                "If you are trying to access a gated repository, ensure you have a valid HF token registered. "
-                "To register your token, run this command in your terminal: `huggingface-cli login`",
-                service_payload={"error": "GatedRepoError"},
-            )
-
-        if isinstance(error, RevisionNotFoundError):
-            raise AquaRuntimeError(
-                reason=f"The specified revision could not be found at `{url}` "
-                "Please check the revision identifier and try again.",
-                service_payload={"error": "RevisionNotFoundError"},
-            )
-
-        raise AquaRuntimeError(
-            reason=f"An error occurred while accessing `{url}` "
-            "Please check your network connection and try again. "
-            "If you are trying to access a gated repository, ensure you have a valid HF token registered. "
-            "To register your token, run this command in your terminal: `huggingface-cli login`",
-            service_payload={"error": "Error"},
-        )
-
-    @handle_exceptions
-    def post(self, *args, **kwargs):
-        """Handles post request for the HF Models APIs
-
-        Raises
-        ------
-        HTTPError
-            Raises HTTPError if inputs are missing or are invalid.
-        """
-        try:
-            input_data = self.get_json_body()
-        except Exception:
-            raise HTTPError(400, Errors.INVALID_INPUT_DATA_FORMAT)
-
-        if not input_data:
-            raise HTTPError(400, Errors.NO_INPUT_DATA)
-
-        model_id = input_data.get("model_id")
-        token = input_data.get("token")
-
-        if not model_id:
-            raise HTTPError(400, Errors.MISSING_REQUIRED_PARAMETER.format("model_id"))
-
-        # Get model info from the HF
-        try:
-            hf_model_info = HfApi(token=token).model_info(model_id)
-        except HfHubHTTPError as err:
-            raise self._format_custom_error_message(err)
-
-        # Check if model is not disabled
-        if hf_model_info.disabled:
-            raise AquaRuntimeError(
-                f"The chosen model '{hf_model_info.id}' is currently disabled and cannot be imported into AQUA. "
-                "Please verify the model's status on the Hugging Face Model Hub or select a different model."
-            )
-
-        # Check pipeline_tag, it should be `text-generation`
-        if (
-            not hf_model_info.pipeline_tag
-            or hf_model_info.pipeline_tag.lower() != ModelTask.TEXT_GENERATION
-        ):
-            raise AquaRuntimeError(
-                f"Unsupported pipeline tag for the chosen model: '{hf_model_info.pipeline_tag}'. "
-                f"AQUA currently supports the following tasks only: {', '.join(ModelTask.values())}. "
-                "Please select a model with a compatible pipeline tag."
-            )
-
-        # Check if it is a service/verified model
-        aqua_model_info: AquaModelSummary = self._find_matching_aqua_model(
-            model_id=hf_model_info.id
-        )
-
-        return self.finish(
-            HFModelSummary(model_info=hf_model_info, aqua_model_info=aqua_model_info)
-        )
-
-
 __handlers__ = [
     ("model/?([^/]*)", AquaModelHandler),
     ("model/?([^/]*)/license", AquaModelLicenseHandler),
-    ("model/hf/search/?([^/]*)", AquaHuggingFaceHandler),
 ]

--- a/ads/aqua/model/entities.py
+++ b/ads/aqua/model/entities.py
@@ -14,7 +14,6 @@ from dataclasses import InitVar, dataclass, field
 from typing import List, Optional
 
 import oci
-from huggingface_hub import hf_api
 
 from ads.aqua import logger
 from ads.aqua.app import CLIBuilderMixin
@@ -95,14 +94,6 @@ class HFModelContainerInfo:
 
     inference_container: str = None
     finetuning_container: str = None
-
-
-@dataclass(repr=False)
-class HFModelSummary:
-    """Represents a summary of Hugging Face model."""
-
-    model_info: hf_api.ModelInfo = field(default_factory=hf_api.ModelInfo)
-    aqua_model_info: Optional[AquaModel] = field(default_factory=AquaModel)
 
 
 @dataclass(repr=False)
@@ -266,11 +257,8 @@ class AquaFineTuneModel(AquaModel, AquaEvalFTCommon, DataClassSerializable):
 class ImportModelDetails(CLIBuilderMixin):
     model: str
     os_path: str
-    local_dir: Optional[str] = None
     inference_container: Optional[str] = None
-    inference_container_type_smc: Optional[bool] = False
     finetuning_container: Optional[str] = None
-    finetuning_container_type_smc: Optional[bool] = False
     compartment_id: Optional[str] = None
     project_id: Optional[str] = None
 

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -35,6 +35,7 @@ from ads.aqua.constants import (
 )
 from ads.aqua.model.constants import *
 from ads.aqua.model.entities import *
+from ads.common.auth import default_signer
 from ads.common.oci_resource import SEARCH_TYPE, OCIResource
 from ads.common.utils import get_console_link, is_path_exists
 from ads.config import (
@@ -679,8 +680,8 @@ class AquaModelApp(AquaApp):
                 finetuning_container (str): selects service defaults
 
         Returns:
-            DataScienceModel:
-                The registered model as a DataScienceModel object.
+            AquaModel:
+                The registered model as a AquaModel object.
         """
         verified_model_details: DataScienceModel = None
 
@@ -838,7 +839,7 @@ class AquaModelApp(AquaApp):
         content = str(
             read_file(
                 file_path=f"{os.path.dirname(artifact_path)}/{LICENSE_TXT}",
-                auth=self._auth,
+                auth=default_signer(),
             )
         )
 

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -8,19 +8,16 @@ from threading import Lock
 from typing import List, Optional, Union
 
 from cachetools import TTLCache
-from huggingface_hub import HfApi, snapshot_download
 from oci.data_science.models import JobRun, Model
 
 from ads.aqua import ODSC_MODEL_COMPARTMENT_OCID
 from ads.aqua.app import AquaApp
-from ads.aqua.common.enums import Tags, HuggingFaceTags, InferenceContainerTypeFamily
+from ads.aqua.common.enums import Tags
 from ads.aqua.common.errors import AquaRuntimeError
 from ads.aqua.common.utils import (
     create_word_icon,
     get_artifact_path,
-    is_service_managed_container,
     read_file,
-    upload_folder,
     copy_model_config,
 )
 from ads.aqua.constants import (
@@ -38,15 +35,12 @@ from ads.aqua.constants import (
 )
 from ads.aqua.model.constants import *
 from ads.aqua.model.entities import *
-from ads.common.auth import default_signer
 from ads.common.oci_resource import SEARCH_TYPE, OCIResource
-from ads.common.utils import get_console_link
+from ads.common.utils import get_console_link, is_path_exists
 from ads.config import (
     AQUA_DEPLOYMENT_CONTAINER_METADATA_NAME,
-    AQUA_DEPLOYMENT_CONTAINER_OVERRIDE_FLAG_METADATA_NAME,
     AQUA_EVALUATION_CONTAINER_METADATA_NAME,
     AQUA_FINETUNING_CONTAINER_METADATA_NAME,
-    AQUA_FINETUNING_CONTAINER_OVERRIDE_FLAG_METADATA_NAME,
     COMPARTMENT_OCID,
     PROJECT_OCID,
     TENANCY_OCID,
@@ -558,8 +552,6 @@ class AquaModelApp(AquaApp):
         model_name: str,
         inference_container: str,
         finetuning_container: str,
-        inference_container_type_smc: bool,
-        finetuning_container_type_smc: bool,
         verified_model: DataScienceModel,
         compartment_id: Optional[str],
         project_id: Optional[str],
@@ -570,23 +562,15 @@ class AquaModelApp(AquaApp):
             os_path (str): OCI  where the model is uploaded - oci://bucket@namespace/prefix
             model_name (str): name of the model
             inference_container (str): selects service defaults
-            inference_container_type_smc (bool): If true, then `inference_contianer` argument should contain service managed container name without tag information
             finetuning_container (str): selects service defaults
-            finetuning_container_type_smc (bool): If true, then `finetuning_container` argument should contain service managed container name without tag
             verified_model (DataScienceModel): If set, then copies all the tags and custom metadata information from the service verified model
             compartment_id (Optional[str]): Compartment Id of the compartment where the model has to be created
             project_id (Optional[str]): Project id of the project where the model has to be created
 
         Returns:
-            DataScienceModel: Returns Datascience model
+            DataScienceModel: Returns Datascience model instance.
         """
-        model_info = None
         model = DataScienceModel()
-        try:
-            api = HfApi()
-            model_info = api.model_info(model_name)
-        except Exception:
-            logger.exception(f"Could not fetch model information for {model_name}")
         tags = (
             {
                 **verified_model.freeform_tags,
@@ -611,8 +595,12 @@ class AquaModelApp(AquaApp):
 
         else:
             metadata = ModelCustomMetadata()
+            if not inference_container:
+                raise AquaRuntimeError(
+                    f"Require Inference container information. Model: {model_name} does not have associated inference container defaults. Check docs for more information on how to pass inference container."
+                )
             if finetuning_container:
-                tags[Tags.AQUA_FINE_TUNING] = "true"
+                tags[Tags.READY_TO_FINE_TUNE] = "true"
                 metadata.add(
                     key=AQUA_FINETUNING_CONTAINER_METADATA_NAME,
                     value=finetuning_container,
@@ -625,53 +613,21 @@ class AquaModelApp(AquaApp):
                     f"This model will not be available for fine tuning."
                 )
 
-            if not inference_container:
-                inference_container = (
-                    InferenceContainerTypeFamily.AQUA_TGI_CONTAINER_FAMILY
-                    if model_info
-                    and model_info.tags
-                    and HuggingFaceTags.TEXT_GENERATION_INFERENCE in model_info.tags
-                    else InferenceContainerTypeFamily.AQUA_VLLM_CONTAINER_FAMILY
-                )
-                logger.info(
-                    f"Model: {model_name} does not have associated inference container defaults. "
-                    f"{inference_container} will be used instead."
-                )
             metadata.add(
                 key=AQUA_DEPLOYMENT_CONTAINER_METADATA_NAME,
                 value=inference_container,
                 description=f"Inference container mapping for {model_name}",
                 category="Other",
             )
-            # If SMC, the container information has to be looked up from container_index.json for the latest version
-            if inference_container and not inference_container_type_smc:
-                metadata.add(
-                    key=AQUA_DEPLOYMENT_CONTAINER_OVERRIDE_FLAG_METADATA_NAME,
-                    value="true",
-                    description="Flag for custom deployment container",
-                    category="Other",
-                )
             metadata.add(
                 key=AQUA_EVALUATION_CONTAINER_METADATA_NAME,
                 value="odsc-llm-evaluate",
                 description="Evaluation container mapping for SMC",
                 category="Other",
             )
-            # If SMC, the container information has to be looked up from container_index.json for the latest version
-            if finetuning_container and not finetuning_container_type_smc:
-                metadata.add(
-                    key=AQUA_FINETUNING_CONTAINER_OVERRIDE_FLAG_METADATA_NAME,
-                    value="true",
-                    description="Flag for custom deployment container",
-                    category="Other",
-                )
-
-            tags["task"] = (model_info and model_info.pipeline_tag) or "UNKNOWN"
-            tags["organization"] = (
-                model_info.author
-                if model_info and hasattr(model_info, "author")
-                else "UNKNOWN"
-            )
+            # TODO: either get task and organization from user or a config file
+            # tags["task"] = "UNKNOWN"
+            # tags["organization"] = "UNKNOWN"
 
         try:
             # If verified model already has a artifact json, use that.
@@ -709,32 +665,37 @@ class AquaModelApp(AquaApp):
 
     def register(
         self, import_model_details: ImportModelDetails = None, **kwargs
-    ) -> DataScienceModel:
-        """Loads the model from huggingface and registers as Model in Data Science Model catalog
-        Note: For the models that require user token, use `huggingface-cli login` to setup the token
-        The inference container and finetuning container could be of type Service Manged Container(SMC) or custom. If it is custom, full container URI is expected. If it of type SMC, only the container family name is expected.
+    ) -> AquaModel:
+        """Loads the model from object storage and registers as Model in Data Science Model catalog
+        The inference container and finetuning container could be of type Service Manged Container(SMC) or custom.
+        If it is custom, full container URI is expected. If it of type SMC, only the container family name is expected.
 
         Args:
             import_model_details (ImportModelDetails): Model details for importing the model.
             kwargs:
-                model (str): name as provided in the huggingface or OCID of the service model that has a inference and finetuning information
+                model (str): name of the model or OCID of the service model that has inference and finetuning information
                 os_path (str): Object storage destination URI to store the downloaded model. Format: oci://bucket-name@namespace/prefix
-                local_dir (str): Defaults to home directory if not set
                 inference_container (str): selects service defaults
-                inference_container_type_smc (bool): If true, then `inference_contianer` argument should contain service managed container name without tag information
                 finetuning_container (str): selects service defaults
-                finetuning_container_type_smc (bool): If true, then `finetuning_container` argument should contain service managed container name without tag information
 
         Returns:
-            str: Model ID of the registered model
+            DataScienceModel:
+                The registered model as a DataScienceModel object.
         """
         verified_model_details: DataScienceModel = None
 
         if not import_model_details:
             import_model_details = ImportModelDetails(**kwargs)
 
-        model_service_id = None
+        if not is_path_exists(
+            f"{import_model_details.os_path.rstrip('/')}/config.json"
+        ):
+            raise AquaRuntimeError(
+                f"The model path {import_model_details.os_path} does not contain the file config.json. "
+                f"Please check if the path is correct or the model artifacts are available at this location."
+            )
 
+        model_service_id = None
         # If OCID of a model is passed, we need to copy the defaults for Tags and metadata from the service model.
         if (
             import_model_details.model.startswith("ocid")
@@ -742,7 +703,7 @@ class AquaModelApp(AquaApp):
         ):
             model_service_id = import_model_details.model
         else:
-            # If users passes huggingface model name, check if there is model with the same name in the service model catalog. If it is there use that model
+            # If users passes model name, check if there is model with the same name in the service model catalog. If it is there, then use that model
             model_service_id = self._find_matching_aqua_model(
                 import_model_details.model
             )
@@ -751,16 +712,6 @@ class AquaModelApp(AquaApp):
             )
         if model_service_id:
             verified_model_details = DataScienceModel.from_id(model_service_id)
-            inference_container = verified_model_details.custom_metadata_list.get(
-                AQUA_DEPLOYMENT_CONTAINER_METADATA_NAME
-            ).value
-            try:
-                # No Default finetuning container
-                finetuning_container = verified_model_details.custom_metadata_list.get(
-                    AQUA_FINETUNING_CONTAINER_METADATA_NAME
-                ).value
-            except:
-                pass
 
         # Copy the model name from the service model if `model` is ocid
         model_name = (
@@ -769,62 +720,54 @@ class AquaModelApp(AquaApp):
             else import_model_details.model
         )
 
-        # Download the model from hub
-        local_dir = import_model_details.local_dir
-        if not local_dir:
-            local_dir = os.path.join(os.path.expanduser("~"), "cached-model")
-        local_dir = os.path.join(local_dir, model_name)
-        retry = 10
-        i = 0
-        huggingface_download_err_message = None
-        while i < retry:
-            try:
-                # Download to cache folder. The while loop retries when there is a network failure
-                snapshot_download(repo_id=model_name)
-            except Exception as e:
-                huggingface_download_err_message = str(e)
-                i += 1
-            else:
-                break
-        if i == retry:
-            raise Exception(
-                f"Could not download the model {model_name} from https://huggingface.co with message {huggingface_download_err_message}"
-            )
-        os.makedirs(local_dir, exist_ok=True)
-        # Copy the model from the cache to destination
-        snapshot_download(
-            repo_id=model_name, local_dir=local_dir, local_dir_use_symlinks=False
-        )
-        # Upload to object storage
-        model_artifact_path = upload_folder(
-            os_path=import_model_details.os_path,
-            local_dir=local_dir,
-            model_name=model_name,
-        )
         # Create Model catalog entry with pass by reference
-        return self._create_model_catalog_entry(
-            model_artifact_path,
+        ds_model = self._create_model_catalog_entry(
+            os_path=import_model_details.os_path,
             model_name=model_name,
             inference_container=import_model_details.inference_container,
             finetuning_container=import_model_details.finetuning_container,
-            inference_container_type_smc=(
-                True
-                if is_service_managed_container(
-                    import_model_details.inference_container
-                )
-                else import_model_details.inference_container_type_smc
-            ),
-            finetuning_container_type_smc=(
-                True
-                if is_service_managed_container(
-                    import_model_details.finetuning_container
-                )
-                else import_model_details.finetuning_container_type_smc
-            ),
             verified_model=verified_model_details,
             compartment_id=import_model_details.compartment_id,
             project_id=import_model_details.project_id,
         )
+        # registered model will always have inference and evaluation container, but
+        # fine-tuning container may be not set
+        inference_container = ds_model.custom_metadata_list.get(
+            ModelCustomMetadataFields.DEPLOYMENT_CONTAINER,
+            ModelCustomMetadataItem(key=ModelCustomMetadataFields.DEPLOYMENT_CONTAINER),
+        ).value
+        evaluation_container = ds_model.custom_metadata_list.get(
+            ModelCustomMetadataFields.EVALUATION_CONTAINER,
+            ModelCustomMetadataItem(key=ModelCustomMetadataFields.EVALUATION_CONTAINER),
+        ).value
+        try:
+            finetuning_container = ds_model.custom_metadata_list.get(
+                ModelCustomMetadataFields.FINETUNE_CONTAINER,
+                ModelCustomMetadataItem(
+                    key=ModelCustomMetadataFields.FINETUNE_CONTAINER
+                ),
+            ).value
+        except:
+            finetuning_container = None
+
+        aqua_model_attributes = dict(
+            **self._process_model(ds_model, self.region),
+            project_id=ds_model.project_id,
+            model_card=str(
+                read_file(
+                    file_path=(
+                        f"{import_model_details.os_path.rstrip('/')}/config/{README}"
+                        if verified_model_details
+                        else f"{import_model_details.os_path.rstrip('/')}/{README}"
+                    ),
+                    auth=self._auth,
+                )
+            ),
+            inference_container=inference_container,
+            finetuning_container=finetuning_container,
+            evaluation_container=evaluation_container,
+        )
+        return AquaModel(**aqua_model_attributes)
 
     def _if_show(self, model: DataScienceModel) -> bool:
         """Determine if the given model should be return by `list`."""
@@ -895,7 +838,7 @@ class AquaModelApp(AquaApp):
         content = str(
             read_file(
                 file_path=f"{os.path.dirname(artifact_path)}/{LICENSE_TXT}",
-                auth=default_signer(),
+                auth=self._auth,
             )
         )
 
@@ -903,18 +846,18 @@ class AquaModelApp(AquaApp):
 
     def _find_matching_aqua_model(self, model_id: str) -> Optional[str]:
         """
-        Finds a matching model in AQUA based on the model ID from Hugging Face.
+        Finds a matching model in AQUA based on the model ID from list of verified models.
 
         Parameters
         ----------
-        model_id (str): The Hugging Face model ID to match.
+        model_id (str): Verified model ID to match.
 
         Returns
         -------
         Optional[str]
             Returns model ocid that matches the model in the service catalog else returns None.
         """
-        # Convert the Hugging Face model ID to lowercase once
+        # Convert the model ID to lowercase once
         model_id_lower = model_id.lower()
 
         aqua_model_list = self.list()

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -5,19 +5,16 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import os
-import shlex
-import tempfile
 from dataclasses import asdict
 from importlib import reload
 from unittest.mock import MagicMock, patch
 
-import huggingface_hub
 import oci
 import pytest
 from parameterized import parameterized
 
 import ads.aqua.model
-from ads.aqua.model.entities import AquaModelSummary, ImportModelDetails
+from ads.aqua.model.entities import AquaModelSummary, ImportModelDetails, AquaModel
 import ads.common
 import ads.common.oci_client
 import ads.config
@@ -29,6 +26,7 @@ from ads.model.model_metadata import (
     ModelProvenanceMetadata,
     ModelTaxonomyMetadata,
 )
+from ads.aqua.common.errors import AquaRuntimeError
 from ads.model.service.oci_datascience_model import OCIDataScienceModel
 
 
@@ -530,21 +528,17 @@ class TestAquaModel:
     )
     @patch("ads.aqua.common.utils.copy_file")
     @patch("ads.common.object_storage_details.ObjectStorageDetails.list_objects")
-    @patch("huggingface_hub.snapshot_download")
-    @patch("subprocess.check_call")
+    @patch("ads.common.utils.is_path_exists", return_value=True)
     def test_import_verified_model(
         self,
-        mock_subprocess,
-        mock_snapshot_download,
+        mock_is_path_exists,
         mock_list_objects,
         mock_copy_file,
         artifact_location_set,
     ):
         ObjectStorageDetails.is_bucket_versioned = MagicMock(return_value=True)
         ads.common.oci_datascience.OCIDataScienceMixin.init_client = MagicMock()
-        huggingface_hub.HfApi.model_info = MagicMock(return_value={})
         DataScienceModel.upload_artifact = MagicMock()
-        # oci.data_science.DataScienceClient = MagicMock()
         DataScienceModel.sync = MagicMock()
         OCIDataScienceModel.create = MagicMock()
 
@@ -560,7 +554,7 @@ class TestAquaModel:
 
         ds_model = DataScienceModel()
         os_path = "oci://aqua-bkt@aqua-ns/prefix/path"
-        hf_model = "oracle/aqua-1t-mega-model"
+        model_name = "oracle/aqua-1t-mega-model"
         ds_freeform_tags = {
             "OCI_AQUA": "ACTIVE",
             "license": "aqua-license",
@@ -571,7 +565,7 @@ class TestAquaModel:
         ds_model = (
             ds_model.with_compartment_id("test_model_compartment_id")
             .with_project_id("test_project_id")
-            .with_display_name(hf_model)
+            .with_display_name(model_name)
             .with_description("test_description")
             .with_model_version_set_id("test_model_version_set_id")
             .with_freeform_tags(**ds_freeform_tags)
@@ -598,81 +592,40 @@ class TestAquaModel:
         DataScienceModel.from_id = MagicMock(return_value=ds_model)
         reload(ads.aqua.model.model)
         app = AquaModelApp()
-        with tempfile.TemporaryDirectory() as tmpdir:
-            model: DataScienceModel = app.register(
-                model="ocid1.datasciencemodel.xxx.xxxx.",
-                os_path=os_path,
-                local_dir=str(tmpdir),
-            )
-            mock_snapshot_download.assert_called_with(
-                repo_id=hf_model,
-                local_dir=f"{str(tmpdir)}/{hf_model}",
-                local_dir_use_symlinks=False,
-            )
-            if not artifact_location_set:
-                mock_copy_file.assert_called()
-            mock_subprocess.assert_called_with(
-                shlex.split(
-                    f"oci os object bulk-upload --src-dir {str(tmpdir)}/{hf_model} --prefix prefix/path/{hf_model}/ -bn aqua-bkt -ns aqua-ns --auth api_key --profile DEFAULT --no-overwrite"
-                )
-            )
-            ds_freeform_tags.pop(
-                "ready_to_import"
-            )  # The imported model should not have this tag
-            assert model.freeform_tags == {
-                "aqua_custom_base_model": "true",
-                "aqua_service_model": "test_model_id",
-                **ds_freeform_tags,
-            }
-            expected_metadata = [
-                {
-                    "key": "evaluation-container",
-                    "value": "odsc-llm-evaluate",
-                    "description": "",
-                    "category": "Other",
-                },
-                {
-                    "key": "deployment-container",
-                    "value": "odsc-tgi-serving",
-                    "description": "",
-                    "category": "Other",
-                },
-                {
-                    "key": "modelDescription",
-                    "value": "true",
-                    "description": "model by reference flag",
-                    "category": "Other",
-                },
-                {
-                    "key": "artifact_location",
-                    "value": f"{os_path}/{hf_model}/"
-                    if artifact_location_set
-                    else artifact_path,
-                    "description": "artifact location",
-                    "category": "Other",
-                },
-            ]
-            for item in expected_metadata:
-                assert model.custom_metadata_list[item["key"]].to_dict() == item
-            assert model.version_id != ds_model.version_id
+        model: AquaModel = app.register(
+            model="ocid1.datasciencemodel.xxx.xxxx.",
+            os_path=os_path,
+        )
+        if not artifact_location_set:
+            mock_copy_file.assert_called()
+        ds_freeform_tags.pop(
+            "ready_to_import"
+        )  # The imported model should not have this tag
+        assert model.tags == {
+            "aqua_custom_base_model": "true",
+            "aqua_service_model": "test_model_id",
+            **ds_freeform_tags,
+        }
+        mock_is_path_exists.assert_called()
 
-    @patch("huggingface_hub.snapshot_download")
-    @patch("subprocess.check_call")
-    def test_import_any_hf_model_no_containers_specified(
-        self,
-        mock_subprocess,
-        mock_snapshot_download,
-    ):
+        assert model.inference_container == "odsc-tgi-serving"
+        assert model.finetuning_container is None
+        assert model.evaluation_container == "odsc-llm-evaluate"
+        assert model.ready_to_import is False
+        assert model.ready_to_deploy is True
+        assert model.ready_to_finetune is False
+
+    @patch("ads.common.utils.is_path_exists", return_value=True)
+    def test_import_any_model_no_containers_specified(self, mock_is_path_exists):
         ObjectStorageDetails.is_bucket_versioned = MagicMock(return_value=True)
         ads.common.oci_datascience.OCIDataScienceMixin.init_client = MagicMock()
-        huggingface_hub.HfApi.model_info = MagicMock(return_value={})
         DataScienceModel.upload_artifact = MagicMock()
         DataScienceModel.sync = MagicMock()
         OCIDataScienceModel.create = MagicMock()
 
         ds_model = DataScienceModel()
         os_path = "oci://aqua-bkt@aqua-ns/prefix/path"
-        hf_model = "oracle/aqua-1t-mega-model"
+        model_name = "oracle/aqua-1t-mega-model"
         ds_freeform_tags = {
             "OCI_AQUA": "ACTIVE",
             "license": "aqua-license",
@@ -682,40 +635,31 @@ class TestAquaModel:
 
         reload(ads.aqua.model.model)
         app = AquaModelApp()
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with pytest.raises(ValueError):
-                with patch.object(AquaModelApp, "list") as aqua_model_mock_list:
-                    aqua_model_mock_list.return_value = [
-                        AquaModelSummary(
-                            id="test_id1",
-                            name="organization1/name1",
-                            organization="organization1",
-                        ),
-                    ]
-                    model: DataScienceModel = app.register(
-                        model=hf_model,
-                        os_path=os_path,
-                        local_dir=str(tmpdir),
-                    )
+        with pytest.raises(AquaRuntimeError):
+            with patch.object(AquaModelApp, "list") as aqua_model_mock_list:
+                aqua_model_mock_list.return_value = [
+                    AquaModelSummary(
+                        id="test_id1",
+                        name="organization1/name1",
+                        organization="organization1",
+                    ),
+                ]
+                model: DataScienceModel = app.register(
+                    model=model_name,
+                    os_path=os_path,
+                )
 
-    @patch("huggingface_hub.snapshot_download")
-    @patch("subprocess.check_call")
-    def test_import_model_with_project_compartment_override(
-        self,
-        mock_subprocess,
-        mock_snapshot_download,
-    ):
+    @patch("ads.common.utils.is_path_exists", return_value=True)
+    def test_import_model_with_project_compartment_override(self, mock_is_path_exists):
         ObjectStorageDetails.is_bucket_versioned = MagicMock(return_value=True)
         ads.common.oci_datascience.OCIDataScienceMixin.init_client = MagicMock()
-        huggingface_hub.HfApi.model_info = MagicMock(return_value={})
         DataScienceModel.upload_artifact = MagicMock()
-        # oci.data_science.DataScienceClient = MagicMock()
         DataScienceModel.sync = MagicMock()
         OCIDataScienceModel.create = MagicMock()
 
         ds_model = DataScienceModel()
         os_path = "oci://aqua-bkt@aqua-ns/prefix/path"
-        hf_model = "oracle/aqua-1t-mega-model"
+        model_name = "oracle/aqua-1t-mega-model"
         compartment_override = "my.blah.compartment"
         project_override = "my.blah.project"
         ds_freeform_tags = {
@@ -727,7 +671,7 @@ class TestAquaModel:
         ds_model = (
             ds_model.with_compartment_id("test_model_compartment_id")
             .with_project_id("test_project_id")
-            .with_display_name(hf_model)
+            .with_display_name(model_name)
             .with_description("test_description")
             .with_model_version_set_id("test_model_version_set_id")
             .with_freeform_tags(**ds_freeform_tags)
@@ -745,41 +689,36 @@ class TestAquaModel:
         DataScienceModel.from_id = MagicMock(return_value=ds_model)
         reload(ads.aqua.model.model)
         app = AquaModelApp()
-        with tempfile.TemporaryDirectory() as tmpdir:
-            model: DataScienceModel = app.register(
-                compartment_id=compartment_override,
-                project_id=project_override,
-                model="ocid1.datasciencemodel.xxx.xxxx.",
+        model: AquaModel = app.register(
+            compartment_id=compartment_override,
+            project_id=project_override,
+            model="ocid1.datasciencemodel.xxx.xxxx.",
+            os_path=os_path,
+        )
+        assert model.compartment_id == compartment_override
+        assert model.project_id == project_override
+
+    @patch("ads.common.utils.is_path_exists", return_value=False)
+    def test_import_model_with_missing_artifact(self, mock_is_path_exists):
+        """Test for validating if error is returned when model artifacts are incomplete or not available."""
+        os_path = "oci://aqua-bkt@aqua-ns/prefix/path"
+        model_name = "oracle/aqua-1t-mega-model"
+        reload(ads.aqua.model.model)
+        app = AquaModelApp()
+        with pytest.raises(AquaRuntimeError):
+            model: AquaModel = app.register(
+                model=model_name,
                 os_path=os_path,
-                local_dir=str(tmpdir),
             )
-            assert model.compartment_id == compartment_override
-            assert model.project_id == project_override
 
-    @patch("huggingface_hub.snapshot_download")
-    @patch("subprocess.check_call")
-    def test_import_any_hf_model_custom_container(
+    @patch("ads.common.utils.is_path_exists", return_value=True)
+    def test_import_any_model_smc_container(
         self,
-        mock_subprocess,
-        mock_snapshot_download,
+        mock_is_path_exists,
     ):
-        hf_model = "oracle/aqua-1t-mega-model"
+        my_model = "oracle/aqua-1t-mega-model"
         ObjectStorageDetails.is_bucket_versioned = MagicMock(return_value=True)
         ads.common.oci_datascience.OCIDataScienceMixin.init_client = MagicMock()
-        huggingface_hub.HfApi.model_info = MagicMock(
-            return_value=huggingface_hub.hf_api.ModelInfo(
-                **{
-                    "id": hf_model,
-                    "license": "aqua-license",
-                    "author": "oracle",
-                    "pipeline_tag": "text-generation",
-                    "private": False,
-                    "downloads": 100,
-                    "likes": 10,
-                    "tags": ["text-generation"],
-                }
-            )
-        )
         DataScienceModel.upload_artifact = MagicMock()
         DataScienceModel.sync = MagicMock()
         OCIDataScienceModel.create = MagicMock()
@@ -787,196 +726,45 @@ class TestAquaModel:
         os_path = "oci://aqua-bkt@aqua-ns/prefix/path"
         ds_freeform_tags = {
             "OCI_AQUA": "active",
-            "organization": "oracle",
-            "task": "text-generation",
         }
 
         reload(ads.aqua.model.model)
         app = AquaModelApp()
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch.object(AquaModelApp, "list") as aqua_model_mock_list:
-                aqua_model_mock_list.return_value = [
-                    AquaModelSummary(
-                        id="test_id1",
-                        name="organization1/name1",
-                        organization="organization1",
-                    ),
-                ]
-                model: DataScienceModel = app.register(
-                    model=hf_model,
-                    os_path=os_path,
-                    local_dir=str(tmpdir),
-                    inference_container="iad.ocir.io/my/own/md-container",
-                    inference_container_type_smc=False,
-                    finetuning_container="iad.ocir.io/my/own/ft-container",
-                    finetuning_container_type_smc=False,
-                )
-                mock_snapshot_download.assert_called_with(
-                    repo_id=hf_model,
-                    local_dir=f"{str(tmpdir)}/{hf_model}",
-                    local_dir_use_symlinks=False,
-                )
-                mock_subprocess.assert_called_with(
-                    shlex.split(
-                        f"oci os object bulk-upload --src-dir {str(tmpdir)}/{hf_model} --prefix prefix/path/{hf_model}/ -bn aqua-bkt -ns aqua-ns --auth api_key --profile DEFAULT --no-overwrite"
-                    )
-                )
-                assert model.freeform_tags == {
-                    "aqua_custom_base_model": "true",
-                    "aqua_finetuning": "true",
-                    **ds_freeform_tags,
-                }
-                expected_metadata = [
-                    {
-                        "key": "evaluation-container",
-                        "value": "odsc-llm-evaluate",
-                        "description": "Evaluation container mapping for SMC",
-                        "category": "Other",
-                    },
-                    {
-                        "key": "deployment-container",
-                        "value": "iad.ocir.io/my/own/md-container",
-                        "description": f"Inference container mapping for {hf_model}",
-                        "category": "Other",
-                    },
-                    {
-                        "key": "finetune-container",
-                        "value": "iad.ocir.io/my/own/ft-container",
-                        "description": f"Fine-tuning container mapping for {hf_model}",
-                        "category": "Other",
-                    },
-                    {
-                        "key": "modelDescription",
-                        "value": "true",
-                        "description": "model by reference flag",
-                        "category": "Other",
-                    },
-                    {
-                        "key": "artifact_location",
-                        "value": f"{os_path}/{hf_model}/",
-                        "description": "artifact location",
-                        "category": "Other",
-                    },
-                ]
-                for item in expected_metadata:
-                    assert model.custom_metadata_list[item["key"]].to_dict() == item
-                assert model.version_id is None
-
-    @patch("huggingface_hub.snapshot_download")
-    @patch("subprocess.check_call")
-    def test_import_any_hf_model_smc_container(
-        self,
-        mock_subprocess,
-        mock_snapshot_download,
-    ):
-        hf_model = "oracle/aqua-1t-mega-model"
-        ObjectStorageDetails.is_bucket_versioned = MagicMock(return_value=True)
-        ads.common.oci_datascience.OCIDataScienceMixin.init_client = MagicMock()
-        huggingface_hub.HfApi.model_info = MagicMock(
-            return_value=huggingface_hub.hf_api.ModelInfo(
-                **{
-                    "id": hf_model,
-                    "license": "aqua-license",
-                    "author": "oracle",
-                    "pipeline_tag": "text-generation",
-                    "private": False,
-                    "downloads": 100,
-                    "likes": 10,
-                    "tags": ["text-generation"],
-                }
+        with patch.object(AquaModelApp, "list") as aqua_model_mock_list:
+            aqua_model_mock_list.return_value = [
+                AquaModelSummary(
+                    id="test_id1",
+                    name="organization1/name1",
+                    organization="organization1",
+                ),
+                AquaModelSummary(
+                    id="test_id2",
+                    name="organization1/name2",
+                    organization="organization1",
+                ),
+                AquaModelSummary(
+                    id="test_id3",
+                    name="organization2/name3",
+                    organization="organization2",
+                ),
+            ]
+            model: AquaModel = app.register(
+                model=my_model,
+                os_path=os_path,
+                inference_container="odsc-vllm-or-tgi-container",
+                finetuning_container="odsc-llm-fine-tuning",
             )
-        )
-        DataScienceModel.upload_artifact = MagicMock()
-        DataScienceModel.sync = MagicMock()
-        OCIDataScienceModel.create = MagicMock()
-
-        os_path = "oci://aqua-bkt@aqua-ns/prefix/path"
-        ds_freeform_tags = {
-            "OCI_AQUA": "active",
-            "organization": "oracle",
-            "task": "text-generation",
-        }
-
-        reload(ads.aqua.model.model)
-        app = AquaModelApp()
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch.object(AquaModelApp, "list") as aqua_model_mock_list:
-                aqua_model_mock_list.return_value = [
-                    AquaModelSummary(
-                        id="test_id1",
-                        name="organization1/name1",
-                        organization="organization1",
-                    ),
-                    AquaModelSummary(
-                        id="test_id2",
-                        name="organization1/name2",
-                        organization="organization1",
-                    ),
-                    AquaModelSummary(
-                        id="test_id3",
-                        name="organization2/name3",
-                        organization="organization2",
-                    ),
-                ]
-                model: DataScienceModel = app.register(
-                    model=hf_model,
-                    os_path=os_path,
-                    local_dir=str(tmpdir),
-                    inference_container="dsmc://md-container",
-                    inference_container_type_smc=False,
-                    finetuning_container="dsmc://ft-container",
-                    finetuning_container_type_smc=False,
-                )
-                mock_snapshot_download.assert_called_with(
-                    repo_id=hf_model,
-                    local_dir=f"{str(tmpdir)}/{hf_model}",
-                    local_dir_use_symlinks=False,
-                )
-                mock_subprocess.assert_called_with(
-                    shlex.split(
-                        f"oci os object bulk-upload --src-dir {str(tmpdir)}/{hf_model} --prefix prefix/path/{hf_model}/ -bn aqua-bkt -ns aqua-ns --auth api_key --profile DEFAULT --no-overwrite"
-                    )
-                )
-                assert model.freeform_tags == {
-                    "aqua_custom_base_model": "true",
-                    "aqua_finetuning": "true",
-                    **ds_freeform_tags,
-                }
-                expected_metadata = [
-                    {
-                        "key": "evaluation-container",
-                        "value": "odsc-llm-evaluate",
-                        "description": "Evaluation container mapping for SMC",
-                        "category": "Other",
-                    },
-                    {
-                        "key": "deployment-container",
-                        "value": "dsmc://md-container",
-                        "description": f"Inference container mapping for {hf_model}",
-                        "category": "Other",
-                    },
-                    {
-                        "key": "finetune-container",
-                        "value": "dsmc://ft-container",
-                        "description": f"Fine-tuning container mapping for {hf_model}",
-                        "category": "Other",
-                    },
-                    {
-                        "key": "modelDescription",
-                        "value": "true",
-                        "description": "model by reference flag",
-                        "category": "Other",
-                    },
-                    {
-                        "key": "artifact_location",
-                        "value": f"{os_path}/{hf_model}/",
-                        "description": "artifact location",
-                        "category": "Other",
-                    },
-                ]
-                for item in expected_metadata:
-                    assert model.custom_metadata_list[item["key"]].to_dict() == item
-                assert model.version_id is None
+            assert model.tags == {
+                "aqua_custom_base_model": "true",
+                "ready_to_fine_tune": "true",
+                **ds_freeform_tags,
+            }
+            assert model.inference_container == "odsc-vllm-or-tgi-container"
+            assert model.finetuning_container == "odsc-llm-fine-tuning"
+            assert model.evaluation_container == "odsc-llm-evaluate"
+            assert model.ready_to_import is False
+            assert model.ready_to_deploy is True
+            assert model.ready_to_finetune is True
 
     @parameterized.expand(
         [

--- a/tests/unitary/with_extras/aqua/test_model_handler.py
+++ b/tests/unitary/with_extras/aqua/test_model_handler.py
@@ -7,20 +7,13 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-import pytest
-from huggingface_hub import HfApi, hf_api
-from huggingface_hub.utils import GatedRepoError
 from notebook.base.handlers import IPythonHandler
-from tornado.web import HTTPError
-
-from ads.aqua.common.errors import AquaRuntimeError
 from ads.aqua.extension.model_handler import (
-    AquaHuggingFaceHandler,
     AquaModelHandler,
     AquaModelLicenseHandler,
 )
 from ads.aqua.model import AquaModelApp
-from ads.aqua.model.entities import AquaModelSummary, HFModelSummary
+from ads.aqua.model.entities import AquaModel
 
 
 class ModelHandlerTestCase(TestCase):
@@ -29,7 +22,6 @@ class ModelHandlerTestCase(TestCase):
         ipython_init_mock.return_value = None
         self.model_handler = AquaModelHandler(MagicMock(), MagicMock())
         self.model_handler.request = MagicMock()
-        self.model_handler.finish = MagicMock()
 
     @patch.object(AquaModelHandler, "list")
     def test_get_no_id(self, mock_list):
@@ -43,32 +35,75 @@ class ModelHandlerTestCase(TestCase):
 
     @patch.object(AquaModelApp, "get")
     def test_read(self, mock_get):
-        self.model_handler.read(model_id="test_model_id")
-        self.model_handler.finish.assert_called_with(mock_get.return_value)
-        mock_get.assert_called_with("test_model_id")
+        with patch(
+            "ads.aqua.extension.base_handler.AquaAPIhandler.finish"
+        ) as mock_finish:
+            mock_finish.side_effect = lambda x: x
+            self.model_handler.read(model_id="test_model_id")
+            mock_get.assert_called_with("test_model_id")
 
     @patch.object(AquaModelApp, "clear_model_list_cache")
     @patch("ads.aqua.extension.model_handler.urlparse")
     def test_delete(self, mock_urlparse, mock_clear_model_list_cache):
         request_path = MagicMock(path="aqua/model/cache")
         mock_urlparse.return_value = request_path
+        mock_clear_model_list_cache.return_value = {
+            "key": {
+                "compartment_id": "test-compartment-ocid",
+            },
+            "cache_deleted": True,
+        }
 
-        self.model_handler.delete()
-        self.model_handler.finish.assert_called_with(
-            mock_clear_model_list_cache.return_value
-        )
-
-        mock_urlparse.assert_called()
-        mock_clear_model_list_cache.assert_called()
+        with patch(
+            "ads.aqua.extension.base_handler.AquaAPIhandler.finish"
+        ) as mock_finish:
+            mock_finish.side_effect = lambda x: x
+            result = self.model_handler.delete()
+            assert result["cache_deleted"] is True
+            mock_urlparse.assert_called()
+            mock_clear_model_list_cache.assert_called()
 
     @patch.object(AquaModelApp, "list")
     def test_list(self, mock_list):
-        self.model_handler.list()
+        with patch(
+            "ads.aqua.extension.base_handler.AquaAPIhandler.finish"
+        ) as mock_finish:
+            mock_finish.side_effect = lambda x: x
+            self.model_handler.list()
+            mock_list.assert_called_with(
+                compartment_id=None, project_id=None, model_type=None
+            )
 
-        self.model_handler.finish.assert_called_with(mock_list.return_value)
-        mock_list.assert_called_with(
-            compartment_id=None, project_id=None, model_type=None
+    @patch("notebook.base.handlers.APIHandler.finish")
+    @patch("ads.aqua.model.model.AquaModelApp.register")
+    def test_register(self, mock_register, mock_finish):
+        mock_register.return_value = AquaModel(
+            id="test_id",
+            inference_container="odsc-tgi-serving",
+            evaluation_container="odsc-llm-evaluate",
         )
+        mock_finish.side_effect = lambda x: x
+
+        self.model_handler.get_json_body = MagicMock(
+            return_value=dict(
+                model="test_model_name",
+                os_path="test_os_path",
+                inference_container="odsc-tgi-serving",
+            )
+        )
+        result = self.model_handler.post()
+        mock_register.assert_called_with(
+            model="test_model_name",
+            os_path="test_os_path",
+            inference_container="odsc-tgi-serving",
+            finetuning_container=None,
+            compartment_id=None,
+            project_id=None,
+        )
+        assert result["id"] == "test_id"
+        assert result["inference_container"] == "odsc-tgi-serving"
+        assert result["evaluation_container"] == "odsc-llm-evaluate"
+        assert result["finetuning_container"] is None
 
 
 class ModelLicenseHandlerTestCase(TestCase):
@@ -86,175 +121,3 @@ class ModelLicenseHandlerTestCase(TestCase):
             mock_load_license.return_value
         )
         mock_load_license.assert_called_with("test_model_id")
-
-
-class TestAquaHuggingFaceHandler:
-    def setup_method(self):
-        with patch.object(IPythonHandler, "__init__"):
-            self.mock_handler = AquaHuggingFaceHandler(MagicMock(), MagicMock())
-            self.mock_handler.request = MagicMock()
-            self.mock_handler.finish = MagicMock()
-            self.mock_handler.set_header = MagicMock()
-            self.mock_handler.set_status = MagicMock()
-
-    @pytest.mark.parametrize(
-        "test_model_id, test_author, expected_aqua_model_name, expected_aqua_model_id",
-        [
-            ("organization1/name1", "organization1", "organization1/name1", "test_id1"),
-            ("organization1/name2", "organization1", "organization1/name2", "test_id2"),
-            ("organization2/name3", "organization2", "organization2/name3", "test_id3"),
-            ("non_existing_name", "organization2", None, None),
-            ("organization1/non_existing_name", "organization1", None, None),
-        ],
-    )
-    @patch.object(AquaModelApp, "get")
-    def test_find_matching_aqua_model(
-        self,
-        mock_get_model,
-        test_model_id,
-        test_author,
-        expected_aqua_model_name,
-        expected_aqua_model_id,
-    ):
-        with patch.object(AquaModelApp, "list") as aqua_model_mock_list:
-            aqua_model_mock_list.return_value = [
-                AquaModelSummary(
-                    id="test_id1",
-                    name="organization1/name1",
-                    organization="organization1",
-                ),
-                AquaModelSummary(
-                    id="test_id2",
-                    name="organization1/name2",
-                    organization="organization1",
-                ),
-                AquaModelSummary(
-                    id="test_id3",
-                    name="organization2/name3",
-                    organization="organization2",
-                ),
-            ]
-
-            test_result = self.mock_handler._find_matching_aqua_model(
-                model_id=test_model_id
-            )
-
-            aqua_model_mock_list.assert_called_once()
-
-            if expected_aqua_model_name:
-                mock_get_model.assert_called_with(
-                    expected_aqua_model_id, load_model_card=False
-                )
-            else:
-                assert test_result == None
-
-    @patch("uuid.uuid4")
-    def test_post_negative(self, mock_uuid):
-        mock_uuid.return_value = "###"
-
-        # case 1
-        self.mock_handler.get_json_body = MagicMock(side_effect=ValueError())
-        self.mock_handler.post()
-        self.mock_handler.finish.assert_called_with(
-            '{"status": 400, "message": "Invalid format of input data.", "service_payload": {}, "reason": "Invalid format of input data.", "request_id": "###"}'
-        )
-
-        # case 2
-        self.mock_handler.get_json_body = MagicMock(return_value={})
-        self.mock_handler.post()
-        self.mock_handler.finish.assert_called_with(
-            '{"status": 400, "message": "No input data provided.", "service_payload": {}, '
-            '"reason": "No input data provided.", "request_id": "###"}'
-        )
-
-        # case 3
-        self.mock_handler.get_json_body = MagicMock(return_value={"some_field": None})
-        self.mock_handler.post()
-        self.mock_handler.finish.assert_called_with(
-            '{"status": 400, "message": "Missing required parameter: \'model_id\'", '
-            '"service_payload": {}, "reason": "Missing required parameter: \'model_id\'", "request_id": "###"}'
-        )
-
-        # case 4
-        self.mock_handler.get_json_body = MagicMock(
-            return_value={"model_id": "test_model_id"}
-        )
-        self.mock_handler._format_custom_error_message = MagicMock(
-            side_effect=AquaRuntimeError("test error message")
-        )
-        with patch.object(HfApi, "model_info") as mock_model_info:
-            mock_model_info.side_effect = GatedRepoError(message="test message")
-            self.mock_handler.post()
-            self.mock_handler.finish.assert_called_with(
-                '{"status": 400, "message": "Something went wrong with your request.", '
-                '"service_payload": {}, "reason": "test error message", "request_id": "###"}'
-            )
-
-        # case 5
-        self.mock_handler.get_json_body = MagicMock(
-            return_value={"model_id": "test_model_id"}
-        )
-        with patch.object(HfApi, "model_info") as mock_model_info:
-            mock_model_info.return_value = MagicMock(disabled=True, id="test_model_id")
-            self.mock_handler.post()
-            self.mock_handler.finish.assert_called_with(
-                '{"status": 400, "message": "Something went wrong with your request.", "service_payload": {}, '
-                '"reason": "The chosen model \'test_model_id\' is currently disabled and cannot be '
-                "imported into AQUA. Please verify the model's status on the Hugging Face Model "
-                'Hub or select a different model.", "request_id": "###"}'
-            )
-
-        # case 6
-        self.mock_handler.get_json_body = MagicMock(
-            return_value={"model_id": "test_model_id"}
-        )
-        with patch.object(HfApi, "model_info") as mock_model_info:
-            mock_model_info.return_value = MagicMock(
-                disabled=False, id="test_model_id", pipeline_tag="not-text-generation"
-            )
-            self.mock_handler.post()
-            self.mock_handler.finish.assert_called_with(
-                '{"status": 400, "message": "Something went wrong with your request.", '
-                '"service_payload": {}, "reason": "Unsupported pipeline tag for the chosen '
-                "model: 'not-text-generation'. AQUA currently supports the following tasks only: "
-                'text-generation. Please select a model with a compatible pipeline tag.", "request_id": "###"}'
-            )
-
-    @patch("uuid.uuid4")
-    def test_post_positive(self, mock_uuid):
-        mock_uuid.return_value = "###"
-
-        self.mock_handler.get_json_body = MagicMock(
-            return_value={"model_id": "test_model_id"}
-        )
-
-        test_aqua_model_summary = AquaModelSummary(
-            name="name1", organization="organization1"
-        )
-        self.mock_handler._find_matching_aqua_model = MagicMock(
-            return_value=test_aqua_model_summary
-        )
-
-        with patch.object(HfApi, "model_info") as mock_model_info:
-            test_hf_model_info = hf_api.ModelInfo(
-                disabled=False,
-                id="test_model_id",
-                pipeline_tag="text-generation",
-                author="test_author",
-                private=False,
-                downloads=10,
-                likes=10,
-                tags=None,
-            )
-            mock_model_info.return_value = test_hf_model_info
-            self.mock_handler.post()
-
-            self.mock_handler._find_matching_aqua_model.assert_called_with(
-                model_id="test_model_id"
-            )
-
-            test_model_summary = HFModelSummary(
-                model_info=test_hf_model_info, aqua_model_info=test_aqua_model_summary
-            )
-
-            self.mock_handler.finish.assert_called_with(test_model_summary)

--- a/tests/unitary/with_extras/aqua/test_model_handler.py
+++ b/tests/unitary/with_extras/aqua/test_model_handler.py
@@ -75,7 +75,7 @@ class ModelHandlerTestCase(TestCase):
             )
 
     @patch("notebook.base.handlers.APIHandler.finish")
-    @patch("ads.aqua.model.model.AquaModelApp.register")
+    @patch("ads.aqua.model.AquaModelApp.register")
     def test_register(self, mock_register, mock_finish):
         mock_register.return_value = AquaModel(
             id="test_id",


### PR DESCRIPTION
### Description

This PR includes changes for the following:
1. Removing references of HF apis.
2. Add a new register post API to register the imported models, returns AquaModel instead of DataScienceModel object.
3. Update register API to accept model name and os_path, remove redundant parameters.

### Using the API

#### Request
```
POST http://localhost:8888/aqua/model
{
    "model": "google/gemma-2b",
    "os_path": "oci://bucket-name@namespace/aqua/models/google/gemma-2b",
    "inference_container": "odsc-tgi-serving"
}

```

#### Response
```
{
    "compartment_id": "ocid1.compartment.oc1..<ocid>",
    "icon": "",
    "id": "ocid1.datasciencemodel.oc1.iad.<ocid>",
    "is_fine_tuned_model": false,
    "license": "gemma",
    "name": "google/gemma-2b",
    "organization": "Google",
    "project_id": "ocid1.datascienceproject.oc1.iad.<ocid>",
    "tags": {
        "aqua_service_model": "ocid1.datasciencemodel.oc1.iad.<ocid>",
        "license": "gemma",
        "task": "text_generation",
        "organization": "Google",
        "aqua_custom_base_model": "true",
        "OCI_AQUA": "active",
        "ready_to_fine_tune": "true"
    },
    "task": "text_generation",
    "time_created": "2024-05-29 18:10:05.283000+00:00",
    "console_link": [
        "https://cloud.oracle.com/data-science/models/ocid1.datasciencemodel.oc1.iad.<ocid>?region=us-ashburn-1"
    ],
    "search_text": "ocid1.datasciencemodel.oc1.iad.<ocid>,gemma,text_generation,Google,true,active,true",
    "ready_to_deploy": true,
    "ready_to_finetune": true,
    "ready_to_import": false,
    "model_card": "",
    "inference_container": "odsc-tgi-serving",
    "finetuning_container": "odsc-llm-fine-tuning",
    "evaluation_container": "odsc-llm-evaluate"
}
```

### Tests

```
> python -m pytest -q tests/unitary/with_extras/aqua/test_model*.py
==================================== test session starts ====================================
platform darwin -- Python 3.8.18, pytest-7.4.0, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-24.9.0, anyio-4.2.0
collected 24 items

tests/unitary/with_extras/aqua/test_model.py .................                        [ 70%]
tests/unitary/with_extras/aqua/test_model_handler.py .......                          [100%]

==================================== 24 passed in 3.67s =====================================

```