### PR TITLE
Added "continue-on-error: true" to step which posts coverage comment

### DIFF
--- a/.github/workflows/run-unittests-py38-cov-report.yml
+++ b/.github/workflows/run-unittests-py38-cov-report.yml
@@ -188,6 +188,7 @@ jobs:
           fi
 
       - name: "Add comment with cov diff to PR"
+        continue-on-error: true
         uses: actions/github-script@v7
         if: github.event_name == 'pull_request'
         with:


### PR DESCRIPTION
### Description

With recent PR from user, who is not in special write-permission-group, there was an error in one step of our test pipeline observed. That step showed 403 erorr (https://github.com/oracle/accelerated-data-science/actions/runs/9504255692/job/26199643545?pr=869) on sending POST to add comment into respective PR. Even though GH action has permissions set to write for pull-request, user should be able to have permission to write to repo (be in that special group).

To overcome this and future issues with PR from such users I am suggesting to make a step, which adds comment to PR optional (add continue-on-error: true). We still will have our coverage reports generated and published to artifacts and PR reviewers can see coverage downloading from artifacts generated by GH actions, but this will omit such message in PR:
![image](https://github.com/oracle/accelerated-data-science/assets/49763871/75e77988-b499-4459-a5a3-18d845584812)

