### PR TITLE
[ODSC-60107] Return container spec with list containers API

### DIFF
--- a/ads/aqua/common/entities.py
+++ b/ads/aqua/common/entities.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+
+class ContainerSpec:
+    """
+    Class to hold to hold keys within the container spec.
+    """
+
+    CONTAINER_SPEC = "containerSpec"
+    CLI_PARM = "cliParam"
+    SERVER_PORT = "serverPort"
+    HEALTH_CHECK_PORT = "healthCheckPort"
+    ENV_VARS = "envVars"
+    RESTRICTED_PARAMS = "restrictedParams"

--- a/ads/aqua/common/enums.py
+++ b/ads/aqua/common/enums.py
@@ -44,6 +44,7 @@ class Tags(str, metaclass=ExtendedEnumMeta):
 class InferenceContainerType(str, metaclass=ExtendedEnumMeta):
     CONTAINER_TYPE_VLLM = "vllm"
     CONTAINER_TYPE_TGI = "tgi"
+    CONTAINER_TYPE_LLAMA_CPP = "llama-cpp"
 
 
 class InferenceContainerTypeFamily(str, metaclass=ExtendedEnumMeta):
@@ -55,6 +56,7 @@ class InferenceContainerTypeFamily(str, metaclass=ExtendedEnumMeta):
 class InferenceContainerParamType(str, metaclass=ExtendedEnumMeta):
     PARAM_TYPE_VLLM = "VLLM_PARAMS"
     PARAM_TYPE_TGI = "TGI_PARAMS"
+    PARAM_TYPE_LLAMA_CPP = "LLAMA_CPP_PARAMS"
 
 
 class HuggingFaceTags(str, metaclass=ExtendedEnumMeta):

--- a/ads/aqua/common/utils.py
+++ b/ads/aqua/common/utils.py
@@ -17,9 +17,11 @@ from string import Template
 from typing import List, Union
 
 import fsspec
-from cachetools import TTLCache, cached
-
 import oci
+from cachetools import TTLCache, cached
+from oci.data_science.models import JobRun, Model
+from oci.object_storage.models import ObjectSummary
+
 from ads.aqua.common.enums import (
     InferenceContainerParamType,
     InferenceContainerType,
@@ -52,8 +54,6 @@ from ads.common.oci_resource import SEARCH_TYPE, OCIResource
 from ads.common.utils import copy_file, get_console_link, upload_to_os
 from ads.config import AQUA_SERVICE_MODELS_BUCKET, CONDA_BUCKET_NS, TENANCY_OCID
 from ads.model import DataScienceModel, ModelVersionSet
-from oci.data_science.models import JobRun, Model
-from oci.object_storage.models import ObjectSummary
 
 logger = logging.getLogger("ads.aqua")
 
@@ -909,6 +909,8 @@ def get_container_params_type(container_type_name: str) -> str:
         return InferenceContainerParamType.PARAM_TYPE_VLLM
     elif InferenceContainerType.CONTAINER_TYPE_TGI in container_type_name.lower():
         return InferenceContainerParamType.PARAM_TYPE_TGI
+    elif InferenceContainerType.CONTAINER_TYPE_LLAMA_CPP in container_type_name.lower():
+        return InferenceContainerParamType.PARAM_TYPE_LLAMA_CPP
     else:
         return UNKNOWN
 

--- a/ads/aqua/constants.py
+++ b/ads/aqua/constants.py
@@ -74,3 +74,7 @@ TGI_INFERENCE_RESTRICTED_PARAMS = {
     "--sharded",
     "--trust-remote-code",
 }
+LLAMA_CPP_INFERENCE_RESTRICTED_PARAMS = {
+    "--port",
+    "--host",
+}

--- a/ads/aqua/modeldeployment/entities.py
+++ b/ads/aqua/modeldeployment/entities.py
@@ -5,7 +5,10 @@
 from dataclasses import dataclass, field
 from typing import Union
 
-from oci.data_science.models import ModelDeployment, ModelDeploymentSummary
+from oci.data_science.models import (
+    ModelDeployment,
+    ModelDeploymentSummary,
+)
 
 from ads.aqua.common.enums import Tags
 from ads.aqua.constants import UNKNOWN, UNKNOWN_DICT
@@ -48,6 +51,7 @@ class AquaDeployment(DataClassSerializable):
     lifecycle_details: str = None
     shape_info: field(default_factory=ShapeInfo) = None
     tags: dict = None
+    environment_variables: dict = None
 
     @classmethod
     def from_oci_model_deployment(
@@ -75,6 +79,7 @@ class AquaDeployment(DataClassSerializable):
             instance_configuration.model_deployment_instance_shape_config_details
         )
         instance_count = oci_model_deployment.model_deployment_configuration_details.model_configuration_details.scaling_policy.instance_count
+        environment_variables = oci_model_deployment.model_deployment_configuration_details.environment_configuration_details.environment_variables
         shape_info = ShapeInfo(
             instance_shape=instance_configuration.instance_shape_name,
             instance_count=instance_count,
@@ -114,6 +119,7 @@ class AquaDeployment(DataClassSerializable):
                 region=region,
             ),
             tags=freeform_tags,
+            environment_variables=environment_variables,
         )
 
 

--- a/ads/aqua/modeldeployment/entities.py
+++ b/ads/aqua/modeldeployment/entities.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
@@ -22,18 +21,6 @@ class ModelParams:
     top_k: float = None
     top_p: float = None
     model: str = None
-
-
-class ContainerSpec:
-    """
-    Class to hold to hold keys within the container spec.
-    """
-
-    CONTAINER_SPEC = "containerSpec"
-    CLI_PARM = "cliParam"
-    SERVER_PORT = "serverPort"
-    HEALTH_CHECK_PORT = "healthCheckPort"
-    ENV_VARS = "envVars"
 
 
 @dataclass
@@ -83,15 +70,11 @@ class AquaDeployment(DataClassSerializable):
         AquaDeployment:
             The instance of the Aqua model deployment.
         """
-        instance_configuration = (
-            oci_model_deployment.model_deployment_configuration_details.model_configuration_details.instance_configuration
-        )
+        instance_configuration = oci_model_deployment.model_deployment_configuration_details.model_configuration_details.instance_configuration
         instance_shape_config_details = (
             instance_configuration.model_deployment_instance_shape_config_details
         )
-        instance_count = (
-            oci_model_deployment.model_deployment_configuration_details.model_configuration_details.scaling_policy.instance_count
-        )
+        instance_count = oci_model_deployment.model_deployment_configuration_details.model_configuration_details.scaling_policy.instance_count
         shape_info = ShapeInfo(
             instance_shape=instance_configuration.instance_shape_name,
             instance_count=instance_count,

--- a/tests/unitary/with_extras/aqua/test_data/ui/container_index.json
+++ b/tests/unitary/with_extras/aqua/test_data/ui/container_index.json
@@ -20,6 +20,7 @@
         }
       ],
       "healthCheckPort": "8080",
+      "restrictedParams": [],
       "serverPort": "8080"
     },
     "odsc-tgi-serving": {
@@ -39,10 +40,17 @@
         }
       ],
       "healthCheckPort": "8080",
+      "restrictedParams": [
+        "--port",
+        "--hostname",
+        "--num-shard",
+        "--sharded",
+        "--trust-remote-code"
+      ],
       "serverPort": "8080"
     },
     "odsc-vllm-serving": {
-      "cliParam": "--served-model-name $(python -c 'import os; print(os.environ.get(\"ODSC_SERVED_MODEL_NAME\",\"odsc-llm\"))') --seed 42 ",
+      "cliParam": "--served-model-name odsc-llm --seed 42 ",
       "envVars": [
         {
           "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions"
@@ -58,6 +66,12 @@
         }
       ],
       "healthCheckPort": "8080",
+      "restrictedParams": [
+        "--port",
+        "--host",
+        "--served-model-name",
+        "--seed"
+      ],
       "serverPort": "8080"
     }
   },

--- a/tests/unitary/with_extras/aqua/test_decorator.py
+++ b/tests/unitary/with_extras/aqua/test_decorator.py
@@ -126,7 +126,7 @@ class TestAquaDecorators(TestCase):
                     "status": 500,
                     "message": "Internal Server Error",
                     "service_payload": {},
-                    "reason": f"MultipartUploadError: MultipartUploadError exception has occurred. {UPLOAD_MANAGER_DEBUG_INFORMATION_LOG}",
+                    "reason": f"MultipartUploadError: MultipartUploadError exception has occured. {UPLOAD_MANAGER_DEBUG_INFORMATION_LOG}",
                     "request_id": TestDataset.mock_request_id,
                 },
             ],

--- a/tests/unitary/with_extras/aqua/test_decorator.py
+++ b/tests/unitary/with_extras/aqua/test_decorator.py
@@ -126,7 +126,7 @@ class TestAquaDecorators(TestCase):
                     "status": 500,
                     "message": "Internal Server Error",
                     "service_payload": {},
-                    "reason": f"MultipartUploadError: MultipartUploadError exception has occured. {UPLOAD_MANAGER_DEBUG_INFORMATION_LOG}",
+                    "reason": f"MultipartUploadError: MultipartUploadError exception has occurred. {UPLOAD_MANAGER_DEBUG_INFORMATION_LOG}",
                     "request_id": TestDataset.mock_request_id,
                 },
             ],

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -181,6 +181,12 @@ class TestDataset:
         "created_on": "2024-01-01T00:00:00.000000+00:00",
         "created_by": "ocid1.user.oc1..<OCID>",
         "endpoint": MODEL_DEPLOYMENT_URL,
+        "environment_variables": {
+            "BASE_MODEL": "service_models/model-name/artifact",
+            "MODEL_DEPLOY_ENABLE_STREAMING": "true",
+            "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions",
+            "PARAMS": "--served-model-name odsc-llm --seed 42",
+        },
         "console_link": "https://cloud.oracle.com/data-science/model-deployments/ocid1.datasciencemodeldeployment.oc1.<region>.<MD_OCID>?region=region-name",
         "lifecycle_details": "",
         "shape_info": {
@@ -190,6 +196,14 @@ class TestDataset:
             "memory_in_gbs": null,
         },
         "tags": {"OCI_AQUA": "active", "aqua_model_name": "model-name"},
+    }
+
+    aqua_deployment_gguf_env_vars = {
+        "BASE_MODEL": "service_models/model-name/artifact",
+        "BASE_MODEL_FILE": "model-name.gguf",
+        "MODEL_DEPLOY_ENABLE_STREAMING": "true",
+        "MODEL_DEPLOY_HEALTH_ENDPOINT": "/v1/models",
+        "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions",
     }
 
     aqua_deployment_gguf_shape_info = {
@@ -544,6 +558,9 @@ class TestAquaDeployment(unittest.TestCase):
         expected_result = copy.deepcopy(TestDataset.aqua_deployment_object)
         expected_result["state"] = "CREATING"
         expected_result["shape_info"] = TestDataset.aqua_deployment_gguf_shape_info
+        expected_result["environment_variables"] = (
+            TestDataset.aqua_deployment_gguf_env_vars
+        )
         assert actual_attributes == expected_result
 
     @parameterized.expand(

--- a/tests/unitary/with_extras/aqua/test_ui.py
+++ b/tests/unitary/with_extras/aqua/test_ui.py
@@ -479,6 +479,7 @@ class TestAquaUI(unittest.TestCase):
                     "family": "odsc-llm-evaluate",
                     "platforms": [],
                     "model_formats": [],
+                    "spec": None,
                 }
             ],
             "inference": [
@@ -489,6 +490,19 @@ class TestAquaUI(unittest.TestCase):
                     "family": "odsc-llama-cpp-serving",
                     "platforms": ["ARM_CPU"],
                     "model_formats": ["GGUF"],
+                    "spec": {
+                        "cli_param": "",
+                        "env_vars": [
+                            {"MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions"},
+                            {"MODEL_DEPLOY_HEALTH_ENDPOINT": "/v1/models"},
+                            {"MODEL_DEPLOY_ENABLE_STREAMING": "true"},
+                            {"PORT": "8080"},
+                            {"HEALTH_CHECK_PORT": "8080"},
+                        ],
+                        "health_check_port": "8080",
+                        "restricted_params": [],
+                        "server_port": "8080",
+                    },
                 },
                 {
                     "name": "dsmc://odsc-text-generation-inference",
@@ -497,6 +511,24 @@ class TestAquaUI(unittest.TestCase):
                     "family": "odsc-tgi-serving",
                     "platforms": ["NVIDIA_GPU"],
                     "model_formats": ["SAFETENSORS"],
+                    "spec": {
+                        "cli_param": "--sharded true --trust-remote-code",
+                        "env_vars": [
+                            {"MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions"},
+                            {"MODEL_DEPLOY_ENABLE_STREAMING": "true"},
+                            {"PORT": "8080"},
+                            {"HEALTH_CHECK_PORT": "8080"},
+                        ],
+                        "health_check_port": "8080",
+                        "restricted_params": [
+                            "--port",
+                            "--hostname",
+                            "--num-shard",
+                            "--sharded",
+                            "--trust-remote-code",
+                        ],
+                        "server_port": "8080",
+                    },
                 },
                 {
                     "name": "dsmc://odsc-vllm-serving",
@@ -505,6 +537,23 @@ class TestAquaUI(unittest.TestCase):
                     "family": "odsc-vllm-serving",
                     "platforms": ["NVIDIA_GPU"],
                     "model_formats": ["SAFETENSORS"],
+                    "spec": {
+                        "cli_param": "--served-model-name odsc-llm --seed 42 ",
+                        "env_vars": [
+                            {"MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions"},
+                            {"MODEL_DEPLOY_ENABLE_STREAMING": "true"},
+                            {"PORT": "8080"},
+                            {"HEALTH_CHECK_PORT": "8080"},
+                        ],
+                        "health_check_port": "8080",
+                        "restricted_params": [
+                            "--port",
+                            "--host",
+                            "--served-model-name",
+                            "--seed",
+                        ],
+                        "server_port": "8080",
+                    },
                 },
             ],
             "finetune": [
@@ -515,6 +564,7 @@ class TestAquaUI(unittest.TestCase):
                     "family": "odsc-llm-fine-tuning",
                     "platforms": [],
                     "model_formats": [],
+                    "spec": None,
                 }
             ],
         }


### PR DESCRIPTION
### Description

This PR covers the following changes:
- Add AquaContainerConfigSpec dataclass and return this information with the list_containers api.
- Disallow param override for llama cpp depoyment.

### Tests

```
> python -m pytest -q tests/unitary/with_extras/aqua/test_*
=========================================================== test session starts ===========================================================
platform darwin -- Python 3.8.19, pytest-7.4.4, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-26.0.0, cov-5.0.0, anyio-4.2.0, xdist-3.6.1
collected 195 items

tests/unitary/with_extras/aqua/test_cli.py ..............                                                                           [  7%]
tests/unitary/with_extras/aqua/test_common_handler.py ...                                                                           [  8%]
tests/unitary/with_extras/aqua/test_decorator.py ..........                                                                         [ 13%]
tests/unitary/with_extras/aqua/test_deployment.py .....................                                                             [ 24%]
tests/unitary/with_extras/aqua/test_deployment_handler.py ..s......                                                                 [ 29%]
tests/unitary/with_extras/aqua/test_evaluation.py .............................                                                     [ 44%]
tests/unitary/with_extras/aqua/test_evaluation_handler.py .........                                                                 [ 48%]
tests/unitary/with_extras/aqua/test_finetuning.py .......                                                                           [ 52%]
tests/unitary/with_extras/aqua/test_finetuning_handler.py .....                                                                     [ 54%]
tests/unitary/with_extras/aqua/test_global.py ...                                                                                   [ 56%]
tests/unitary/with_extras/aqua/test_handlers.py .................                                                                   [ 65%]
tests/unitary/with_extras/aqua/test_model.py .................                                                                      [ 73%]
tests/unitary/with_extras/aqua/test_model_handler.py .......                                                                        [ 77%]
tests/unitary/with_extras/aqua/test_ui.py ...............                                                                           [ 85%]
tests/unitary/with_extras/aqua/test_ui_handler.py ..............                                                                    [ 92%]
tests/unitary/with_extras/aqua/test_ui_websocket_handler.py ....                                                                    [ 94%]
tests/unitary/with_extras/aqua/test_utils.py ...........                                                                            [100%]

===================================================== 194 passed, 1 skipped in 30.69s =====================================================
```