### PR TITLE
Passing Early stopping params to SMC container for finetuning

### DIFF
--- a/ads/aqua/extension/finetune_handler.py
+++ b/ads/aqua/extension/finetune_handler.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
@@ -9,8 +8,8 @@ from urllib.parse import urlparse
 from tornado.web import HTTPError
 
 from ads.aqua.common.decorator import handle_exceptions
-from ads.aqua.extension.errors import Errors
 from ads.aqua.extension.base_handler import AquaAPIhandler
+from ads.aqua.extension.errors import Errors
 from ads.aqua.extension.utils import validate_function_parameters
 from ads.aqua.finetuning import AquaFineTuningApp
 from ads.aqua.finetuning.entities import CreateFineTuningDetails

--- a/ads/aqua/finetuning/entities.py
+++ b/ads/aqua/finetuning/entities.py
@@ -100,3 +100,5 @@ class CreateFineTuningDetails(DataClassSerializable):
     log_id: Optional[str] = None
     log_group_id: Optional[str] = None
     force_overwrite: Optional[bool] = False
+    early_stopping_patience: Optional[int] = None
+    early_stopping_threshold: Optional[float] = 0.0

--- a/ads/aqua/finetuning/entities.py
+++ b/ads/aqua/finetuning/entities.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 from dataclasses import dataclass, field
@@ -14,9 +13,9 @@ class AquaFineTuningParams(DataClassSerializable):
     epochs: int
     learning_rate: Optional[float] = None
     sample_packing: Optional[bool] = "auto"
-    batch_size: Optional[
-        int
-    ] = None  # make it batch_size for user, but internally this is micro_batch_size
+    batch_size: Optional[int] = (
+        None  # make it batch_size for user, but internally this is micro_batch_size
+    )
     sequence_len: Optional[int] = None
     pad_to_sequence_len: Optional[bool] = None
     lora_r: Optional[int] = None
@@ -24,6 +23,8 @@ class AquaFineTuningParams(DataClassSerializable):
     lora_dropout: Optional[float] = None
     lora_target_linear: Optional[bool] = None
     lora_target_modules: Optional[List] = None
+    early_stopping_patience: Optional[int] = None
+    early_stopping_threshold: Optional[float] = None
 
 
 @dataclass(repr=False)
@@ -100,5 +101,3 @@ class CreateFineTuningDetails(DataClassSerializable):
     log_id: Optional[str] = None
     log_group_id: Optional[str] = None
     force_overwrite: Optional[bool] = False
-    early_stopping_patience: Optional[int] = None
-    early_stopping_threshold: Optional[float] = 0.0

--- a/ads/aqua/finetuning/finetuning.py
+++ b/ads/aqua/finetuning/finetuning.py
@@ -532,9 +532,9 @@ class AquaFineTuningApp(AquaApp):
         early_stopping_threshold: float = 0.0
     ) -> str:
         """Builds the oci launch cmd for fine tuning container runtime."""
-        oci_launch_cmd = f"--training_data {dataset_path} --output_dir {report_path} --val_set_size {val_set_size}"
+        oci_launch_cmd = f"--training_data {dataset_path} --output_dir {report_path} --val_set_size {val_set_size} "
         if early_stopping_patience:
-            oci_launch_cmd += f" --early_stopping_patience {early_stopping_patience} --early_stopping_threshold {early_stopping_threshold}"
+            oci_launch_cmd += f"--early_stopping_patience {early_stopping_patience} --early_stopping_threshold {early_stopping_threshold} "
         for key, value in asdict(parameters).items():
             if value is not None:
                 if key == "batch_size":

--- a/ads/aqua/finetuning/finetuning.py
+++ b/ads/aqua/finetuning/finetuning.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import json
 import os
-from dataclasses import asdict, fields, MISSING
+from dataclasses import MISSING, asdict, fields
 from typing import Dict
 
 from oci.data_science.models import (
@@ -14,7 +13,7 @@ from oci.data_science.models import (
     UpdateModelProvenanceDetails,
 )
 
-from ads.aqua import ODSC_MODEL_COMPARTMENT_OCID, logger
+from ads.aqua import logger
 from ads.aqua.app import AquaApp
 from ads.aqua.common.enums import Resource, Tags
 from ads.aqua.common.errors import AquaFileExistsError, AquaValueError
@@ -22,6 +21,7 @@ from ads.aqua.common.utils import (
     get_container_image,
     upload_local_to_os,
 )
+from ads.aqua.config.config import get_finetuning_config_defaults
 from ads.aqua.constants import (
     DEFAULT_FT_BATCH_SIZE,
     DEFAULT_FT_BLOCK_STORAGE_SIZE,
@@ -31,7 +31,6 @@ from ads.aqua.constants import (
     UNKNOWN,
     UNKNOWN_DICT,
 )
-from ads.aqua.config.config import get_finetuning_config_defaults
 from ads.aqua.data import AquaResourceIdentifier
 from ads.aqua.finetuning.constants import *
 from ads.aqua.finetuning.entities import *
@@ -132,7 +131,7 @@ class AquaFineTuningApp(AquaApp):
             or create_fine_tuning_details.validation_set_size >= 1
         ):
             raise AquaValueError(
-                f"Fine tuning validation set size should be a float number in between [0, 1)."
+                "Fine tuning validation set size should be a float number in between [0, 1)."
             )
 
         if create_fine_tuning_details.replica < DEFAULT_FT_REPLICA:
@@ -334,8 +333,6 @@ class AquaFineTuningApp(AquaApp):
                 parameters=ft_parameters,
                 ft_container=ft_container,
                 is_custom_container=is_custom_container,
-                early_stopping_patience=create_fine_tuning_details.early_stopping_patience,
-                early_stopping_threshold=create_fine_tuning_details.early_stopping_threshold
             )
         ).create()
         logger.debug(
@@ -396,7 +393,7 @@ class AquaFineTuningApp(AquaApp):
         )
         # track shapes that were used for fine-tune creation
         self.telemetry.record_event_async(
-            category=f"aqua/service/finetune/create/shape/",
+            category="aqua/service/finetune/create/shape/",
             action=f"{create_fine_tuning_details.shape_name}x{create_fine_tuning_details.replica}",
             **telemetry_kwargs,
         )
@@ -479,8 +476,6 @@ class AquaFineTuningApp(AquaApp):
         ft_container: str = None,
         finetuning_params: str = None,
         is_custom_container: bool = False,
-        early_stopping_patience: int = None,
-        early_stopping_threshold: float = 0.0
     ) -> Runtime:
         """Builds fine tuning runtime for Job."""
         container = (
@@ -509,8 +504,6 @@ class AquaFineTuningApp(AquaApp):
                         val_set_size=val_set_size,
                         parameters=parameters,
                         finetuning_params=finetuning_params,
-                        early_stopping_patience=early_stopping_patience,
-                        early_stopping_threshold=early_stopping_threshold
                     ),
                     "CONDA_BUCKET_NS": CONDA_BUCKET_NS,
                 }
@@ -528,13 +521,9 @@ class AquaFineTuningApp(AquaApp):
         val_set_size: float,
         parameters: AquaFineTuningParams,
         finetuning_params: str = None,
-        early_stopping_patience: int = None,
-        early_stopping_threshold: float = 0.0
     ) -> str:
         """Builds the oci launch cmd for fine tuning container runtime."""
         oci_launch_cmd = f"--training_data {dataset_path} --output_dir {report_path} --val_set_size {val_set_size} "
-        if early_stopping_patience:
-            oci_launch_cmd += f"--early_stopping_patience {early_stopping_patience} --early_stopping_threshold {early_stopping_threshold} "
         for key, value in asdict(parameters).items():
             if value is not None:
                 if key == "batch_size":
@@ -543,6 +532,12 @@ class AquaFineTuningApp(AquaApp):
                     oci_launch_cmd += f"--num_{key} {value} "
                 elif key == "lora_target_modules":
                     oci_launch_cmd += f"--{key} {','.join(str(k) for k in value)} "
+                elif key == "early_stopping_patience":
+                    if value != 0:
+                        oci_launch_cmd += f"--{key} {value} "
+                elif key == "early_stopping_threshold":
+                    if "early_stopping_patience" in oci_launch_cmd:
+                        oci_launch_cmd += f"--{key} {value} "
                 else:
                     oci_launch_cmd += f"--{key} {value} "
 

--- a/ads/aqua/finetuning/finetuning.py
+++ b/ads/aqua/finetuning/finetuning.py
@@ -334,6 +334,8 @@ class AquaFineTuningApp(AquaApp):
                 parameters=ft_parameters,
                 ft_container=ft_container,
                 is_custom_container=is_custom_container,
+                early_stopping_patience=create_fine_tuning_details.early_stopping_patience,
+                early_stopping_threshold=create_fine_tuning_details.early_stopping_threshold
             )
         ).create()
         logger.debug(
@@ -477,6 +479,8 @@ class AquaFineTuningApp(AquaApp):
         ft_container: str = None,
         finetuning_params: str = None,
         is_custom_container: bool = False,
+        early_stopping_patience: int = None,
+        early_stopping_threshold: float = 0.0
     ) -> Runtime:
         """Builds fine tuning runtime for Job."""
         container = (
@@ -505,6 +509,8 @@ class AquaFineTuningApp(AquaApp):
                         val_set_size=val_set_size,
                         parameters=parameters,
                         finetuning_params=finetuning_params,
+                        early_stopping_patience=early_stopping_patience,
+                        early_stopping_threshold=early_stopping_threshold
                     ),
                     "CONDA_BUCKET_NS": CONDA_BUCKET_NS,
                 }
@@ -522,9 +528,11 @@ class AquaFineTuningApp(AquaApp):
         val_set_size: float,
         parameters: AquaFineTuningParams,
         finetuning_params: str = None,
+        early_stopping_patience: int = None,
+        early_stopping_threshold: float = 0.0
     ) -> str:
         """Builds the oci launch cmd for fine tuning container runtime."""
-        oci_launch_cmd = f"--training_data {dataset_path} --output_dir {report_path} --val_set_size {val_set_size} "
+        oci_launch_cmd = f"--training_data {dataset_path} --output_dir {report_path} --val_set_size {val_set_size} --early_stopping_patience {early_stopping_patience} --early_stopping_threshold {early_stopping_threshold}"
         for key, value in asdict(parameters).items():
             if value is not None:
                 if key == "batch_size":

--- a/ads/aqua/finetuning/finetuning.py
+++ b/ads/aqua/finetuning/finetuning.py
@@ -532,7 +532,9 @@ class AquaFineTuningApp(AquaApp):
         early_stopping_threshold: float = 0.0
     ) -> str:
         """Builds the oci launch cmd for fine tuning container runtime."""
-        oci_launch_cmd = f"--training_data {dataset_path} --output_dir {report_path} --val_set_size {val_set_size} --early_stopping_patience {early_stopping_patience} --early_stopping_threshold {early_stopping_threshold}"
+        oci_launch_cmd = f"--training_data {dataset_path} --output_dir {report_path} --val_set_size {val_set_size}"
+        if early_stopping_patience:
+            oci_launch_cmd += f" --early_stopping_patience {early_stopping_patience} --early_stopping_threshold {early_stopping_threshold}"
         for key, value in asdict(parameters).items():
             if value is not None:
                 if key == "batch_size":


### PR DESCRIPTION
This PR intends to add changes in create FT api to pass early stopping params to SMC container if provided by user
<img width="1117" alt="Screenshot 2024-10-17 at 7 33 11 PM" src="https://github.com/user-attachments/assets/f82ba3c9-2b01-4ee9-a816-fbec8d366ba6">

## UTs
<img width="1453" alt="Screenshot 2024-10-17 at 8 17 20 PM" src="https://github.com/user-attachments/assets/b0f9920f-7fc0-4a9d-a095-2c4409c3a782">
<img width="1406" alt="Screenshot 2024-10-18 at 2 10 19 PM" src="https://github.com/user-attachments/assets/eb067261-f01e-485f-a14d-3350bf276dea">


