### PR TITLE
ODSC-58449: ads LangChain plugin update

### DIFF
--- a/ads/llm/langchain/plugins/base.py
+++ b/ads/llm/langchain/plugins/base.py
@@ -3,6 +3,7 @@
 
 # Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+import logging
 from typing import Any, Dict, List, Optional
 
 from langchain.llms.base import LLM
@@ -10,6 +11,8 @@ from langchain.pydantic_v1 import BaseModel, Field, root_validator
 
 from ads.common.auth import default_signer
 from ads.config import COMPARTMENT_OCID
+
+logger = logging.getLogger(__name__)
 
 
 class BaseLLM(LLM):
@@ -95,6 +98,11 @@ class GenerativeAiClientModel(BaseModel):
         """Validate that python package exists in environment."""
         # Initialize client only if user does not pass in client.
         # Users may choose to initialize the OCI client by themselves and pass it into this model.
+        logger.warning(
+            f"The ads langchain plugin {cls.__name__} will be deprecated soon. "
+            "Please refer to https://python.langchain.com/v0.2/docs/integrations/providers/oci/ "
+            "for the latest support."
+        )
         if not values.get("client"):
             auth = values.get("auth", {})
             client_kwargs = auth.get("client_kwargs") or {}

--- a/ads/llm/langchain/plugins/base.py
+++ b/ads/llm/langchain/plugins/base.py
@@ -3,16 +3,14 @@
 
 # Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
-import logging
 from typing import Any, Dict, List, Optional
 
 from langchain.llms.base import LLM
 from langchain.pydantic_v1 import BaseModel, Field, root_validator
 
+from ads import logger
 from ads.common.auth import default_signer
 from ads.config import COMPARTMENT_OCID
-
-logger = logging.getLogger(__name__)
 
 
 class BaseLLM(LLM):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ pii = [
   "spacy==3.6.1",
   "report-creator==1.0.9",
 ]
-llm = ["langchain-community<0.0.32", "langchain>=0.1.10,<0.1.14", "evaluate>=0.4.0", "langchain-core<0.1.51"]
+llm = ["langchain-community<0.0.32", "langchain>=0.1.10,<0.1.14", "evaluate>=0.4.0"]
 aqua = ["jupyter_server"]
 
 # To reduce backtracking (decrese deps install time) during test/dev env setup reducing number of versions pip is


### PR DESCRIPTION
# Description
We would like to relax langchain-core version restriction:
* 0.1.51 improve the serialization by saving model parameters. ( <= 0.1.50, the serialized object will not contain model parameters)

For gen ai plugin, we are going to put deprecation warning and point user to their own support in langchain.

# Test
![Screenshot 2024-06-07 at 14 00 29](https://github.com/oracle/accelerated-data-science/assets/49049296/455d7e2d-c069-4420-9614-b726ee2ca79b)
