### PR TITLE
Updated Schema for Pre and Post-Processing; Added additional methods

### DIFF
--- a/ads/opctl/operator/lowcode/anomaly/operator_config.py
+++ b/ads/opctl/operator/lowcode/anomaly/operator_config.py
@@ -17,6 +17,7 @@ from ads.opctl.operator.common.operator_config import (
 )
 from .const import SupportedModels
 from ads.opctl.operator.lowcode.common.utils import find_output_dirname
+from ads.opctl.operator.lowcode.common.const import ImputationMethods
 
 
 @dataclass(repr=True)
@@ -41,16 +42,8 @@ class TestData(InputData):
 class PreprocessingSteps(DataClassSerializable):
     """Class representing preprocessing steps for operator."""
 
-    missing_value_imputation: bool = True
-    outlier_treatment: bool = False
+    missing_value_imputation: str = ImputationMethods.LINEAR_INTERPOLATION
 
-
-@dataclass(repr=True)
-class DataPreprocessor(DataClassSerializable):
-    """Class representing operator specification preprocessing details."""
-
-    enabled: bool = True
-    steps: PreprocessingSteps = field(default_factory=PreprocessingSteps)
 
 @dataclass(repr=True)
 class AnomalyOperatorSpec(DataClassSerializable):
@@ -70,7 +63,7 @@ class AnomalyOperatorSpec(DataClassSerializable):
     outliers_filename: str = None
     target_column: str = None
     target_category_columns: List[str] = field(default_factory=list)
-    preprocessing: bool = None
+    preprocessing: PreprocessingSteps = field(default_factory=PreprocessingSteps)
     generate_report: bool = None
     generate_metrics: bool = None
     generate_inliers: bool = None
@@ -93,7 +86,7 @@ class AnomalyOperatorSpec(DataClassSerializable):
         )
         self.model_kwargs = self.model_kwargs or dict()
         self.preprocessing = (
-            self.preprocessing if self.preprocessing is not None else DataPreprocessor(enabled=True)
+            self.preprocessing if self.preprocessing is not None else PreprocessingSteps()
         )
 
 @dataclass(repr=True)

--- a/ads/opctl/operator/lowcode/anomaly/schema.yaml
+++ b/ads/opctl/operator/lowcode/anomaly/schema.yaml
@@ -318,20 +318,14 @@ spec:
       type: dict
       required: false
       schema:
-        enabled:
-          type: boolean
+        missing_value_imputation:
+          type: string
           required: false
-          default: true
+          default: linear_interpolation
           meta:
-            description: "preprocessing and feature engineering can be disabled using this flag, Defaults to true"
-        steps:
-          type: dict
-          required: false
-          schema:
-            missing_value_imputation:
-              type: boolean
-              required: false
-              default: false
+            description: "Method to handle missing values in the dataset. Default is 'linear_interpolation'.
+             Other options are 'median', 'none' and 'mean'"
+
 
     generate_report:
       type: boolean

--- a/ads/opctl/operator/lowcode/common/const.py
+++ b/ads/opctl/operator/lowcode/common/const.py
@@ -5,6 +5,21 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 
+from ads.common.extended_enum import ExtendedEnumMeta
+
+
 class DataColumns:
     Series = "Series"
     Date = "Date"
+
+
+class ImputationMethods(str, metaclass=ExtendedEnumMeta):
+    MEAN = "mean"
+    MEDIAN = "median"
+    LINEAR_INTERPOLATION = "linear_interpolation"
+    NONE = "None"
+
+
+class OutlierTreatmentMethods(str, metaclass=ExtendedEnumMeta):
+    ZSCORE_WITH_MEAN = "zscore_with_mean"
+    NONE = "None"

--- a/ads/opctl/operator/lowcode/forecast/model/arima.py
+++ b/ads/opctl/operator/lowcode/forecast/model/arima.py
@@ -143,6 +143,7 @@ class ArimaOperatorModel(ForecastOperatorBaseModel):
             horizon=self.spec.horizon,
             target_column=self.original_target_column,
             dt_column=self.spec.datetime_column.name,
+            postprocessing=self.spec.postprocessing
         )
 
         Parallel(n_jobs=-1, require="sharedmem")(

--- a/ads/opctl/operator/lowcode/forecast/model/automlx.py
+++ b/ads/opctl/operator/lowcode/forecast/model/automlx.py
@@ -96,6 +96,7 @@ class AutoMLXOperatorModel(ForecastOperatorBaseModel):
             horizon=self.spec.horizon,
             target_column=self.original_target_column,
             dt_column=self.spec.datetime_column.name,
+            postprocessing=self.spec.postprocessing
         )
 
         # Clean up kwargs for pass through

--- a/ads/opctl/operator/lowcode/forecast/model/autots.py
+++ b/ads/opctl/operator/lowcode/forecast/model/autots.py
@@ -53,6 +53,7 @@ class AutoTSOperatorModel(ForecastOperatorBaseModel):
             horizon=self.spec.horizon,
             target_column=self.original_target_column,
             dt_column=self.spec.datetime_column.name,
+            postprocessing=self.spec.postprocessing
         )
         try:
             model = self.loaded_models if self.loaded_models is not None else None

--- a/ads/opctl/operator/lowcode/forecast/model/forecast_datasets.py
+++ b/ads/opctl/operator/lowcode/forecast/model/forecast_datasets.py
@@ -323,8 +323,8 @@ class ForecastOutput:
         --------
         None
         """
-        min_threshold = self.postprocessing.set_min_forecast
-        max_threshold = self.postprocessing.set_max_forecast
+        min_threshold = self.postprocessing.minimum_value
+        max_threshold = self.postprocessing.maximum_value
         if min_threshold is not None:
             forecast_val = np.maximum(forecast_val, min_threshold)
         if max_threshold is not None:

--- a/ads/opctl/operator/lowcode/forecast/model/forecast_datasets.py
+++ b/ads/opctl/operator/lowcode/forecast/model/forecast_datasets.py
@@ -29,7 +29,7 @@ from ads.opctl.operator.lowcode.common.errors import (
 )
 from ..const import SupportedModels
 from abc import ABC, abstractmethod
-from ..operator_config import DataPostprocessor
+from ..operator_config import PostprocessingSteps
 
 
 class HistoricalData(AbstractData):
@@ -261,7 +261,7 @@ class ForecastOutput:
         horizon: int,
         target_column: str,
         dt_column: str,
-        postprocessing: DataPostprocessor
+        postprocessing: PostprocessingSteps
     ):
         """Forecast Output contains all of the details required to generate the forecast.csv output file.
 
@@ -324,9 +324,12 @@ class ForecastOutput:
         --------
         None
         """
-        if self.postprocessing.enabled:
-            min_threshold = self.postprocessing.steps.set_min_forecast
+        min_threshold = self.postprocessing.set_min_forecast
+        max_threshold = self.postprocessing.set_max_forecast
+        if min_threshold is not None:
             forecast_val = np.maximum(forecast_val, min_threshold)
+        if max_threshold is not None:
+            forecast_val = np.minimum(forecast_val, max_threshold)
         try:
             output_i = self.series_id_map[series_id]
         except KeyError:

--- a/ads/opctl/operator/lowcode/forecast/model/ml_forecast.py
+++ b/ads/opctl/operator/lowcode/forecast/model/ml_forecast.py
@@ -180,6 +180,7 @@ class MLForecastOperatorModel(ForecastOperatorBaseModel):
             horizon=self.spec.horizon,
             target_column=self.original_target_column,
             dt_column=self.date_col,
+            postprocessing=self.spec.postprocessing
         )
         self._train_model(data_train, data_test, model_kwargs)
         return self.forecast_output.get_forecast_long()

--- a/ads/opctl/operator/lowcode/forecast/model/neuralprophet.py
+++ b/ads/opctl/operator/lowcode/forecast/model/neuralprophet.py
@@ -240,6 +240,7 @@ class NeuralProphetOperatorModel(ForecastOperatorBaseModel):
             horizon=self.spec.horizon,
             target_column=self.original_target_column,
             dt_column=self.spec.datetime_column.name,
+            postprocessing=self.spec.postprocessing
         )
 
         for i, (s_id, df) in enumerate(full_data_dict.items()):

--- a/ads/opctl/operator/lowcode/forecast/model/prophet.py
+++ b/ads/opctl/operator/lowcode/forecast/model/prophet.py
@@ -45,7 +45,6 @@ def _add_unit(num, unit):
 
 def _fit_model(data, params, additional_regressors):
     from prophet import Prophet
-    params['growth'] = 'logistic'
     model = Prophet(**params)
     for add_reg in additional_regressors:
         model.add_regressor(add_reg)
@@ -81,13 +80,6 @@ class ProphetOperatorModel(ForecastOperatorBaseModel):
             )
 
             data = self.preprocess(df, series_id)
-            cap = data['y'].max() * 1.2
-            if self.spec.postprocessing.enabled:
-                floor = self.spec.postprocessing.steps.set_min_forecast
-            else:
-                floor = data['y'].min() * 0.8
-            data['cap'] = cap
-            data['floor'] = floor
             data_i = self.drop_horizon(data)
             if self.loaded_models is not None and series_id in self.loaded_models:
                 model = self.loaded_models[series_id]
@@ -103,8 +95,7 @@ class ProphetOperatorModel(ForecastOperatorBaseModel):
 
             # Get future df for prediction
             future = data.drop("y", axis=1)
-            future['cap'] = cap
-            future['floor'] = floor
+
             # Make Prediction
             forecast = model.predict(future)
             logger.debug(f"-----------------Model {i}----------------------")

--- a/ads/opctl/operator/lowcode/forecast/model_evaluator.py
+++ b/ads/opctl/operator/lowcode/forecast/model_evaluator.py
@@ -108,6 +108,7 @@ class ModelEvaluator:
         backtest_spec["output_directory"] = {"url": output_file_path}
         backtest_spec["target_category_columns"] = [DataColumns.Series]
         backtest_spec['generate_explanations'] = False
+        backtest_spec.pop('postprocessing', None)
         cleaned_config = self.remove_none_values(backtest_op_config_draft)
 
         backtest_op_config = ForecastOperatorConfig.from_dict(

--- a/ads/opctl/operator/lowcode/forecast/operator_config.py
+++ b/ads/opctl/operator/lowcode/forecast/operator_config.py
@@ -15,6 +15,7 @@ from ads.opctl.operator.common.operator_config import OperatorConfig, OutputDire
 from .const import SupportedMetrics, SpeedAccuracyMode
 from .const import SupportedModels
 from ads.opctl.operator.lowcode.common.utils import find_output_dirname
+from ads.opctl.operator.lowcode.common.const import OutlierTreatmentMethods, ImputationMethods
 
 @dataclass(repr=True)
 class TestData(InputData):
@@ -30,34 +31,20 @@ class DateTimeColumn(DataClassSerializable):
 
 
 @dataclass(repr=True)
-class PreprocessingSteps(DataClassSerializable):
-    """Class representing preprocessing steps for operator."""
-
-    missing_value_imputation: bool = True
-    outlier_treatment: bool = True
-
-
-@dataclass(repr=True)
 class PostprocessingSteps(DataClassSerializable):
     """Class representing postprocessing steps for operator."""
 
-    set_min_forecast: int = 0
+    set_min_forecast: int = None
+    set_max_forecast: int = None
 
 
 @dataclass(repr=True)
-class DataPreprocessor(DataClassSerializable):
-    """Class representing operator specification preprocessing details."""
+class PreprocessingSteps(DataClassSerializable):
+    """Class representing preprocessing steps for operator."""
 
-    enabled: bool = True
-    steps: PreprocessingSteps = field(default_factory=PreprocessingSteps)
+    missing_value_imputation: str = ImputationMethods.LINEAR_INTERPOLATION
+    outlier_treatment: str = OutlierTreatmentMethods.ZSCORE_WITH_MEAN
 
-
-@dataclass(repr=True)
-class DataPostprocessor(DataClassSerializable):
-    """Class representing operator specification preprocessing details."""
-
-    enabled: bool = False
-    steps: PostprocessingSteps = field(default_factory=PostprocessingSteps)
 
 @dataclass(repr=True)
 class Tuning(DataClassSerializable):
@@ -84,8 +71,8 @@ class ForecastOperatorSpec(DataClassSerializable):
     global_explanation_filename: str = None
     local_explanation_filename: str = None
     target_column: str = None
-    preprocessing: DataPreprocessor = field(default_factory=DataPreprocessor)
-    postprocessing: DataPostprocessor = field(default_factory=DataPostprocessor)
+    preprocessing: PreprocessingSteps = field(default_factory=PreprocessingSteps)
+    postprocessing: PostprocessingSteps = field(default_factory=PostprocessingSteps)
     datetime_column: DateTimeColumn = field(default_factory=DateTimeColumn)
     target_category_columns: List[str] = field(default_factory=list)
     generate_report: bool = None
@@ -111,10 +98,10 @@ class ForecastOperatorSpec(DataClassSerializable):
         self.confidence_interval_width = self.confidence_interval_width or 0.80
         self.report_filename = self.report_filename or "report.html"
         self.preprocessing = (
-            self.preprocessing if self.preprocessing is not None else DataPreprocessor(enabled=True)
+            self.preprocessing if self.preprocessing is not None else PreprocessingSteps()
         )
         self.postprocessing = (
-            self.postprocessing if self.postprocessing is not None else DataPostprocessor(enabled=False)
+            self.postprocessing if self.postprocessing is not None else PostprocessingSteps()
         )
         # For Report Generation. When user doesn't specify defaults to True
         self.generate_report = (
@@ -131,7 +118,7 @@ class ForecastOperatorSpec(DataClassSerializable):
             else False
         )
         self.explanations_accuracy_mode = (
-            self.explanations_accuracy_mode or SpeedAccuracyMode.FAST_APPROXIMATE
+                self.explanations_accuracy_mode or SpeedAccuracyMode.FAST_APPROXIMATE
         )
 
         self.generate_model_parameters = (
@@ -149,10 +136,10 @@ class ForecastOperatorSpec(DataClassSerializable):
         self.test_metrics_filename = self.test_metrics_filename or "test_metrics.csv"
         self.forecast_filename = self.forecast_filename or "forecast.csv"
         self.global_explanation_filename = (
-            self.global_explanation_filename or "global_explanation.csv"
+                self.global_explanation_filename or "global_explanation.csv"
         )
         self.local_explanation_filename = (
-            self.local_explanation_filename or "local_explanation.csv"
+                self.local_explanation_filename or "local_explanation.csv"
         )
         self.target_column = self.target_column or "Sales"
         self.errors_dict_filename = "errors.json"

--- a/ads/opctl/operator/lowcode/forecast/operator_config.py
+++ b/ads/opctl/operator/lowcode/forecast/operator_config.py
@@ -34,8 +34,8 @@ class DateTimeColumn(DataClassSerializable):
 class PostprocessingSteps(DataClassSerializable):
     """Class representing postprocessing steps for operator."""
 
-    set_min_forecast: int = None
-    set_max_forecast: int = None
+    minimum_value: int = None
+    maximum_value: int = None
 
 
 @dataclass(repr=True)

--- a/ads/opctl/operator/lowcode/forecast/operator_config.py
+++ b/ads/opctl/operator/lowcode/forecast/operator_config.py
@@ -38,12 +38,26 @@ class PreprocessingSteps(DataClassSerializable):
 
 
 @dataclass(repr=True)
+class PostprocessingSteps(DataClassSerializable):
+    """Class representing postprocessing steps for operator."""
+
+    set_min_forecast: int = 0
+
+
+@dataclass(repr=True)
 class DataPreprocessor(DataClassSerializable):
     """Class representing operator specification preprocessing details."""
 
     enabled: bool = True
     steps: PreprocessingSteps = field(default_factory=PreprocessingSteps)
 
+
+@dataclass(repr=True)
+class DataPostprocessor(DataClassSerializable):
+    """Class representing operator specification preprocessing details."""
+
+    enabled: bool = False
+    steps: PostprocessingSteps = field(default_factory=PostprocessingSteps)
 
 @dataclass(repr=True)
 class Tuning(DataClassSerializable):
@@ -71,6 +85,7 @@ class ForecastOperatorSpec(DataClassSerializable):
     local_explanation_filename: str = None
     target_column: str = None
     preprocessing: DataPreprocessor = field(default_factory=DataPreprocessor)
+    postprocessing: DataPostprocessor = field(default_factory=DataPostprocessor)
     datetime_column: DateTimeColumn = field(default_factory=DateTimeColumn)
     target_category_columns: List[str] = field(default_factory=list)
     generate_report: bool = None
@@ -97,6 +112,9 @@ class ForecastOperatorSpec(DataClassSerializable):
         self.report_filename = self.report_filename or "report.html"
         self.preprocessing = (
             self.preprocessing if self.preprocessing is not None else DataPreprocessor(enabled=True)
+        )
+        self.postprocessing = (
+            self.postprocessing if self.postprocessing is not None else DataPostprocessor(enabled=False)
         )
         # For Report Generation. When user doesn't specify defaults to True
         self.generate_report = (

--- a/ads/opctl/operator/lowcode/forecast/schema.yaml
+++ b/ads/opctl/operator/lowcode/forecast/schema.yaml
@@ -317,35 +317,16 @@ spec:
       type: dict
       required: false
       schema:
-        set_min_forecast:
+        minimum_value:
           type: integer
           required: false
           meta:
             description: "This can be used to define the minimum forecast in the output."
-        set_max_forcast:
+        maximum_value:
           type: integer
           required: false
           meta:
             description: "This can be used to define the maximum forecast in the output."
-
-    postprocessing:
-      type: dict
-      required: false
-      schema:
-        enabled:
-          type: boolean
-          required: false
-          default: false
-          meta:
-            description: "postprocessing can be disabled using this flag, Defaults to false"
-        steps:
-          type: dict
-          required: false
-          schema:
-            set_min_forecast:
-              type: integer
-              required: false
-              default: 0
 
     generate_explanations:
       type: boolean

--- a/ads/opctl/operator/lowcode/forecast/schema.yaml
+++ b/ads/opctl/operator/lowcode/forecast/schema.yaml
@@ -298,43 +298,35 @@ spec:
       type: dict
       required: false
       schema:
-        enabled:
-          type: boolean
+        missing_value_imputation:
+          type: string
           required: false
-          default: true
+          default: "linear_interpolation"
           meta:
-            description: "preprocessing and feature engineering can be disabled using this flag, Defaults to true"
-        steps:
-          type: dict
+            description: "Method to handle missing values in the dataset. Default is 'linear_interpolation'.
+             Other options are 'median', 'none' and 'mean'"
+        outlier_treatment:
+          type: string
           required: false
-          schema:
-            missing_value_imputation:
-              type: boolean
-              required: false
-              default: false
-            outlier_treatment:
-              type: boolean
-              required: false
-              default: false
+          default: mean
+          meta:
+            description: "Method to handle outliers in the data. Default is 'zscore_with_mean',
+              which can be disabled by setting it to 'none.'"
 
     postprocessing:
       type: dict
       required: false
       schema:
-        enabled:
-          type: boolean
+        set_min_forecast:
+          type: integer
           required: false
-          default: false
           meta:
-            description: "postprocessing can be disabled using this flag, Defaults to false"
-        steps:
-          type: dict
+            description: "This can be used to define the minimum forecast in the output."
+        set_max_forcast:
+          type: integer
           required: false
-          schema:
-            set_min_forecast:
-              type: integer
-              required: false
-              default: 0
+          meta:
+            description: "This can be used to define the maximum forecast in the output."
 
     generate_explanations:
       type: boolean

--- a/ads/opctl/operator/lowcode/forecast/schema.yaml
+++ b/ads/opctl/operator/lowcode/forecast/schema.yaml
@@ -317,6 +317,25 @@ spec:
               required: false
               default: false
 
+    postprocessing:
+      type: dict
+      required: false
+      schema:
+        enabled:
+          type: boolean
+          required: false
+          default: false
+          meta:
+            description: "postprocessing can be disabled using this flag, Defaults to false"
+        steps:
+          type: dict
+          required: false
+          schema:
+            set_min_forecast:
+              type: integer
+              required: false
+              default: 0
+
     generate_explanations:
       type: boolean
       required: false

--- a/docs/source/user_guide/operators/forecasting_operator/yaml_schema.rst
+++ b/docs/source/user_guide/operators/forecasting_operator/yaml_schema.rst
@@ -49,7 +49,12 @@ Here is an example forecast.yaml with every parameter specified:
 
     * **tuning**: (optional) This dictionary specific details around tuning the NeuralProphet and Prophet models.
         * **n_trials**: The number of separate tuning jobs to run. Increasing this integer increases the time to completion, but may improve the quality.
-    * **preprocessing**: (optional) Preprocessing and feature engineering can be disabled using this flag, Defaults to true
+    * **preprocessing**: (optional) This dictionary contains steps for preprocessing such as missing_value_imputation, outlier_treatment
+        * **missing_value_imputation** (optional) Method to handle missing values in the dataset. Default is 'linear_interpolation'. Other options are 'median', 'none' and 'mean'
+        * **outlier_treatment** (optional) Method to handle outliers in the data. Default is 'zscore_with_mean', which can be disabled by setting it to 'none.'
+    * **postprocessing**: (optional) This dictionary contains steps for postprocessing such as setting min, max values.
+        * **minimum_value** (optional) This can be used to define the minimum forecast in the output.
+        * **maximum_value** (optional) This can be used to define the maximum forecast in the output.
     * **metric**: (optional) The metric to select across. Users can select among: MAPE, RMSE, MSE, and SMAPE
     * **confidence_interval_width**: (optional) The width of the confidence interval to caluclate in the forecast and report.html. Defaults to 0.80 meaning an 80% confidence interval   
 

--- a/tests/operators/forecast/test_errors.py
+++ b/tests/operators/forecast/test_errors.py
@@ -196,7 +196,7 @@ def populate_yaml(
 ):
     if historical_data_path is None:
         historical_data_path, additional_data_path, test_data_path = setup_rossman()
-    assert tmpdirname is not None, "Error casued from incomplete setup function"
+    assert tmpdirname is not None, "Error caused from incomplete setup function"
 
     output_data_path = output_data_path or f"{tmpdirname}/results"
     yaml_i = deepcopy(TEMPLATE_YAML)
@@ -397,7 +397,7 @@ def test_0_series(operator_setup, model):
         historical_data_path=historical_data_path,
         additional_data_path=additional_data_path,
         test_data_path=test_data_path,
-        preprocessing={"enabled": False},
+        preprocessing={"missing_value_imputation": "none", "outlier_treatment": "none"},
     )
     with pytest.raises(DataMismatchError):
         run_yaml(
@@ -493,10 +493,9 @@ def test_disabling_outlier_treatment(operator_setup):
         item not in input_vals_without_outlier for item in outliers
     ), "forecast file should not contain any outliers"
 
-    # switching off outlier_treatment
-    preprocessing_steps = {"missing_value_imputation": True, "outlier_treatment": False}
-    preprocessing = {"enabled": True, "steps": preprocessing_steps}
-    yaml_i["spec"]["preprocessing"] = preprocessing
+    # switching off outlier_treatment and using mean for MVI
+    preprocessing_steps = {"missing_value_imputation": "mean", "outlier_treatment": "none"}
+    yaml_i["spec"]["preprocessing"] = preprocessing_steps
     run_yaml(
         tmpdirname=tmpdirname,
         yaml_i=yaml_i,
@@ -535,14 +534,14 @@ def test_2_series(operator_setup, model):
     historical_data_path, additional_data_path, test_data_path = setup_artificial_data(
         tmpdirname, hist_data, add_data, test_data
     )
-    preprocessing_steps = {"missing_value_imputation": True, "outlier_treatment": False}
+    preprocessing_steps = {"outlier_treatment": "none"}
     yaml_i, output_data_path = populate_yaml(
         tmpdirname=tmpdirname,
         model=model,
         historical_data_path=historical_data_path,
         additional_data_path=additional_data_path,
         test_data_path=test_data_path,
-        preprocessing={"enabled": True, "steps": preprocessing_steps},
+        preprocessing= preprocessing_steps
     )
     with pytest.raises(DataMismatchError):
         # 4 columns in historical data, but only 1 cat col specified
@@ -573,10 +572,10 @@ def test_all_series_failure(model):
         historical_data_path=historical_data_path,
         additional_data_path=additional_data_path,
     )
-    preprocessing_steps = {"missing_value_imputation": True, "outlier_treatment": False}
+    preprocessing_steps = {"outlier_treatment": "none"}
     yaml_i["spec"]["model"] = model
     yaml_i["spec"]["horizon"] = 10
-    yaml_i["spec"]["preprocessing"] = {"enabled": True, "steps": preprocessing_steps}
+    yaml_i["spec"]["preprocessing"] = preprocessing_steps
     if yaml_i["spec"].get("additional_data") is not None and model != "autots":
         yaml_i["spec"]["generate_explanations"] = True
     if model == "autots":
@@ -651,7 +650,7 @@ def test_arima_automlx_errors(operator_setup, model):
      any supported types according to the casting rule ''safe''
     Added label encoding before passing data to explainer
     """
-    preprocessing_steps = {"missing_value_imputation": True, "outlier_treatment": False}
+    preprocessing_steps = {"outlier_treatment": "none"}
     yaml_i["spec"]["horizon"] = 10
     yaml_i["spec"]["preprocessing"] = preprocessing_steps
     yaml_i["spec"]["generate_explanations"] = True


### PR DESCRIPTION
[ODSC-61573](https://jira.oci.oraclecorp.com/browse/ODSC-61573)

The PR includes following enhancements: 
* Simplified schema for pre and post processing.
* For **Missing Value Imputation** the default method is set to `linear_interpolation`. Added more options  e.g. `median`, `none`, and `mean`.
* For **Outlier Handling**   the default method for handling outliers is `zscore_with_mean`, which can be disabled by setting it to `none`. This method uses the z-score to identify anomalies and replaces them with the mean.
* Added `maximum_value` and `minimum_value` as post processing steps to control / clip the output for forecasting operator. 