### PR TITLE
[ODSC-60499] Update validation for models registered from object storage

### DIFF
--- a/ads/aqua/common/enums.py
+++ b/ads/aqua/common/enums.py
@@ -39,6 +39,7 @@ class Tags(str, metaclass=ExtendedEnumMeta):
     BASE_MODEL_CUSTOM = "aqua_custom_base_model"
     AQUA_EVALUATION_MODEL_ID = "evaluation_model_id"
     MODEL_FORMAT = "model_format"
+    MODEL_ARTIFACT_FILE = "model_file"
 
 
 class InferenceContainerType(str, metaclass=ExtendedEnumMeta):

--- a/ads/aqua/common/utils.py
+++ b/ads/aqua/common/utils.py
@@ -801,33 +801,6 @@ def upload_folder(os_path: str, local_dir: str, model_name: str) -> str:
     return f"oci://{os_details.bucket}@{os_details.namespace}" + "/" + object_path
 
 
-def upload_folder(os_path: str, local_dir: str, model_name: str) -> str:
-    """Upload the local folder to the object storage
-
-    Args:
-        os_path (str): object storage URI with prefix. This is the path to upload
-        local_dir (str): Local directory where the object is downloaded
-        model_name (str): Name of the huggingface model
-    Retuns:
-        str: Object name inside the bucket
-    """
-    os_details: ObjectStorageDetails = ObjectStorageDetails.from_path(os_path)
-    if not os_details.is_bucket_versioned():
-        raise ValueError(f"Version is not enabled at object storage location {os_path}")
-    auth_state = AuthState()
-    object_path = os_details.filepath.rstrip("/") + "/" + model_name + "/"
-    command = f"oci os object bulk-upload --src-dir {local_dir} --prefix {object_path} -bn {os_details.bucket} -ns {os_details.namespace} --auth {auth_state.oci_iam_type} --profile {auth_state.oci_key_profile} --no-overwrite"
-    try:
-        logger.info(f"Running: {command}")
-        subprocess.check_call(shlex.split(command))
-    except subprocess.CalledProcessError as e:
-        logger.error(
-            f"Error uploading the object. Exit code: {e.returncode} with error {e.stdout}"
-        )
-
-    return f"oci://{os_details.bucket}@{os_details.namespace}" + "/" + object_path
-
-
 def is_service_managed_container(container):
     return container and container.startswith(SERVICE_MANAGED_CONTAINER_URI_SCHEME)
 

--- a/ads/aqua/extension/deployment_handler.py
+++ b/ads/aqua/extension/deployment_handler.py
@@ -101,6 +101,7 @@ class AquaDeploymentHandler(AquaAPIhandler):
         container_family = input_data.get("container_family")
         ocpus = input_data.get("ocpus")
         memory_in_gbs = input_data.get("memory_in_gbs")
+        model_file = input_data.get("model_file")
 
         self.finish(
             AquaDeploymentApp().create(
@@ -122,6 +123,7 @@ class AquaDeploymentHandler(AquaAPIhandler):
                 container_family=container_family,
                 ocpus=ocpus,
                 memory_in_gbs=memory_in_gbs,
+                model_file=model_file,
             )
         )
 

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -115,17 +115,16 @@ class AquaModelHandler(AquaAPIhandler):
         finetuning_container = input_data.get("finetuning_container")
         compartment_id = input_data.get("compartment_id")
         project_id = input_data.get("project_id")
-        model_file = input_data.get("model_file")
 
         return self.finish(
             AquaModelApp().register(
                 model=model,
                 os_path=os_path,
+                download_from_hf=False,
                 inference_container=inference_container,
                 finetuning_container=finetuning_container,
                 compartment_id=compartment_id,
                 project_id=project_id,
-                model_file=model_file,
             )
         )
 

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -37,11 +37,9 @@ class AquaModelHandler(AquaAPIhandler):
         url_parse = urlparse(self.request.path)
         paths = url_parse.path.strip("/")
         if paths.startswith("aqua/model/files"):
-            os_path = self.get_argument("os_path")
-            if not os_path:
-                raise HTTPError(
-                    400, Errors.MISSING_REQUIRED_PARAMETER.format("os_path")
-                )
+            os_path = self.get_argument("os_path", None)
+            model_name = self.get_argument("model_name", None)
+
             model_format = self.get_argument("model_format")
             if not model_format:
                 raise HTTPError(
@@ -52,7 +50,21 @@ class AquaModelHandler(AquaAPIhandler):
             except ValueError as err:
                 raise AquaValueError(f"Invalid model format: {model_format}") from err
             else:
-                return self.finish(AquaModelApp.get_model_files(os_path, model_format))
+                if os_path:
+                    return self.finish(
+                        AquaModelApp.get_model_files(os_path, model_format)
+                    )
+                elif model_name:
+                    return self.finish(
+                        AquaModelApp.get_hf_model_files(model_name, model_format)
+                    )
+                else:
+                    raise HTTPError(
+                        400,
+                        Errors.MISSING_ONEOF_REQUIRED_PARAMETER.format(
+                            "os_path", "model_name"
+                        ),
+                    )
         elif not model_id:
             return self.list()
 

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -115,16 +115,21 @@ class AquaModelHandler(AquaAPIhandler):
         finetuning_container = input_data.get("finetuning_container")
         compartment_id = input_data.get("compartment_id")
         project_id = input_data.get("project_id")
+        model_file = input_data.get("model_file")
+        download_from_hf = (
+            str(input_data.get("download_from_hf", "false")).lower() == "true"
+        )
 
         return self.finish(
             AquaModelApp().register(
                 model=model,
                 os_path=os_path,
-                download_from_hf=False,
+                download_from_hf=download_from_hf,
                 inference_container=inference_container,
                 finetuning_container=finetuning_container,
                 compartment_id=compartment_id,
                 project_id=project_id,
+                model_file=model_file,
             )
         )
 

--- a/ads/aqua/model/entities.py
+++ b/ads/aqua/model/entities.py
@@ -43,9 +43,10 @@ class AquaFineTuneValidation(DataClassSerializable):
     value: str = ""
 
 
+@dataclass(repr=False)
 class ModelValidationResult:
-    model_file: Optional[str] = None
-    model_format: ModelFormat = None
+    model_files: List[str] = field(default_factory=list)
+    model_formats: List[ModelFormat] = field(default_factory=list)
     telemetry_model_name: str = None
 
 
@@ -86,7 +87,7 @@ class AquaModelSummary(DataClassSerializable):
     ready_to_import: bool = False
     nvidia_gpu_supported: bool = False
     arm_cpu_supported: bool = False
-    model_format: ModelFormat = ModelFormat.UNKNOWN
+    model_formats: List[ModelFormat] = field(default_factory=list)
 
 
 @dataclass(repr=False)
@@ -277,11 +278,11 @@ class AquaFineTuneModel(AquaModel, AquaEvalFTCommon, DataClassSerializable):
 class ImportModelDetails(CLIBuilderMixin):
     model: str
     os_path: str
+    download_from_hf: bool = True
     inference_container: Optional[str] = None
     finetuning_container: Optional[str] = None
     compartment_id: Optional[str] = None
     project_id: Optional[str] = None
-    model_file: Optional[str] = None
 
     def __post_init__(self):
         self._command = "model register"

--- a/ads/aqua/model/entities.py
+++ b/ads/aqua/model/entities.py
@@ -45,7 +45,7 @@ class AquaFineTuneValidation(DataClassSerializable):
 
 @dataclass(repr=False)
 class ModelValidationResult:
-    model_files: List[str] = field(default_factory=list)
+    model_file: Optional[str] = None
     model_formats: List[ModelFormat] = field(default_factory=list)
     telemetry_model_name: str = None
 
@@ -87,6 +87,7 @@ class AquaModelSummary(DataClassSerializable):
     ready_to_import: bool = False
     nvidia_gpu_supported: bool = False
     arm_cpu_supported: bool = False
+    model_file: Optional[str] = None
     model_formats: List[ModelFormat] = field(default_factory=list)
 
 
@@ -284,6 +285,7 @@ class ImportModelDetails(CLIBuilderMixin):
     finetuning_container: Optional[str] = None
     compartment_id: Optional[str] = None
     project_id: Optional[str] = None
+    model_file: Optional[str] = None
 
     def __post_init__(self):
         self._command = "model register"

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -648,7 +648,7 @@ class AquaModelApp(AquaApp):
         )
         tags.update({Tags.BASE_MODEL_CUSTOM: "true"})
 
-        if validation_result:
+        if validation_result and validation_result.model_formats:
             tags.update(
                 {
                     Tags.MODEL_FORMAT: ",".join(

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -215,10 +215,11 @@ class AquaDeploymentApp(AquaApp):
 
         env_var.update({"BASE_MODEL": f"{model_path_prefix}"})
 
-        model_format = aqua_model.freeform_tags.get(
+        model_formats_str = aqua_model.freeform_tags.get(
             Tags.MODEL_FORMAT, ModelFormat.SAFETENSORS.value
         ).upper()
-        if model_format == ModelFormat.GGUF.value:
+        model_format = model_formats_str.split(",")
+        if ModelFormat.GGUF.value in model_format:
             if model_file is not None:
                 logger.info(
                     f"Overriding {model_file} as model_file for model {aqua_model.id}."

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -106,6 +106,7 @@ class AquaDeploymentApp(AquaApp):
         container_family: str = None,
         memory_in_gbs: Optional[float] = None,
         ocpus: Optional[float] = None,
+        model_file: Optional[str] = None,
     ) -> "AquaDeployment":
         """
         Creates a new Aqua deployment
@@ -150,6 +151,8 @@ class AquaDeploymentApp(AquaApp):
             The memory in gbs for the shape selected.
         ocpus: float
             The ocpu count for the shape selected.
+        model_file: str
+            The file used for model deployment.
         Returns
         -------
         AquaDeployment
@@ -216,16 +219,24 @@ class AquaDeploymentApp(AquaApp):
             Tags.MODEL_FORMAT, ModelFormat.SAFETENSORS.value
         ).upper()
         if model_format == ModelFormat.GGUF.value:
-            try:
-                model_file = aqua_model.custom_metadata_list.get(
-                    AQUA_MODEL_ARTIFACT_FILE
-                ).value
-            except ValueError as err:
-                raise AquaValueError(
-                    f"{AQUA_MODEL_ARTIFACT_FILE} key is not available in the custom metadata field "
-                    f"for model {aqua_model.id}."
-                ) from err
+            if model_file is not None:
+                logger.info(
+                    f"Overriding {model_file} as model_file for model {aqua_model.id}."
+                )
+            else:
+                try:
+                    model_file = aqua_model.custom_metadata_list.get(
+                        AQUA_MODEL_ARTIFACT_FILE
+                    ).value
+                except ValueError as err:
+                    raise AquaValueError(
+                        f"{AQUA_MODEL_ARTIFACT_FILE} key is not available in the custom metadata field "
+                        f"for model {aqua_model.id}. Either register the model with a default model_file or pass "
+                        f"as a parameter when creating a deployment."
+                    ) from err
+
             env_var.update({"BASE_MODEL_FILE": f"{model_file}"})
+            tags.update({Tags.MODEL_ARTIFACT_FILE: model_file})
 
         if is_fine_tuned_model:
             _, fine_tune_output_path = get_model_by_reference_paths(


### PR DESCRIPTION
### Description

This PR covers the following changes:
- Register api takes in a parameter download_from_hf, set to True by default. For API call via model_handler, this is set as False. For CLI command, this will be set to true by default. The changes for HF flow will be covered in a different PR.
- AquaModelSummary has a field name change, model_format to model_formats.
- Validation changes when registering model via object storage.

#### Request
```
POST http://localhost:8888/aqua/model

{
    "model": "google/gemma-2b-it",
    "os_path": "oci://<bucket>@<namespace>/<prefix>",
    "inference_container": "odsc-tgi-serving"
}
```

#### Response
```
{
    "compartment_id": "ocid1.compartment.oc1..<ocid>",
    "icon": "",
    "id": "ocid1.datasciencemodel.oc1.iad.<ocid>",
    "is_fine_tuned_model": false,
    "license": "gemma",
    "name": "google/gemma-2b-it",
    "organization": "Google",
    "project_id": "ocid1.datascienceproject.oc1.iad.<ocid>",
    "tags": {
        "aqua_service_model": "ocid1.datasciencemodel.oc1.iad.<ocid>",
        "license": "gemma",
        "task": "text_generation",
        "model_format": "SAFETENSORS",
        "organization": "Google",
        "aqua_custom_base_model": "true",
        "OCI_AQUA": "active",
        "ready_to_fine_tune": "true"
    },
    "task": "text_generation",
    "time_created": "2024-07-26 02:31:33.316000+00:00",
    "console_link": "https://cloud.oracle.com/data-science/models/ocid1.datasciencemodel.oc1.iad.<ocid>?region=us-ashburn-1",
    "search_text": "ocid1.datasciencemodel.oc1.iad.<ocid>,gemma,text_generation,SAFETENSORS,Google,true,active,true",
    "ready_to_deploy": true,
    "ready_to_finetune": true,
    "ready_to_import": false,
    "nvidia_gpu_supported": true,
    "arm_cpu_supported": false,
    "model_formats": [
        "SAFETENSORS"
    ],
    "model_card": "<content>",
    "inference_container": "odsc-tgi-serving",
    "finetuning_container": "odsc-llm-fine-tuning",
    "evaluation_container": "odsc-llm-evaluate",
    "artifact_location": "oci://<bucket>@<namespace>/<prefix>"
}
```

### Unit Tests

Tests will be covered in a separate PR.