### PR TITLE
[AQUA][Evaluate] Externalize Supported Evaluation Metrics List to Service Config

### DIFF
--- a/ads/aqua/evaluation/evaluation.py
+++ b/ads/aqua/evaluation/evaluation.py
@@ -904,7 +904,9 @@ class AquaEvaluationApp(AquaApp):
 
     def get_supported_metrics(self) -> dict:
         """Gets a list of supported metrics for evaluation."""
-        return [item.to_dict() for item in evaluation_service_config().metrics]
+        return [
+            item.to_dict() for item in evaluation_service_config().ui_config.metrics
+        ]
 
     @telemetry(entry_point="plugin=evaluation&action=load_metrics", name="aqua")
     def load_metrics(self, eval_id: str) -> AquaEvalMetrics:

--- a/tests/unitary/with_extras/aqua/test_evaluation.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation.py
@@ -25,6 +25,7 @@ from ads.aqua.common.errors import (
 from ads.aqua.config.evaluation.evaluation_service_config import (
     EvaluationServiceConfig,
     MetricConfig,
+    UIConfig,
 )
 from ads.aqua.constants import EVALUATION_REPORT_JSON, EVALUATION_REPORT_MD, UNKNOWN
 from ads.aqua.evaluation import AquaEvaluationApp
@@ -886,25 +887,27 @@ class TestAquaEvaluation(unittest.TestCase):
         """
 
         test_evaluation_service_config = EvaluationServiceConfig(
-            metrics=[
-                MetricConfig(
-                    **{
-                        "args": {},
-                        "description": "BERT Score.",
-                        "key": "bertscore",
-                        "name": "BERT Score",
-                        "tags": [],
-                        "task": ["text-generation"],
-                    },
-                )
-            ]
+            ui_config=UIConfig(
+                metrics=[
+                    MetricConfig(
+                        **{
+                            "args": {},
+                            "description": "BERT Score.",
+                            "key": "bertscore",
+                            "name": "BERT Score",
+                            "tags": [],
+                            "task": ["text-generation"],
+                        },
+                    )
+                ]
+            )
         )
         mock_evaluation_service_config.return_value = test_evaluation_service_config
         response = self.app.get_supported_metrics()
         assert isinstance(response, list)
-        assert len(response) == len(test_evaluation_service_config.metrics)
+        assert len(response) == len(test_evaluation_service_config.ui_config.metrics)
         assert response == [
-            item.to_dict() for item in test_evaluation_service_config.metrics
+            item.to_dict() for item in test_evaluation_service_config.ui_config.metrics
         ]
 
     def test_load_evaluation_config(self):

--- a/tests/unitary/with_extras/aqua/utils.py
+++ b/tests/unitary/with_extras/aqua/utils.py
@@ -77,17 +77,6 @@ class BaseFormat:
 
 
 @dataclass
-class SupportMetricsFormat(BaseFormat):
-    """Format for supported evaluation metrics."""
-
-    use_case: list
-    key: str
-    name: str
-    description: str
-    args: dict
-
-
-@dataclass
 class EvaluationConfigFormat(BaseFormat):
     """Evaluation config format."""
 


### PR DESCRIPTION
## Description

Shift the management of the supported metrics list from being hardcoded in the ADS SDK to being stored and managed at the evaluation service config level.