### PR TITLE
[ODSC-59697] Llama cpp deployment support 

### DIFF
--- a/ads/aqua/extension/common_ws_msg_handler.py
+++ b/ads/aqua/extension/common_ws_msg_handler.py
@@ -1,4 +1,10 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
 import json
+from importlib import metadata
 from typing import List, Union
 
 from ads.aqua import ODSC_MODEL_COMPARTMENT_OCID, fetch_service_compartment
@@ -6,13 +12,14 @@ from ads.aqua.common.decorator import handle_exceptions
 from ads.aqua.common.errors import AquaResourceAccessError
 from ads.aqua.common.utils import known_realm
 from ads.aqua.extension.aqua_ws_msg_handler import AquaWSMsgHandler
-from ads.aqua.extension.models.ws_models import RequestResponseType, AdsVersionResponse, AdsVersionRequest, \
-    CompatibilityCheckResponse
-from importlib import metadata
+from ads.aqua.extension.models.ws_models import (
+    AdsVersionResponse,
+    CompatibilityCheckResponse,
+    RequestResponseType,
+)
 
 
 class AquaCommonWsMsgHandler(AquaWSMsgHandler):
-
     @staticmethod
     def get_message_types() -> List[RequestResponseType]:
         return [RequestResponseType.AdsVersion, RequestResponseType.CompatibilityCheck]
@@ -21,25 +28,30 @@ class AquaCommonWsMsgHandler(AquaWSMsgHandler):
         super().__init__(message)
 
     @handle_exceptions
-    def process(self) -> AdsVersionResponse | CompatibilityCheckResponse:
+    def process(self) -> Union[AdsVersionResponse, CompatibilityCheckResponse]:
         request = json.loads(self.message)
-        if request.get('kind') == 'AdsVersion':
+        if request.get("kind") == "AdsVersion":
             version = metadata.version("oracle_ads")
             response = AdsVersionResponse(
                 message_id=request.get("message_id"),
                 kind=RequestResponseType.AdsVersion,
-                data=version)
+                data=version,
+            )
             return response
-        if request.get('kind') == 'CompatibilityCheck':
+        if request.get("kind") == "CompatibilityCheck":
             if ODSC_MODEL_COMPARTMENT_OCID or fetch_service_compartment():
-                return CompatibilityCheckResponse(message_id=request.get("message_id"),
-                                                  kind=RequestResponseType.CompatibilityCheck,
-                                                  data={'status': 'ok'})
+                return CompatibilityCheckResponse(
+                    message_id=request.get("message_id"),
+                    kind=RequestResponseType.CompatibilityCheck,
+                    data={"status": "ok"},
+                )
             elif known_realm():
-                return CompatibilityCheckResponse(message_id=request.get("message_id"),
-                                                  kind=RequestResponseType.CompatibilityCheck,
-                                                  data={'status': 'compatible'})
+                return CompatibilityCheckResponse(
+                    message_id=request.get("message_id"),
+                    kind=RequestResponseType.CompatibilityCheck,
+                    data={"status": "compatible"},
+                )
             else:
                 raise AquaResourceAccessError(
-                    f"The AI Quick actions extension is not compatible in the given region."
+                    "The AI Quick actions extension is not compatible in the given region."
                 )

--- a/ads/aqua/extension/deployment_handler.py
+++ b/ads/aqua/extension/deployment_handler.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
@@ -8,8 +7,8 @@ from urllib.parse import urlparse
 from tornado.web import HTTPError
 
 from ads.aqua.common.decorator import handle_exceptions
-from ads.aqua.extension.errors import Errors
 from ads.aqua.extension.base_handler import AquaAPIhandler
+from ads.aqua.extension.errors import Errors
 from ads.aqua.modeldeployment import AquaDeploymentApp, MDInferenceResponse
 from ads.aqua.modeldeployment.entities import ModelParams
 from ads.config import COMPARTMENT_OCID, PROJECT_OCID
@@ -66,8 +65,8 @@ class AquaDeploymentHandler(AquaAPIhandler):
         """
         try:
             input_data = self.get_json_body()
-        except Exception:
-            raise HTTPError(400, Errors.INVALID_INPUT_DATA_FORMAT)
+        except Exception as ex:
+            raise HTTPError(400, Errors.INVALID_INPUT_DATA_FORMAT) from ex
 
         if not input_data:
             raise HTTPError(400, Errors.NO_INPUT_DATA)
@@ -100,6 +99,8 @@ class AquaDeploymentHandler(AquaAPIhandler):
         health_check_port = input_data.get("health_check_port")
         env_var = input_data.get("env_var")
         container_family = input_data.get("container_family")
+        ocpus = input_data.get("ocpus")
+        memory_in_gbs = input_data.get("memory_in_gbs")
 
         self.finish(
             AquaDeploymentApp().create(
@@ -119,6 +120,8 @@ class AquaDeploymentHandler(AquaAPIhandler):
                 health_check_port=health_check_port,
                 env_var=env_var,
                 container_family=container_family,
+                ocpus=ocpus,
+                memory_in_gbs=memory_in_gbs,
             )
         )
 
@@ -153,9 +156,7 @@ class AquaDeploymentInferenceHandler(AquaAPIhandler):
                 return False
             if not url.netloc:
                 return False
-            if not url.path.endswith("/predict"):
-                return False
-            return True
+            return url.path.endswith("/predict")
         except Exception:
             return False
 
@@ -170,8 +171,8 @@ class AquaDeploymentInferenceHandler(AquaAPIhandler):
         """
         try:
             input_data = self.get_json_body()
-        except Exception:
-            raise HTTPError(400, Errors.INVALID_INPUT_DATA_FORMAT)
+        except Exception as ex:
+            raise HTTPError(400, Errors.INVALID_INPUT_DATA_FORMAT) from ex
 
         if not input_data:
             raise HTTPError(400, Errors.NO_INPUT_DATA)
@@ -192,10 +193,10 @@ class AquaDeploymentInferenceHandler(AquaAPIhandler):
         )
         try:
             model_params_obj = ModelParams(**model_params)
-        except:
+        except Exception as ex:
             raise HTTPError(
                 400, Errors.INVALID_INPUT_DATA_FORMAT.format("model_params")
-            )
+            ) from ex
 
         return self.finish(
             MDInferenceResponse(prompt, model_params_obj).get_model_deployment_response(
@@ -236,8 +237,8 @@ class AquaDeploymentParamsHandler(AquaAPIhandler):
         """
         try:
             input_data = self.get_json_body()
-        except Exception:
-            raise HTTPError(400, Errors.INVALID_INPUT_DATA_FORMAT)
+        except Exception as ex:
+            raise HTTPError(400, Errors.INVALID_INPUT_DATA_FORMAT) from ex
 
         if not input_data:
             raise HTTPError(400, Errors.NO_INPUT_DATA)

--- a/ads/aqua/extension/deployment_ws_msg_handler.py
+++ b/ads/aqua/extension/deployment_ws_msg_handler.py
@@ -1,25 +1,35 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
 import json
 from typing import List, Union
 
 from ads.aqua.common.decorator import handle_exceptions
 from ads.aqua.extension.aqua_ws_msg_handler import AquaWSMsgHandler
-from ads.aqua.extension.models.ws_models import RequestResponseType, ListDeploymentResponse, ListDeploymentRequest, \
-    ModelDeploymentDetailsResponse
+from ads.aqua.extension.models.ws_models import (
+    ListDeploymentResponse,
+    ModelDeploymentDetailsResponse,
+    RequestResponseType,
+)
 from ads.aqua.modeldeployment import AquaDeploymentApp
 from ads.config import COMPARTMENT_OCID
 
 
 class AquaDeploymentWSMsgHandler(AquaWSMsgHandler):
-
     def __init__(self, message: Union[str, bytes]):
         super().__init__(message)
 
     @staticmethod
     def get_message_types() -> List[RequestResponseType]:
-        return [RequestResponseType.ListDeployments, RequestResponseType.DeploymentDetails]
+        return [
+            RequestResponseType.ListDeployments,
+            RequestResponseType.DeploymentDetails,
+        ]
 
     @handle_exceptions
-    def process(self) -> ListDeploymentResponse | ModelDeploymentDetailsResponse:
+    def process(self) -> Union[ListDeploymentResponse, ModelDeploymentDetailsResponse]:
         request = json.loads(self.message)
         if request.get("kind") == "ListDeployments":
             deployment_list = AquaDeploymentApp().list(
@@ -33,8 +43,12 @@ class AquaDeploymentWSMsgHandler(AquaWSMsgHandler):
             )
             return response
         elif request.get("kind") == "DeploymentDetails":
-            deployment_details = AquaDeploymentApp().get(request.get("model_deployment_id"))
-            response = ModelDeploymentDetailsResponse(message_id=request.get("message_id"),
-                                                      kind=RequestResponseType.DeploymentDetails,
-                                                      data=deployment_details)
+            deployment_details = AquaDeploymentApp().get(
+                request.get("model_deployment_id")
+            )
+            response = ModelDeploymentDetailsResponse(
+                message_id=request.get("message_id"),
+                kind=RequestResponseType.DeploymentDetails,
+                data=deployment_details,
+            )
             return response

--- a/ads/aqua/extension/evaluation_ws_msg_handler.py
+++ b/ads/aqua/extension/evaluation_ws_msg_handler.py
@@ -29,7 +29,7 @@ class AquaEvaluationWSMsgHandler(AquaWSMsgHandler):
         super().__init__(message)
 
     @handle_exceptions
-    def process(self) -> ListEvaluationsResponse | EvaluationDetailsResponse:
+    def process(self) -> Union[ListEvaluationsResponse, EvaluationDetailsResponse]:
         request = json.loads(self.message)
         if request["kind"] == "ListEvaluations":
             return self.list_evaluations(request)

--- a/ads/aqua/extension/models_ws_msg_handler.py
+++ b/ads/aqua/extension/models_ws_msg_handler.py
@@ -1,30 +1,37 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
 import json
 from typing import List, Union
 
 from ads.aqua.common.decorator import handle_exceptions
 from ads.aqua.extension.aqua_ws_msg_handler import AquaWSMsgHandler
-from ads.aqua.extension.models.ws_models import RequestResponseType, ListModelsResponse, ListModelsRequest, \
-    ModelDetailsResponse
+from ads.aqua.extension.models.ws_models import (
+    ListModelsResponse,
+    ModelDetailsResponse,
+    RequestResponseType,
+)
 from ads.aqua.model import AquaModelApp
 
 
 class AquaModelWSMsgHandler(AquaWSMsgHandler):
-
     def __init__(self, message: Union[str, bytes]):
         super().__init__(message)
 
     @staticmethod
     def get_message_types() -> List[RequestResponseType]:
-        return [RequestResponseType.ListModels,RequestResponseType.ModelDetails]
+        return [RequestResponseType.ListModels, RequestResponseType.ModelDetails]
 
     @handle_exceptions
-    def process(self) -> ListModelsResponse | ModelDetailsResponse:
+    def process(self) -> Union[ListModelsResponse, ModelDetailsResponse]:
         request = json.loads(self.message)
-        if request.get('kind') == 'ListModels':
+        if request.get("kind") == "ListModels":
             models_list = AquaModelApp().list(
                 compartment_id=request.get("compartment_id"),
                 project_id=request.get("project_id"),
-                model_type=request.get("model_type")
+                model_type=request.get("model_type"),
             )
             response = ListModelsResponse(
                 message_id=request.get("message_id"),
@@ -32,10 +39,11 @@ class AquaModelWSMsgHandler(AquaWSMsgHandler):
                 data=models_list,
             )
             return response
-        elif request.get('kind') == 'ModelDetails':
-            model_id=request.get("model_id")
-            response=AquaModelApp().get(model_id)
-            return ModelDetailsResponse(message_id=request.get("message_id"),
-                                        kind=RequestResponseType.ModelDetails,
-                                        data=response)
-
+        elif request.get("kind") == "ModelDetails":
+            model_id = request.get("model_id")
+            response = AquaModelApp().get(model_id)
+            return ModelDetailsResponse(
+                message_id=request.get("message_id"),
+                kind=RequestResponseType.ModelDetails,
+                data=response,
+            )

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -3,7 +3,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import logging
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from ads.aqua.app import AquaApp, logger
 from ads.aqua.common.enums import (
@@ -102,6 +102,8 @@ class AquaDeploymentApp(AquaApp):
         health_check_port: int = None,
         env_var: Dict = None,
         container_family: str = None,
+        memory_in_gbs: Optional[float] = None,
+        ocpus: Optional[float] = None,
     ) -> "AquaDeployment":
         """
         Creates a new Aqua deployment
@@ -142,6 +144,10 @@ class AquaDeploymentApp(AquaApp):
             Environment variable for the deployment, by default None.
         container_family: str
             The image family of model deployment container runtime. Required for unverified Aqua models.
+        memory_in_gbs: float
+            The memory in gbs for the shape selected.
+        ocpus: float
+            The ocpu count for the shape selected.
         Returns
         -------
         AquaDeployment
@@ -325,6 +331,11 @@ class AquaDeploymentApp(AquaApp):
                 log_id=predict_log_id,
             )
         )
+        if memory_in_gbs and ocpus and infrastructure.shape_name.endswith("Flex"):
+            infrastructure.with_shape_config_details(
+                ocpus=ocpus,
+                memory_in_gbs=memory_in_gbs,
+            )
         # configure model deployment runtime
         container_runtime = (
             ModelDeploymentContainerRuntime()
@@ -338,6 +349,7 @@ class AquaDeploymentApp(AquaApp):
             .with_overwrite_existing_artifact(True)
             .with_remove_existing_artifact(True)
         )
+
         # configure model deployment and deploy model on container runtime
         deployment = (
             ModelDeployment()

--- a/tests/unitary/with_extras/aqua/test_data/deployment/aqua_create_gguf_deployment.yaml
+++ b/tests/unitary/with_extras/aqua/test_data/deployment/aqua_create_gguf_deployment.yaml
@@ -1,0 +1,40 @@
+kind: deployment
+spec:
+  createdBy: ocid1.user.oc1..<OCID>
+  displayName: model-deployment-name
+  freeformTags:
+    OCI_AQUA: active
+    aqua_model_name: model-name
+  id: "ocid1.datasciencemodeldeployment.oc1.<region>.<MD_OCID>"
+  infrastructure:
+    kind: infrastructure
+    spec:
+      bandwidthMbps: 10
+      compartmentId: ocid1.compartment.oc1..<OCID>
+      deploymentType: SINGLE_MODEL
+      policyType: FIXED_SIZE
+      projectId: ocid1.datascienceproject.oc1.iad.<OCID>
+      replica: 1
+      shapeName: "VM.Standard.A1.Flex"
+      shapeConfigDetails:
+        memoryInGBs: 60.0
+        ocpus: 10
+    type: datascienceModelDeployment
+  lifecycleState: CREATING
+  modelDeploymentUrl: "https://modeldeployment.customer-oci.com/ocid1.datasciencemodeldeployment.oc1.<region>.<MD_OCID>"
+  runtime:
+    kind: runtime
+    spec:
+      env:
+        BASE_MODEL: service_models/model-name/artifact
+        BASE_MODEL_FILE: model-name.gguf
+        MODEL_DEPLOY_ENABLE_STREAMING: 'true'
+        MODEL_DEPLOY_PREDICT_ENDPOINT: /v1/completions
+        MODEL_DEPLOY_HEALTH_ENDPOINT: /v1/models
+      healthCheckPort: 8080
+      image: "dsmc://image-name:1.0.0.0"
+      modelUri: "ocid1.datasciencemodeldeployment.oc1.<region>.<MODEL_OCID>"
+      serverPort: 8080
+    type: container
+  timeCreated: 2024-01-01T00:00:00.000000+00:00
+type: modelDeployment

--- a/tests/unitary/with_extras/aqua/test_data/deployment/deployment_config.json
+++ b/tests/unitary/with_extras/aqua/test_data/deployment/deployment_config.json
@@ -5,9 +5,26 @@
         "TGI_PARAMS": "--max-stop-sequences 6",
         "VLLM_PARAMS": "--max-model-len 4096"
       }
+    },
+    "VM.Standard.A1.Flex": {
+      "parameters": {},
+      "shape_info": {
+        "configs": [
+          {
+            "memory_in_gbs": 128,
+            "ocpu": 32
+          },
+          {
+            "memory_in_gbs": 256,
+            "ocpu": 64
+          }
+        ],
+        "type": "CPU"
+      }
     }
   },
   "shape": [
-    "VM.GPU.A10.1"
+    "VM.GPU.A10.1",
+    "VM.Standard.A1.Flex"
   ]
 }

--- a/tests/unitary/with_extras/aqua/test_data/ui/container_index.json
+++ b/tests/unitary/with_extras/aqua/test_data/ui/container_index.json
@@ -1,5 +1,27 @@
 {
   "containerSpec": {
+    "odsc-llama-cpp-serving": {
+      "cliParam": "",
+      "envVars": [
+        {
+          "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions"
+        },
+        {
+          "MODEL_DEPLOY_HEALTH_ENDPOINT": "/v1/models"
+        },
+        {
+          "MODEL_DEPLOY_ENABLE_STREAMING": "true"
+        },
+        {
+          "PORT": "8080"
+        },
+        {
+          "HEALTH_CHECK_PORT": "8080"
+        }
+      ],
+      "healthCheckPort": "8080",
+      "serverPort": "8080"
+    },
     "odsc-tgi-serving": {
       "cliParam": "--sharded true --trust-remote-code",
       "envVars": [
@@ -39,6 +61,14 @@
       "serverPort": "8080"
     }
   },
+  "odsc-llama-cpp-serving": [
+    {
+      "displayName": "llama.cpp",
+      "name": "dsmc://odsc-llama-cpp-serving",
+      "type": "inference",
+      "version": "0.2.75.2"
+    }
+  ],
   "odsc-llm-evaluate": [
     {
       "name": "dsmc://odsc-llm-evaluate",

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -41,6 +41,7 @@ class TestDataset:
     MODEL_ID = "ocid1.datasciencemodeldeployment.oc1.<region>.<MODEL_OCID>"
     DEPLOYMENT_IMAGE_NAME = "dsmc://image-name:1.0.0.0"
     DEPLOYMENT_SHAPE_NAME = "VM.GPU.A10.1"
+    DEPLOYMENT_SHAPE_NAME_CPU = "VM.Standard.A1.Flex"
 
     model_deployment_object = [
         {
@@ -111,6 +112,65 @@ class TestDataset:
         }
     ]
 
+    model_deployment_object_gguf = [
+        {
+            "compartment_id": "ocid1.compartment.oc1..<OCID>",
+            "created_by": "ocid1.user.oc1..<OCID>",
+            "defined_tags": {},
+            "description": "Mock description",
+            "display_name": "model-deployment-name",
+            "freeform_tags": {"OCI_AQUA": "active", "aqua_model_name": "model-name"},
+            "id": "ocid1.datasciencemodeldeployment.oc1.<region>.<MD_OCID>",
+            "lifecycle_state": "ACTIVE",
+            "model_deployment_configuration_details": oci.data_science.models.SingleModelDeploymentConfigurationDetails(
+                **{
+                    "deployment_type": "SINGLE_MODEL",
+                    "environment_configuration_details": oci.data_science.models.OcirModelDeploymentEnvironmentConfigurationDetails(
+                        **{
+                            "cmd": [],
+                            "entrypoint": [],
+                            "environment_configuration_type": "OCIR_CONTAINER",
+                            "environment_variables": {
+                                "BASE_MODEL": "service_models/model-name/artifact",
+                                "BASE_MODEL_FILE": "model-name.gguf",
+                                "MODEL_DEPLOY_ENABLE_STREAMING": "true",
+                                "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions",
+                                "MODEL_DEPLOY_HEALTH_ENDPOINT": "/v1/models",
+                            },
+                            "health_check_port": 8080,
+                            "image": "dsmc://image-name:1.0.0.0",
+                            "image_digest": "sha256:mock22373c16f2015f6f33c5c8553923cf8520217da0bd9504471c5e53cbc9d",
+                            "server_port": 8080,
+                        }
+                    ),
+                    "model_configuration_details": oci.data_science.models.ModelConfigurationDetails(
+                        **{
+                            "bandwidth_mbps": 10,
+                            "instance_configuration": oci.data_science.models.InstanceConfiguration(
+                                **{
+                                    "instance_shape_name": DEPLOYMENT_SHAPE_NAME_CPU,
+                                    "model_deployment_instance_shape_config_details": oci.data_science.models.ModelDeploymentInstanceShapeConfigDetails(
+                                        **{
+                                            "ocpus": 10,
+                                            "memory_in_gbs": 60.0,
+                                        }
+                                    ),
+                                }
+                            ),
+                            "model_id": "ocid1.datasciencemodel.oc1.<region>.<OCID>",
+                            "scaling_policy": oci.data_science.models.FixedSizeScalingPolicy(
+                                **{"instance_count": 1, "policy_type": "FIXED_SIZE"}
+                            ),
+                        }
+                    ),
+                }
+            ),
+            "model_deployment_url": MODEL_DEPLOYMENT_URL,
+            "project_id": "ocid1.datascienceproject.oc1.<region>.<OCID>",
+            "time_created": "2024-01-01T00:00:00.000000+00:00",
+        }
+    ]
+
     aqua_deployment_object = {
         "id": "ocid1.datasciencemodeldeployment.oc1.<region>.<MD_OCID>",
         "display_name": "model-deployment-name",
@@ -130,6 +190,13 @@ class TestDataset:
             "memory_in_gbs": null,
         },
         "tags": {"OCI_AQUA": "active", "aqua_model_name": "model-name"},
+    }
+
+    aqua_deployment_gguf_shape_info = {
+        "instance_shape": DEPLOYMENT_SHAPE_NAME_CPU,
+        "instance_count": 1,
+        "ocpus": 10,
+        "memory_in_gbs": 60.0,
     }
 
     aqua_deployment_detail = {
@@ -404,6 +471,79 @@ class TestAquaDeployment(unittest.TestCase):
         assert set(actual_attributes) == set(expected_attributes), "Attributes mismatch"
         expected_result = copy.deepcopy(TestDataset.aqua_deployment_object)
         expected_result["state"] = "CREATING"
+        assert actual_attributes == expected_result
+
+    @patch("ads.aqua.modeldeployment.deployment.get_container_config")
+    @patch("ads.aqua.model.AquaModelApp.create")
+    @patch("ads.aqua.modeldeployment.deployment.get_container_image")
+    @patch("ads.model.deployment.model_deployment.ModelDeployment.deploy")
+    def test_create_deployment_for_gguf_model(
+        self,
+        mock_deploy,
+        mock_get_container_image,
+        mock_create,
+        mock_get_container_config,
+    ):
+        """Test to create a deployment for fine-tuned model"""
+
+        aqua_model = os.path.join(
+            self.curr_dir, "test_data/deployment/aqua_foundation_model.yaml"
+        )
+        datascience_model = DataScienceModel.from_yaml(uri=aqua_model)
+        mock_create.return_value = datascience_model
+
+        config_json = os.path.join(
+            self.curr_dir, "test_data/deployment/deployment_config.json"
+        )
+        with open(config_json, "r") as _file:
+            config = json.load(_file)
+
+        self.app.get_deployment_config = MagicMock(return_value=config)
+
+        container_index_json = os.path.join(
+            self.curr_dir, "test_data/ui/container_index.json"
+        )
+        with open(container_index_json, "r") as _file:
+            container_index_config = json.load(_file)
+        mock_get_container_config.return_value = container_index_config
+
+        mock_get_container_image.return_value = TestDataset.DEPLOYMENT_IMAGE_NAME
+        aqua_deployment = os.path.join(
+            self.curr_dir, "test_data/deployment/aqua_create_gguf_deployment.yaml"
+        )
+        model_deployment_obj = ModelDeployment.from_yaml(uri=aqua_deployment)
+        model_deployment_dsc_obj = copy.deepcopy(
+            TestDataset.model_deployment_object_gguf[0]
+        )
+        model_deployment_dsc_obj["lifecycle_state"] = "CREATING"
+        model_deployment_obj.dsc_model_deployment = (
+            oci.data_science.models.ModelDeploymentSummary(**model_deployment_dsc_obj)
+        )
+        mock_deploy.return_value = model_deployment_obj
+
+        result = self.app.create(
+            model_id=TestDataset.MODEL_ID,
+            instance_shape="VM.Standard.A1.Flex",
+            display_name="model-deployment-name",
+            log_group_id="ocid1.loggroup.oc1.<region>.<OCID>",
+            access_log_id="ocid1.log.oc1.<region>.<OCID>",
+            predict_log_id="ocid1.log.oc1.<region>.<OCID>",
+            ocpus=10.0,
+            memory_in_gbs=60.0,
+        )
+
+        mock_create.assert_called_with(
+            model_id=TestDataset.MODEL_ID, compartment_id=None, project_id=None
+        )
+        mock_get_container_image.assert_called()
+        mock_deploy.assert_called()
+
+        expected_attributes = set(AquaDeployment.__annotations__.keys())
+        actual_attributes = asdict(result)
+        assert set(actual_attributes) == set(expected_attributes), "Attributes mismatch"
+        expected_result = copy.deepcopy(TestDataset.aqua_deployment_object)
+        expected_result["state"] = "CREATING"
+        expected_result["shape_info"] = TestDataset.aqua_deployment_gguf_shape_info
         assert actual_attributes == expected_result
 
     @parameterized.expand(

--- a/tests/unitary/with_extras/aqua/test_deployment_handler.py
+++ b/tests/unitary/with_extras/aqua/test_deployment_handler.py
@@ -126,6 +126,8 @@ class TestAquaDeploymentHandler(unittest.TestCase):
             health_check_port=None,
             env_var=None,
             container_family=None,
+            memory_in_gbs=None,
+            ocpus=None,
         )
 
 


### PR DESCRIPTION
### Description

This PR covers the following:
- Support deployment of gguf models with cpu shapes 
- Add copyright/license text to missing python files
- Fix function typing to web socket handlers to work with python 3.8
- Ruff updates


### Tests

```
python -m pytest -q tests/unitary/with_extras/aqua/test_deployment*
============================================= test session starts =============================================
platform darwin -- Python 3.8.19, pytest-7.4.4, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-26.0.0, cov-5.0.0, anyio-4.2.0, xdist-3.6.1
collected 30 items

tests/unitary/with_extras/aqua/test_deployment.py .....................                                 [ 70%]
tests/unitary/with_extras/aqua/test_deployment_handler.py ..s......                                     [100%]

======================================== 29 passed, 1 skipped in 8.24s ========================================
```