### PR TITLE
Adds service model parameters for the evaluation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ logs/
 
 # Python Wheel
 *.whl
+
+# Demo folder
+.demo

--- a/ads/aqua/evaluation/entities.py
+++ b/ads/aqua/evaluation/entities.py
@@ -105,6 +105,16 @@ class ModelParams(DataClassSerializable):
 
 
 @dataclass(repr=False)
+class ServiceModelParams(DataClassSerializable):
+    """
+    The service model params that will be added to the final list of the user-defined parameters.
+    """
+
+    model: Optional[str] = "odsc-llm"
+    add_generation_prompt: Optional[bool] = False
+
+
+@dataclass(repr=False)
 class AquaEvalParams(ModelParams, DataClassSerializable):
     shape: str = ""
     dataset_path: str = ""

--- a/ads/aqua/evaluation/evaluation.py
+++ b/ads/aqua/evaluation/evaluation.py
@@ -74,6 +74,7 @@ from ads.aqua.evaluation.entities import (
     AquaResourceIdentifier,
     CreateAquaEvaluationDetails,
     ModelParams,
+    ServiceModelParams,
 )
 from ads.aqua.evaluation.errors import EVALUATION_JOB_EXIT_CODE_MESSAGE
 from ads.aqua.ui import AquaContainerConfig
@@ -414,11 +415,16 @@ class AquaEvaluationApp(AquaApp):
                 container_image=container_image,
                 dataset_path=evaluation_dataset_path,
                 report_path=create_aqua_evaluation_details.report_path,
-                model_parameters=create_aqua_evaluation_details.model_parameters,
+                model_parameters={
+                    **ServiceModelParams().to_dict(),
+                    **create_aqua_evaluation_details.model_parameters,
+                },
                 metrics=create_aqua_evaluation_details.metrics,
-                inference_configuration=eval_inference_configuration.to_filtered_dict()
-                if eval_inference_configuration
-                else {},
+                inference_configuration=(
+                    eval_inference_configuration.to_filtered_dict()
+                    if eval_inference_configuration
+                    else {}
+                ),
             )
         ).create(**kwargs)  ## TODO: decide what parameters will be needed
         logger.debug(
@@ -1225,7 +1231,7 @@ class AquaEvaluationApp(AquaApp):
                 f"Exception message: {ex}"
             )
 
-    def load_evaluation_config(self, eval_id):
+    def load_evaluation_config(self, eval_id: str = ""):  # noqa: ARG002
         """Loads evaluation config."""
         return {
             "model_params": {


### PR DESCRIPTION
## Description

In the initial implementation of the aqua-evaluate project, default model parameters were hard coded within the project. Given the diversity of LLM frameworks, which may support varying parameters under the Open AI spec, this setup could lead to compatibility issues. To enhance flexibility and adaptability, it is proposed to implement a pass-through mechanism. This mechanism would allow parameters from the client side to be directly forwarded to the LLM inferencing framework, enabling the framework to handle the parameters and generate errors. 

As a temporary solution, this PR addressing a list of mandatory service parameters that will be added on top of user-provided parameters during evaluation. 

```
model: Optional[str] = "odsc-llm"
add_generation_prompt: Optional[bool] = False
```

In the next iteration, these parameters will be moved to the service containers' config as outlined in the dedicated ticket - https://jira.oci.oraclecorp.com/browse/ODSC-60520.
