### PR TITLE
[ODSC-60499] Add HF tags for model and add additional tests

### DIFF
--- a/ads/aqua/app.py
+++ b/ads/aqua/app.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
@@ -175,7 +174,7 @@ class AquaApp:
                         f"Invalid model version set name. Please provide a model version set with `{tag}` in tags."
                     )
 
-            except:
+            except Exception:
                 logger.debug(
                     f"Model version set {model_version_set_name} doesn't exist. "
                     "Creating new model version set."
@@ -254,7 +253,7 @@ class AquaApp:
 
         try:
             response = self.ds_client.head_model_artifact(model_id=model_id, **kwargs)
-            return True if response.status == 200 else False
+            return response.status == 200
         except oci.exceptions.ServiceError as ex:
             if ex.status == 404:
                 logger.info(f"Artifact not found in model {model_id}.")
@@ -302,7 +301,7 @@ class AquaApp:
                 config_path,
                 config_file_name=config_file_name,
             )
-        except:
+        except Exception:
             # todo: temp fix for issue related to config load for byom models, update logic to choose the right path
             try:
                 config_path = f"{artifact_path.rstrip('/')}/config/"
@@ -310,7 +309,7 @@ class AquaApp:
                     config_path,
                     config_file_name=config_file_name,
                 )
-            except:
+            except Exception:
                 pass
 
         if not config:
@@ -343,7 +342,7 @@ class CLIBuilderMixin:
         params = [
             f"--{field.name} {getattr(self,field.name)}"
             for field in fields(self.__class__)
-            if getattr(self, field.name)
+            if getattr(self, field.name) is not None
         ]
         cmd = f"{cmd} {' '.join(params)}"
         return cmd

--- a/ads/aqua/common/utils.py
+++ b/ads/aqua/common/utils.py
@@ -22,6 +22,12 @@ import fsspec
 import oci
 from cachetools import TTLCache, cached
 from huggingface_hub.hf_api import HfApi, ModelInfo
+from huggingface_hub.utils import (
+    GatedRepoError,
+    HfHubHTTPError,
+    RepositoryNotFoundError,
+    RevisionNotFoundError,
+)
 from oci.data_science.models import JobRun, Model
 from oci.object_storage.models import ObjectSummary
 
@@ -987,6 +993,56 @@ def get_huggingface_login_timeout() -> int:
     return timeout
 
 
+def format_hf_custom_error_message(error: HfHubHTTPError):
+    """
+    Formats a custom error message based on the Hugging Face error response.
+
+    Parameters
+    ----------
+    error (HfHubHTTPError): The caught exception.
+
+    Raises
+    ------
+    AquaRuntimeError: A user-friendly error message.
+    """
+    # Extract the repository URL from the error message if present
+    match = re.search(r"(https://huggingface.co/[^\s]+)", str(error))
+    url = match.group(1) if match else "the requested Hugging Face URL."
+
+    if isinstance(error, RepositoryNotFoundError):
+        raise AquaRuntimeError(
+            reason=f"Failed to access `{url}`. Please check if the provided repository name is correct. "
+            "If the repo is private, make sure you are authenticated and have a valid HF token registered. "
+            "To register your token, run this command in your terminal: `huggingface-cli login`",
+            service_payload={"error": "RepositoryNotFoundError"},
+        )
+
+    if isinstance(error, GatedRepoError):
+        raise AquaRuntimeError(
+            reason=f"Access denied to `{url}` "
+            "This repository is gated. Access is restricted to authorized users. "
+            "Please request access or check with the repository administrator. "
+            "If you are trying to access a gated repository, ensure you have a valid HF token registered. "
+            "To register your token, run this command in your terminal: `huggingface-cli login`",
+            service_payload={"error": "GatedRepoError"},
+        )
+
+    if isinstance(error, RevisionNotFoundError):
+        raise AquaRuntimeError(
+            reason=f"The specified revision could not be found at `{url}` "
+            "Please check the revision identifier and try again.",
+            service_payload={"error": "RevisionNotFoundError"},
+        )
+
+    raise AquaRuntimeError(
+        reason=f"An error occurred while accessing `{url}` "
+        "Please check your network connection and try again. "
+        "If you are trying to access a gated repository, ensure you have a valid HF token registered. "
+        "To register your token, run this command in your terminal: `huggingface-cli login`",
+        service_payload={"error": "Error"},
+    )
+
+
 @cached(cache=TTLCache(maxsize=1, ttl=timedelta(hours=5), timer=datetime.now))
 def get_hf_model_info(repo_id: str) -> ModelInfo:
     """Gets the model information object for the given model repository name. For models that requires a token,
@@ -1004,9 +1060,5 @@ def get_hf_model_info(repo_id: str) -> ModelInfo:
     """
     try:
         return HfApi().model_info(repo_id=repo_id)
-    except Exception as e:
-        huggingface_err_message = str(e)
-        raise AquaValueError(
-            f"Could not get the model_info of {repo_id} from https://huggingface.co. "
-            f"Error: {huggingface_err_message}."
-        ) from e
+    except HfHubHTTPError as err:
+        raise format_hf_custom_error_message(err) from err

--- a/ads/aqua/model/entities.py
+++ b/ads/aqua/model/entities.py
@@ -48,6 +48,7 @@ class ModelValidationResult:
     model_file: Optional[str] = None
     model_formats: List[ModelFormat] = field(default_factory=list)
     telemetry_model_name: str = None
+    tags: Optional[dict] = None
 
 
 @dataclass(repr=False)

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -898,15 +898,34 @@ class AquaModelApp(AquaApp):
             # get tags for models from hf
             if import_model_details.download_from_hf:
                 model_info = get_hf_model_info(repo_id=model_name)
-                hf_tags = {
-                    Tags.TASK: (model_info and model_info.pipeline_tag) or UNKNOWN,
-                    Tags.ORGANIZATION: (
-                        model_info.author
-                        if model_info and hasattr(model_info, "author")
-                        else UNKNOWN
-                    ),
-                }
-                validation_result.tags = hf_tags
+
+                try:
+                    license_value = UNKNOWN
+                    if model_info.tags:
+                        license_tag = next(
+                            (
+                                tag
+                                for tag in model_info.tags
+                                if tag.startswith("license:")
+                            ),
+                            UNKNOWN,
+                        )
+                        license_value = (
+                            license_tag.split(":")[1] if license_tag else UNKNOWN
+                        )
+
+                    hf_tags = {
+                        Tags.TASK: (model_info and model_info.pipeline_tag) or UNKNOWN,
+                        Tags.ORGANIZATION: (
+                            model_info.author
+                            if model_info and hasattr(model_info, "author")
+                            else UNKNOWN
+                        ),
+                        Tags.LICENSE: license_value,
+                    }
+                    validation_result.tags = hf_tags
+                except Exception:
+                    pass
 
         validation_result.model_formats = model_formats
 

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -724,6 +724,7 @@ class AquaModelApp(AquaApp):
                 tags[Tags.ORGANIZATION] = validation_result.tags.get(
                     Tags.ORGANIZATION, UNKNOWN
                 )
+                tags[Tags.LICENSE] = validation_result.tags.get(Tags.LICENSE, UNKNOWN)
 
         try:
             # If verified model already has a artifact json, use that.

--- a/tests/unitary/with_extras/aqua/test_deployment_handler.py
+++ b/tests/unitary/with_extras/aqua/test_deployment_handler.py
@@ -128,6 +128,7 @@ class TestAquaDeploymentHandler(unittest.TestCase):
             container_family=None,
             memory_in_gbs=None,
             ocpus=None,
+            model_file=None,
         )
 
 

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*--
-import json
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import os
+import shlex
+import tempfile
+import json
 from dataclasses import asdict
 from importlib import reload
 from unittest.mock import MagicMock, patch
@@ -13,9 +15,15 @@ import oci
 import pytest
 from ads.aqua.ui import ModelFormat
 from parameterized import parameterized
+from huggingface_hub.hf_api import HfApi, ModelInfo
 
 import ads.aqua.model
-from ads.aqua.model.entities import AquaModelSummary, ImportModelDetails, AquaModel
+from ads.aqua.model.entities import (
+    AquaModelSummary,
+    ImportModelDetails,
+    AquaModel,
+    ModelValidationResult,
+)
 import ads.common
 import ads.common.oci_client
 import ads.config
@@ -27,7 +35,11 @@ from ads.model.model_metadata import (
     ModelProvenanceMetadata,
     ModelTaxonomyMetadata,
 )
-from ads.aqua.common.errors import AquaRuntimeError, AquaFileNotFoundError
+from ads.aqua.common.errors import (
+    AquaRuntimeError,
+    AquaFileNotFoundError,
+    AquaValueError,
+)
 from ads.model.service.oci_datascience_model import OCIDataScienceModel
 
 
@@ -50,6 +62,92 @@ def mock_get_container_config():
             container_index_json = json.load(_file)
         mock_config.return_value = container_index_json
         yield mock_config
+
+
+@pytest.fixture(autouse=True, scope="class")
+def mock_get_hf_model_info():
+    with patch.object(HfApi, "model_info") as mock_get_hf_model_info:
+        test_hf_model_info = ModelInfo(
+            disabled=False,
+            id="oracle/aqua-1t-mega-model",
+            pipeline_tag="text-generation",
+            author="test_author",
+            private=False,
+            downloads=10,
+            likes=10,
+            tags=None,
+            siblings=[
+                {
+                    "rfilename": ".gitattributes",
+                    "size": None,
+                    "blob_id": None,
+                    "lfs": None,
+                },
+                {"rfilename": "README.md", "size": None, "blob_id": None, "lfs": None},
+                {
+                    "rfilename": "config.json",
+                    "size": None,
+                    "blob_id": None,
+                    "lfs": None,
+                },
+                {
+                    "rfilename": "model_file.gguf",
+                    "size": None,
+                    "blob_id": None,
+                    "lfs": None,
+                },
+                {
+                    "rfilename": "generation_config.json",
+                    "size": None,
+                    "blob_id": None,
+                    "lfs": None,
+                },
+                {
+                    "rfilename": "model-00001-of-00001.safetensors",
+                    "size": None,
+                    "blob_id": None,
+                    "lfs": None,
+                },
+                {
+                    "rfilename": "model-00002-of-00002.safetensors",
+                    "size": None,
+                    "blob_id": None,
+                    "lfs": None,
+                },
+                {
+                    "rfilename": "model.safetensors.index.json",
+                    "size": None,
+                    "blob_id": None,
+                    "lfs": None,
+                },
+                {
+                    "rfilename": "special_tokens_map.json",
+                    "size": None,
+                    "blob_id": None,
+                    "lfs": None,
+                },
+                {
+                    "rfilename": "tokenizer.json",
+                    "size": None,
+                    "blob_id": None,
+                    "lfs": None,
+                },
+                {
+                    "rfilename": "tokenizer.model",
+                    "size": None,
+                    "blob_id": None,
+                    "lfs": None,
+                },
+                {
+                    "rfilename": "tokenizer_config.json",
+                    "size": None,
+                    "blob_id": None,
+                    "lfs": None,
+                },
+            ],
+        )
+        mock_get_hf_model_info.return_value = test_hf_model_info
+        yield mock_get_hf_model_info
 
 
 @pytest.fixture(autouse=True, scope="class")
@@ -341,6 +439,7 @@ class TestAquaModel:
 
         assert asdict(aqua_model) == {
             "arm_cpu_supported": False,
+            "artifact_location": "oci://bucket@namespace/prefix/",
             "compartment_id": f"{ds_model.compartment_id}",
             "console_link": f"https://cloud.oracle.com/data-science/models/{ds_model.id}?region={self.app.region}",
             "icon": "",
@@ -348,7 +447,8 @@ class TestAquaModel:
             "is_fine_tuned_model": False,
             "license": f'{ds_model.freeform_tags["license"]}',
             "model_card": f"{mock_read_file.return_value}",
-            "model_format": ModelFormat.SAFETENSORS,
+            "model_formats": [ModelFormat.SAFETENSORS],
+            "model_file": "",
             "name": f"{ds_model.display_name}",
             "nvidia_gpu_supported": True,
             "organization": f'{ds_model.freeform_tags["organization"]}',
@@ -484,6 +584,7 @@ class TestAquaModel:
 
         assert asdict(model) == {
             "arm_cpu_supported": False,
+            "artifact_location": "oci://bucket@namespace/prefix/",
             "compartment_id": f"{ds_model.compartment_id}",
             "console_link": f"https://cloud.oracle.com/data-science/models/{ds_model.id}?region={self.app.region}",
             "dataset": "test_training_data",
@@ -522,7 +623,8 @@ class TestAquaModel:
                 },
             ],
             "model_card": f"{mock_read_file.return_value}",
-            "model_format": ModelFormat.SAFETENSORS,
+            "model_formats": [ModelFormat.SAFETENSORS],
+            "model_file": "",
             "name": f"{ds_model.display_name}",
             "nvidia_gpu_supported": True,
             "organization": "test_organization",
@@ -546,21 +648,31 @@ class TestAquaModel:
         }
 
     @pytest.mark.parametrize(
-        "artifact_location_set",
+        ("artifact_location_set", "download_from_hf"),
         [
-            True,
-            False,
+            (True, True),
+            (True, False),
+            (False, True),
+            (False, False),
         ],
     )
+    @patch.object(AquaModelApp, "_find_matching_aqua_model")
     @patch("ads.aqua.common.utils.copy_file")
     @patch("ads.common.object_storage_details.ObjectStorageDetails.list_objects")
     @patch("ads.aqua.common.utils.load_config", return_value={})
+    @patch("huggingface_hub.snapshot_download")
+    @patch("subprocess.check_call")
     def test_import_verified_model(
         self,
+        mock_subprocess,
+        mock_snapshot_download,
         mock_load_config,
         mock_list_objects,
         mock_copy_file,
+        mock__find_matching_aqua_model,
         artifact_location_set,
+        download_from_hf,
+        mock_get_hf_model_info,
     ):
         ObjectStorageDetails.is_bucket_versioned = MagicMock(return_value=True)
         ads.common.oci_datascience.OCIDataScienceMixin.init_client = MagicMock()
@@ -617,12 +729,37 @@ class TestAquaModel:
         ds_model.set_spec(ds_model.CONST_MODEL_FILE_DESCRIPTION, {})
         ds_model.dsc_model = MagicMock(id="test_model_id")
         DataScienceModel.from_id = MagicMock(return_value=ds_model)
+        mock__find_matching_aqua_model.return_value = "test_model_id"
+
         reload(ads.aqua.model.model)
         app = AquaModelApp()
-        model: AquaModel = app.register(
-            model="ocid1.datasciencemodel.xxx.xxxx.",
-            os_path=os_path,
-        )
+        if download_from_hf:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                model: AquaModel = app.register(
+                    model=model_name,
+                    os_path=os_path,
+                    local_dir=str(tmpdir),
+                    download_from_hf=True,
+                )
+                mock_snapshot_download.assert_called_with(
+                    repo_id=model_name,
+                    local_dir=f"{str(tmpdir)}/{model_name}",
+                )
+                mock_subprocess.assert_called_with(
+                    shlex.split(
+                        f"oci os object bulk-upload --src-dir {str(tmpdir)}/{model_name} --prefix prefix/path/{model_name}/ -bn aqua-bkt -ns aqua-ns --auth api_key --profile DEFAULT --no-overwrite"
+                    )
+                )
+        else:
+            model: AquaModel = app.register(
+                model="ocid1.datasciencemodel.xxx.xxxx.",
+                os_path=os_path,
+                download_from_hf=False,
+            )
+            mock_snapshot_download.assert_not_called()
+            mock_subprocess.assert_not_called()
+            mock_load_config.assert_called()
+
         if not artifact_location_set:
             mock_copy_file.assert_called()
         ds_freeform_tags.pop(
@@ -633,7 +770,6 @@ class TestAquaModel:
             "aqua_service_model": "test_model_id",
             **ds_freeform_tags,
         }
-        mock_load_config.assert_called()
 
         assert model.inference_container == "odsc-tgi-serving"
         assert model.finetuning_container is None
@@ -642,15 +778,17 @@ class TestAquaModel:
         assert model.ready_to_deploy is True
         assert model.ready_to_finetune is False
 
+    @patch.object(AquaModelApp, "_validate_model")
     @patch("ads.aqua.common.utils.load_config", return_value={})
-    def test_import_any_model_no_containers_specified(self, mock_load_config):
+    def test_import_any_model_no_containers_specified(
+        self, mock_load_config, mock__validate_model, mock_get_hf_model_info
+    ):
         ObjectStorageDetails.is_bucket_versioned = MagicMock(return_value=True)
         ads.common.oci_datascience.OCIDataScienceMixin.init_client = MagicMock()
         DataScienceModel.upload_artifact = MagicMock()
         DataScienceModel.sync = MagicMock()
         OCIDataScienceModel.create = MagicMock()
 
-        ds_model = DataScienceModel()
         os_path = "oci://aqua-bkt@aqua-ns/prefix/path"
         model_name = "oracle/aqua-1t-mega-model"
         ds_freeform_tags = {
@@ -659,6 +797,12 @@ class TestAquaModel:
             "organization": "oracle",
             "task": "text-generation",
         }
+        mock__validate_model.return_value = ModelValidationResult(
+            model_file="model_file.gguf",
+            model_formats=[ModelFormat.SAFETENSORS],
+            telemetry_model_name=model_name,
+            tags=ds_freeform_tags,
+        )
 
         reload(ads.aqua.model.model)
         app = AquaModelApp()
@@ -671,19 +815,38 @@ class TestAquaModel:
                         organization="organization1",
                     ),
                 ]
-                model: DataScienceModel = app.register(
+                model: AquaModel = app.register(
                     model=model_name,
                     os_path=os_path,
+                    download_from_hf=False,
                 )
 
+    @pytest.mark.parametrize(
+        "download_from_hf",
+        [True, False],
+    )
+    @patch.object(AquaModelApp, "_find_matching_aqua_model")
+    @patch("ads.common.object_storage_details.ObjectStorageDetails.list_objects")
     @patch("ads.aqua.common.utils.load_config", return_value={})
-    def test_import_model_with_project_compartment_override(self, mock_load_config):
+    @patch("huggingface_hub.snapshot_download")
+    @patch("subprocess.check_call")
+    def test_import_model_with_project_compartment_override(
+        self,
+        mock_subprocess,
+        mock_snapshot_download,
+        mock_load_config,
+        mock_list_objects,
+        mock__find_matching_aqua_model,
+        download_from_hf,
+        mock_get_hf_model_info,
+    ):
         ObjectStorageDetails.is_bucket_versioned = MagicMock(return_value=True)
         ads.common.oci_datascience.OCIDataScienceMixin.init_client = MagicMock()
         DataScienceModel.upload_artifact = MagicMock()
         DataScienceModel.sync = MagicMock()
         OCIDataScienceModel.create = MagicMock()
 
+        mock_list_objects.return_value = MagicMock(objects=[])
         ds_model = DataScienceModel()
         os_path = "oci://aqua-bkt@aqua-ns/prefix/path"
         model_name = "oracle/aqua-1t-mega-model"
@@ -714,38 +877,87 @@ class TestAquaModel:
         ds_model.with_custom_metadata_list(custom_metadata_list)
         ds_model.set_spec(ds_model.CONST_MODEL_FILE_DESCRIPTION, {})
         DataScienceModel.from_id = MagicMock(return_value=ds_model)
+        mock__find_matching_aqua_model.return_value = "test_model_id"
         reload(ads.aqua.model.model)
         app = AquaModelApp()
-        model: AquaModel = app.register(
-            compartment_id=compartment_override,
-            project_id=project_override,
-            model="ocid1.datasciencemodel.xxx.xxxx.",
-            os_path=os_path,
-        )
+
+        if download_from_hf:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                model: AquaModel = app.register(
+                    compartment_id=compartment_override,
+                    project_id=project_override,
+                    model=model_name,
+                    os_path=os_path,
+                    local_dir=str(tmpdir),
+                    download_from_hf=True,
+                )
+        else:
+            model: AquaModel = app.register(
+                compartment_id=compartment_override,
+                project_id=project_override,
+                model="ocid1.datasciencemodel.xxx.xxxx.",
+                os_path=os_path,
+                download_from_hf=False,
+            )
         assert model.compartment_id == compartment_override
         assert model.project_id == project_override
 
+    @pytest.mark.parametrize(
+        "download_from_hf",
+        [True, False],
+    )
+    @patch("ads.common.object_storage_details.ObjectStorageDetails.list_objects")
     @patch("ads.aqua.common.utils.load_config", side_effect=AquaFileNotFoundError)
+    @patch("huggingface_hub.snapshot_download")
+    @patch("subprocess.check_call")
     def test_import_model_with_missing_config(
-        self, mock_load_config, mock_get_container_config
+        self,
+        mock_subprocess,
+        mock_snapshot_download,
+        mock_load_config,
+        mock_list_objects,
+        mock_get_container_config,
+        download_from_hf,
+        mock_get_hf_model_info,
     ):
         """Test for validating if error is returned when model artifacts are incomplete or not available."""
 
         os_path = "oci://aqua-bkt@aqua-ns/prefix/path"
         model_name = "oracle/aqua-1t-mega-model"
+        ObjectStorageDetails.is_bucket_versioned = MagicMock(return_value=True)
+        ads.common.oci_datascience.OCIDataScienceMixin.init_client = MagicMock()
+        DataScienceModel.upload_artifact = MagicMock()
+        mock_list_objects.return_value = MagicMock(objects=[])
         reload(ads.aqua.model.model)
         app = AquaModelApp()
         app.list = MagicMock(return_value=[])
-        with pytest.raises(AquaRuntimeError):
-            model: AquaModel = app.register(
-                model=model_name,
-                os_path=os_path,
-            )
 
+        if download_from_hf:
+            with pytest.raises(AquaValueError):
+                mock_get_hf_model_info.return_value.siblings = []
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    model: AquaModel = app.register(
+                        model=model_name,
+                        os_path=os_path,
+                        local_dir=str(tmpdir),
+                        download_from_hf=True,
+                    )
+        else:
+            with pytest.raises(AquaRuntimeError):
+                model: AquaModel = app.register(
+                    model=model_name,
+                    os_path=os_path,
+                    download_from_hf=False,
+                )
+
+    @patch("ads.common.object_storage_details.ObjectStorageDetails.list_objects")
+    @patch.object(HfApi, "model_info")
     @patch("ads.aqua.common.utils.load_config", return_value={})
     def test_import_any_model_smc_container(
         self,
         mock_load_config,
+        mock_list_objects,
+        mock_get_hf_model_info,
     ):
         my_model = "oracle/aqua-1t-mega-model"
         ObjectStorageDetails.is_bucket_versioned = MagicMock(return_value=True)
@@ -758,6 +970,7 @@ class TestAquaModel:
         ds_freeform_tags = {
             "OCI_AQUA": "active",
         }
+        mock_list_objects.return_value = MagicMock(objects=[])
 
         reload(ads.aqua.model.model)
         app = AquaModelApp()
@@ -784,6 +997,7 @@ class TestAquaModel:
                 os_path=os_path,
                 inference_container="odsc-vllm-or-tgi-container",
                 finetuning_container="odsc-llm-fine-tuning",
+                download_from_hf=False,
             )
             assert model.tags == {
                 "aqua_custom_base_model": "true",
@@ -798,7 +1012,8 @@ class TestAquaModel:
             assert model.ready_to_deploy is True
             assert model.ready_to_finetune is True
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "data, expected_output",
         [
             (
                 {
@@ -806,16 +1021,33 @@ class TestAquaModel:
                     "model": "oracle/oracle-1it",
                     "inference_container": "odsc-vllm-serving",
                 },
-                f"ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --inference_container odsc-vllm-serving",
+                "ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf True --inference_container odsc-vllm-serving",
             ),
             (
                 {
                     "os_path": "oci://aqua-bkt@aqua-ns/path",
                     "model": "ocid1.datasciencemodel.oc1.iad.<OCID>",
                 },
-                f"ads aqua model register --model ocid1.datasciencemodel.oc1.iad.<OCID> --os_path oci://aqua-bkt@aqua-ns/path",
+                "ads aqua model register --model ocid1.datasciencemodel.oc1.iad.<OCID> --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf True",
             ),
-        ]
+            (
+                {
+                    "os_path": "oci://aqua-bkt@aqua-ns/path",
+                    "model": "oracle/oracle-1it",
+                    "download_from_hf": False,
+                },
+                "ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf False",
+            ),
+            (
+                {
+                    "os_path": "oci://aqua-bkt@aqua-ns/path",
+                    "model": "oracle/oracle-1it",
+                    "download_from_hf": True,
+                    "model_file": "test_model_file",
+                },
+                "ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf True --model_file test_model_file",
+            ),
+        ],
     )
     def test_import_cli(self, data, expected_output):
         import_details = ImportModelDetails(**data)

--- a/tests/unitary/with_extras/aqua/test_model_handler.py
+++ b/tests/unitary/with_extras/aqua/test_model_handler.py
@@ -1,20 +1,24 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*--
-import json
-import os
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+import pytest
+from huggingface_hub.hf_api import HfApi, ModelInfo
+from huggingface_hub.utils import GatedRepoError
 from notebook.base.handlers import IPythonHandler
+
+from ads.aqua.common.errors import AquaRuntimeError
 from ads.aqua.extension.model_handler import (
     AquaModelHandler,
     AquaModelLicenseHandler,
+    AquaHuggingFaceHandler,
 )
 from ads.aqua.model import AquaModelApp
-from ads.aqua.model.entities import AquaModel
+from ads.aqua.model.entities import AquaModel, AquaModelSummary, HFModelSummary
 
 
 class ModelHandlerTestCase(TestCase):
@@ -107,6 +111,7 @@ class ModelHandlerTestCase(TestCase):
             compartment_id=None,
             project_id=None,
             model_file=None,
+            download_from_hf=False,
         )
         assert result["id"] == "test_id"
         assert result["inference_container"] == "odsc-tgi-serving"
@@ -129,3 +134,175 @@ class ModelLicenseHandlerTestCase(TestCase):
             mock_load_license.return_value
         )
         mock_load_license.assert_called_with("test_model_id")
+
+
+class TestAquaHuggingFaceHandler:
+    def setup_method(self):
+        with patch.object(IPythonHandler, "__init__"):
+            self.mock_handler = AquaHuggingFaceHandler(MagicMock(), MagicMock())
+            self.mock_handler.request = MagicMock()
+            self.mock_handler.finish = MagicMock()
+            self.mock_handler.set_header = MagicMock()
+            self.mock_handler.set_status = MagicMock()
+
+    @pytest.mark.parametrize(
+        "test_model_id, test_author, expected_aqua_model_name, expected_aqua_model_id",
+        [
+            ("organization1/name1", "organization1", "organization1/name1", "test_id1"),
+            ("organization1/name2", "organization1", "organization1/name2", "test_id2"),
+            ("organization2/name3", "organization2", "organization2/name3", "test_id3"),
+            ("non_existing_name", "organization2", None, None),
+            ("organization1/non_existing_name", "organization1", None, None),
+        ],
+    )
+    @patch.object(AquaModelApp, "get")
+    def test_find_matching_aqua_model(
+        self,
+        mock_get_model,
+        test_model_id,
+        test_author,
+        expected_aqua_model_name,
+        expected_aqua_model_id,
+    ):
+        with patch.object(AquaModelApp, "list") as aqua_model_mock_list:
+            aqua_model_mock_list.return_value = [
+                AquaModelSummary(
+                    id="test_id1",
+                    name="organization1/name1",
+                    organization="organization1",
+                ),
+                AquaModelSummary(
+                    id="test_id2",
+                    name="organization1/name2",
+                    organization="organization1",
+                ),
+                AquaModelSummary(
+                    id="test_id3",
+                    name="organization2/name3",
+                    organization="organization2",
+                ),
+            ]
+
+            test_result = self.mock_handler._find_matching_aqua_model(
+                model_id=test_model_id
+            )
+
+            aqua_model_mock_list.assert_called_once()
+
+            if expected_aqua_model_name:
+                mock_get_model.assert_called_with(
+                    expected_aqua_model_id, load_model_card=False
+                )
+            else:
+                assert test_result == None
+
+    @patch("uuid.uuid4")
+    def test_post_negative(self, mock_uuid):
+        mock_uuid.return_value = "###"
+
+        # case 1
+        self.mock_handler.get_json_body = MagicMock(side_effect=ValueError())
+        self.mock_handler.post()
+        self.mock_handler.finish.assert_called_with(
+            '{"status": 400, "message": "Invalid format of input data.", "service_payload": {}, "reason": "Invalid format of input data.", "request_id": "###"}'
+        )
+
+        # case 2
+        self.mock_handler.get_json_body = MagicMock(return_value={})
+        self.mock_handler.post()
+        self.mock_handler.finish.assert_called_with(
+            '{"status": 400, "message": "No input data provided.", "service_payload": {}, '
+            '"reason": "No input data provided.", "request_id": "###"}'
+        )
+
+        # case 3
+        self.mock_handler.get_json_body = MagicMock(return_value={"some_field": None})
+        self.mock_handler.post()
+        self.mock_handler.finish.assert_called_with(
+            '{"status": 400, "message": "Missing required parameter: \'model_id\'", '
+            '"service_payload": {}, "reason": "Missing required parameter: \'model_id\'", "request_id": "###"}'
+        )
+
+        # case 4
+        self.mock_handler.get_json_body = MagicMock(
+            return_value={"model_id": "test_model_id"}
+        )
+        self.mock_handler._format_custom_error_message = MagicMock(
+            side_effect=AquaRuntimeError("test error message")
+        )
+        with patch.object(HfApi, "model_info") as mock_model_info:
+            mock_model_info.side_effect = GatedRepoError(message="test message")
+            self.mock_handler.post()
+            self.mock_handler.finish.assert_called_with(
+                '{"status": 400, "message": "Something went wrong with your request.", '
+                '"service_payload": {}, "reason": "test error message", "request_id": "###"}'
+            )
+
+        # case 5
+        self.mock_handler.get_json_body = MagicMock(
+            return_value={"model_id": "test_model_id"}
+        )
+        with patch.object(HfApi, "model_info") as mock_model_info:
+            mock_model_info.return_value = MagicMock(disabled=True, id="test_model_id")
+            self.mock_handler.post()
+            self.mock_handler.finish.assert_called_with(
+                '{"status": 400, "message": "Something went wrong with your request.", "service_payload": {}, '
+                '"reason": "The chosen model \'test_model_id\' is currently disabled and cannot be '
+                "imported into AQUA. Please verify the model's status on the Hugging Face Model "
+                'Hub or select a different model.", "request_id": "###"}'
+            )
+
+        # case 6
+        self.mock_handler.get_json_body = MagicMock(
+            return_value={"model_id": "test_model_id"}
+        )
+        with patch.object(HfApi, "model_info") as mock_model_info:
+            mock_model_info.return_value = MagicMock(
+                disabled=False, id="test_model_id", pipeline_tag="not-text-generation"
+            )
+            self.mock_handler.post()
+            self.mock_handler.finish.assert_called_with(
+                '{"status": 400, "message": "Something went wrong with your request.", '
+                '"service_payload": {}, "reason": "Unsupported pipeline tag for the chosen '
+                "model: 'not-text-generation'. AQUA currently supports the following tasks only: "
+                'text-generation. Please select a model with a compatible pipeline tag.", "request_id": "###"}'
+            )
+
+    @patch("uuid.uuid4")
+    def test_post_positive(self, mock_uuid):
+        mock_uuid.return_value = "###"
+
+        self.mock_handler.get_json_body = MagicMock(
+            return_value={"model_id": "test_model_id"}
+        )
+
+        test_aqua_model_summary = AquaModelSummary(
+            name="name1", organization="organization1"
+        )
+        self.mock_handler._find_matching_aqua_model = MagicMock(
+            return_value=test_aqua_model_summary
+        )
+
+        with patch.object(HfApi, "model_info") as mock_model_info:
+            test_hf_model_info = ModelInfo(
+                disabled=False,
+                id="test_model_id",
+                pipeline_tag="text-generation",
+                author="test_author",
+                private=False,
+                downloads=10,
+                likes=10,
+                tags=None,
+            )
+            mock_model_info.return_value = test_hf_model_info
+            self.mock_handler.post()
+
+            self.mock_handler._find_matching_aqua_model.assert_called_with(
+                model_id="test_model_id"
+            )
+
+            test_model_summary = HFModelSummary(
+                model_info=test_hf_model_info, aqua_model_info=test_aqua_model_summary
+            )
+
+            self.mock_handler.finish.assert_called_with(test_model_summary)


### PR DESCRIPTION
### Description

This PR adds the following:
- build_cli in app.py is updated to allow fields with value "False"
- added a new util function `get_hf_model_info` that caches the model info from Hugging Face for 5 hours. Cache size is set as 1.
- if model is downloaded from HF, tags for org and task are added.
- Unit tests for HF modules have been added

### Tests

```
> python -m pytest -q tests/unitary/with_extras/aqua/test_*
================================================ test session starts =================================================
platform darwin -- Python 3.8.19, pytest-7.4.4, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-26.0.0, cov-5.0.0, anyio-4.2.0, xdist-3.6.1
collected 208 items

tests/unitary/with_extras/aqua/test_cli.py ..............                                                      [  6%]
tests/unitary/with_extras/aqua/test_common_handler.py ...                                                      [  8%]
tests/unitary/with_extras/aqua/test_decorator.py ..........                                                    [ 12%]
tests/unitary/with_extras/aqua/test_deployment.py .....................                                        [ 23%]
tests/unitary/with_extras/aqua/test_deployment_handler.py ..s......                                            [ 27%]
tests/unitary/with_extras/aqua/test_evaluation.py .............................                                [ 41%]
tests/unitary/with_extras/aqua/test_evaluation_handler.py .........                                            [ 45%]
tests/unitary/with_extras/aqua/test_finetuning.py .......                                                      [ 49%]
tests/unitary/with_extras/aqua/test_finetuning_handler.py .....                                                [ 51%]
tests/unitary/with_extras/aqua/test_global.py ...                                                              [ 52%]
tests/unitary/with_extras/aqua/test_handlers.py .................                                              [ 61%]
tests/unitary/with_extras/aqua/test_model.py .......................                                           [ 72%]
tests/unitary/with_extras/aqua/test_model_handler.py ..............                                            [ 78%]
tests/unitary/with_extras/aqua/test_ui.py ...............                                                      [ 86%]
tests/unitary/with_extras/aqua/test_ui_handler.py ..............                                               [ 92%]
tests/unitary/with_extras/aqua/test_ui_websocket_handler.py ....                                               [ 94%]
tests/unitary/with_extras/aqua/test_utils.py ...........                                                       [100%]

========================================== 207 passed, 1 skipped in 31.06s ===========================================

```