### PR TITLE
Updated compatibility check for aqua

### DIFF
--- a/ads/aqua/extension/common_handler.py
+++ b/ads/aqua/extension/common_handler.py
@@ -11,16 +11,15 @@ from huggingface_hub import HfApi
 from huggingface_hub.utils import LocalTokenNotFoundError
 from tornado.web import HTTPError
 
-from ads.aqua import ODSC_MODEL_COMPARTMENT_OCID
 from ads.aqua.common.decorator import handle_exceptions
 from ads.aqua.common.errors import AquaResourceAccessError, AquaRuntimeError
 from ads.aqua.common.utils import (
-    fetch_service_compartment,
     get_huggingface_login_timeout,
     known_realm,
 )
 from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua.extension.errors import Errors
+from ads.aqua.extension.utils import ui_compatability_check
 
 
 class ADSVersionHandler(AquaAPIhandler):
@@ -51,7 +50,7 @@ class CompatibilityCheckHandler(AquaAPIhandler):
             AquaResourceAccessError: raised when aqua is not accessible in the given session/region.
 
         """
-        if ODSC_MODEL_COMPARTMENT_OCID or fetch_service_compartment():
+        if ui_compatability_check():
             return self.finish({"status": "ok"})
         elif known_realm():
             return self.finish({"status": "compatible"})

--- a/ads/aqua/extension/common_ws_msg_handler.py
+++ b/ads/aqua/extension/common_ws_msg_handler.py
@@ -7,7 +7,6 @@ import json
 from importlib import metadata
 from typing import List, Union
 
-from ads.aqua import ODSC_MODEL_COMPARTMENT_OCID, fetch_service_compartment
 from ads.aqua.common.decorator import handle_exceptions
 from ads.aqua.common.errors import AquaResourceAccessError
 from ads.aqua.common.utils import known_realm
@@ -17,6 +16,7 @@ from ads.aqua.extension.models.ws_models import (
     CompatibilityCheckResponse,
     RequestResponseType,
 )
+from ads.aqua.extension.utils import ui_compatability_check
 
 
 class AquaCommonWsMsgHandler(AquaWSMsgHandler):
@@ -39,7 +39,7 @@ class AquaCommonWsMsgHandler(AquaWSMsgHandler):
             )
             return response
         if request.get("kind") == "CompatibilityCheck":
-            if ODSC_MODEL_COMPARTMENT_OCID or fetch_service_compartment():
+            if ui_compatability_check():
                 return CompatibilityCheckResponse(
                     message_id=request.get("message_id"),
                     kind=RequestResponseType.CompatibilityCheck,

--- a/ads/aqua/extension/utils.py
+++ b/ads/aqua/extension/utils.py
@@ -28,4 +28,7 @@ def validate_function_parameters(data_class, input_data: Dict):
 
 @cached(cache=TTLCache(maxsize=1, ttl=timedelta(minutes=1), timer=datetime.now))
 def ui_compatability_check():
+    """This method caches the service compartment OCID details that is set by either the environment variable or if
+    fetched from the configuration. The cached result is returned when multiple calls are made in quick succession
+    from the UI to avoid multiple config file loads."""
     return ODSC_MODEL_COMPARTMENT_OCID or fetch_service_compartment()

--- a/ads/aqua/extension/utils.py
+++ b/ads/aqua/extension/utils.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 from dataclasses import fields
+from datetime import datetime, timedelta
 from typing import Dict, Optional
 
+from cachetools import TTLCache, cached
 from tornado.web import HTTPError
 
+from ads.aqua import ODSC_MODEL_COMPARTMENT_OCID
+from ads.aqua.common.utils import fetch_service_compartment
 from ads.aqua.extension.errors import Errors
 
 
@@ -21,3 +24,8 @@ def validate_function_parameters(data_class, input_data: Dict):
             raise HTTPError(
                 400, Errors.MISSING_REQUIRED_PARAMETER.format(required_parameter)
             )
+
+
+@cached(cache=TTLCache(maxsize=1, ttl=timedelta(minutes=1), timer=datetime.now))
+def ui_compatability_check():
+    return ODSC_MODEL_COMPARTMENT_OCID or fetch_service_compartment()

--- a/tests/unitary/with_extras/aqua/test_handlers.py
+++ b/tests/unitary/with_extras/aqua/test_handlers.py
@@ -13,7 +13,6 @@ from unittest.mock import MagicMock, patch
 from notebook.base.handlers import APIHandler, IPythonHandler
 from oci.exceptions import ServiceError
 from parameterized import parameterized
-from tornado.httpserver import HTTPRequest
 from tornado.httputil import HTTPServerRequest
 from tornado.web import Application, HTTPError
 
@@ -191,6 +190,7 @@ class TestHandlers(unittest.TestCase):
 
         reload(ads.config)
         reload(ads.aqua)
+        reload(ads.aqua.extension.utils)
         reload(ads.aqua.extension.common_handler)
 
     @classmethod
@@ -200,6 +200,7 @@ class TestHandlers(unittest.TestCase):
 
         reload(ads.config)
         reload(ads.aqua)
+        reload(ads.aqua.extension.utils)
         reload(ads.aqua.extension.common_handler)
 
     @parameterized.expand(


### PR DESCRIPTION
### Description

This PR covers the following:
- add threaded decorator back to the load_config function.
- add ui_compatability_check function that caches the compartment info.

### Tests

```
> python -m pytest -q tests/unitary/with_extras/aqua/test_*
===================================================== test session starts ======================================================
platform darwin -- Python 3.8.19, pytest-7.4.4, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-26.0.0, cov-5.0.0, anyio-4.2.0, xdist-3.6.1
collected 230 items

tests/unitary/with_extras/aqua/test_cli.py ..............                                                                [  6%]
tests/unitary/with_extras/aqua/test_common_handler.py ...                                                                [  7%]
tests/unitary/with_extras/aqua/test_config.py .                                                                          [  7%]
tests/unitary/with_extras/aqua/test_decorator.py ..........                                                              [ 12%]
tests/unitary/with_extras/aqua/test_deployment.py .....................                                                  [ 21%]
tests/unitary/with_extras/aqua/test_deployment_handler.py ..s......                                                      [ 25%]
tests/unitary/with_extras/aqua/test_evaluation.py .............................                                          [ 37%]
tests/unitary/with_extras/aqua/test_evaluation_handler.py .........                                                      [ 41%]
tests/unitary/with_extras/aqua/test_evaluation_service_config.py .....................                                   [ 50%]
tests/unitary/with_extras/aqua/test_finetuning.py .......                                                                [ 53%]
tests/unitary/with_extras/aqua/test_finetuning_handler.py .....                                                          [ 56%]
tests/unitary/with_extras/aqua/test_global.py ...                                                                        [ 57%]
tests/unitary/with_extras/aqua/test_handlers.py .................                                                        [ 64%]
tests/unitary/with_extras/aqua/test_model.py .......................                                                     [ 74%]
tests/unitary/with_extras/aqua/test_model_handler.py ..............                                                      [ 80%]
tests/unitary/with_extras/aqua/test_ui.py ...............                                                                [ 87%]
tests/unitary/with_extras/aqua/test_ui_handler.py ..............                                                         [ 93%]
tests/unitary/with_extras/aqua/test_ui_websocket_handler.py ....                                                         [ 95%]
tests/unitary/with_extras/aqua/test_utils.py ...........                                                                 [100%]

=============================================== 229 passed, 1 skipped in 28.40s ================================================
```