### PR TITLE
Added ruff for pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,12 @@ repos:
       rev: v0.4.9
       hooks:
           - id: ruff
+            types_or: [ python, pyi, jupyter ]
             args: [ --fix ]
             files: ^ads
             exclude: ^docs/
           - id: ruff-format
+            types_or: [ python, pyi, jupyter ]
             exclude: ^docs/
     # Standard hooks
     - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,14 @@
 repos:
+    # ruff
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.4.9
+      hooks:
+          - id: ruff
+            args: [ --fix ]
+            files: ^ads
+            exclude: ^docs/
+          - id: ruff-format
+            exclude: ^docs/
     # Standard hooks
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.4.0
@@ -19,12 +29,6 @@ repos:
             args: ["--autofix"]
           - id: trailing-whitespace
             args: [--markdown-linebreak-ext=md]
-            exclude: ^docs/
-    # Black, the code formatter, natively supports pre-commit
-    - repo: https://github.com/psf/black
-      rev: 23.3.0
-      hooks:
-          - id: black
             exclude: ^docs/
     # Regex based rst files common mistakes detector
     - repo: https://github.com/pre-commit/pygrep-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,3 +221,30 @@ name = "ads" # name for local build and import, see https://flit.pypa.io/en/late
 # By default `ads` folder and `LICENSE.txt` file included in sdist. Folders `docs` and `tests` are excluded, as weel as other project files
 # Use this section to include/exclude files and folders. See doc: https://flit.pypa.io/en/latest/pyproject_toml.html#sdist-section
 include = ["THIRD_PARTY_LICENSES.txt"]
+
+# Configuring Ruff (https://docs.astral.sh/ruff/configuration/)
+[tool.ruff]
+fix = true
+
+[tool.ruff.lint]
+exclude = ["*.yaml", "*jinja2"]
+# rules - https://docs.astral.sh/ruff/rules/
+select = [
+  # pyflakes
+  "F",
+  # subset of the pycodestyle
+  "E4", "E7", "E9",
+  # warnings
+  "W",
+  # isort
+  "I"
+  ]
+ignore = [
+  # module level import not at top of file
+  "E402",
+  # line-length violations
+  "E501",
+  ]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,22 +229,37 @@ fix = true
 [tool.ruff.lint]
 exclude = ["*.yaml", "*jinja2"]
 # rules - https://docs.astral.sh/ruff/rules/
-select = [
-  # pyflakes
-  "F",
-  # subset of the pycodestyle
-  "E4", "E7", "E9",
-  # warnings
-  "W",
-  # isort
-  "I"
-  ]
+extend-ignore = ["E402", "N806", "N803"]
 ignore = [
-  # module level import not at top of file
-  "E402",
-  # line-length violations
-  "E501",
-  ]
+  "S101",    # use of assert
+  "B008",    # function call in argument defaults
+  "B017",    # pytest.raises considered evil
+  "B023",    # function definition in loop (TODO: un-ignore this)
+  "B028",    # explicit stacklevel for warnings
+  "C901",    # function is too complex (TODO: un-ignore this)
+  "E501",    # from scripts/lint_backend.sh
+  "PLR091",  # complexity rules
+  "PLR2004", # magic numbers
+  "PLW2901", # `for` loop variable overwritten by assignment target
+  "SIM105",  # contextlib.suppress (has a performance cost)
+  "SIM117",  # multiple nested with blocks (doesn't look good with gr.Row etc)
+  "UP006",   # use `list` instead of `List` for type annotations (fails for 3.8)
+  "UP007",   # use X | Y for type annotations (TODO: can be enabled once Pydantic plays nice with them)
+]
+extend-select = [
+  "ARG",
+  "B",
+  "C",
+  "E",
+  "F",
+  "I",
+  "N",
+  "PL",
+  "S101",
+  "SIM",
+  "UP",
+  "W",
+]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,3 +9,4 @@ pytest
 pytest-cov
 pytest-xdist
 kubernetes
+ruff


### PR DESCRIPTION
### Description

Ruff can be used to replace Flake8 (plus dozens of plugins), Black, isort, pydocstyle, and more, all while executing tens or hundreds of times faster than any individual tool.

Added ruff to run mainly default settings with little extra and exclude. While developing our code we will add/exclude more. Please check on rules and suggest what can be added to default (section 'select' in pyproject.toml) and what can be excluded (section 'ignore' in pyproject.toml)- https://docs.astral.sh/ruff/rules/.

### What was done

- added repo to .pre-commit-config.yaml
- added rules to pyproject.toml
- removed black, because ruff has drop-in parity with it