### PR TITLE
Adding model task in MD tags

### DIFF
--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -46,7 +46,6 @@ from ads.common.utils import get_log_links
 from ads.config import (
     AQUA_CONFIG_FOLDER,
     AQUA_DEPLOYMENT_CONTAINER_METADATA_NAME,
-    AQUA_DEPLOYMENT_CONTAINER_OVERRIDE_FLAG_METADATA_NAME,
     AQUA_MODEL_DEPLOYMENT_CONFIG,
     AQUA_MODEL_DEPLOYMENT_CONFIG_DEFAULTS,
     COMPARTMENT_OCID,
@@ -87,26 +86,26 @@ class AquaDeploymentApp(AquaApp):
 
     @telemetry(entry_point="plugin=deployment&action=create", name="aqua")
     def create(
-            self,
-            model_id: str,
-            instance_shape: str,
-            display_name: str,
-            instance_count: int = None,
-            log_group_id: str = None,
-            access_log_id: str = None,
-            predict_log_id: str = None,
-            compartment_id: str = None,
-            project_id: str = None,
-            description: str = None,
-            bandwidth_mbps: int = None,
-            web_concurrency: int = None,
-            server_port: int = None,
-            health_check_port: int = None,
-            env_var: Dict = None,
-            container_family: str = None,
-            memory_in_gbs: Optional[float] = None,
-            ocpus: Optional[float] = None,
-            model_file: Optional[str] = None,
+        self,
+        model_id: str,
+        instance_shape: str,
+        display_name: str,
+        instance_count: int = None,
+        log_group_id: str = None,
+        access_log_id: str = None,
+        predict_log_id: str = None,
+        compartment_id: str = None,
+        project_id: str = None,
+        description: str = None,
+        bandwidth_mbps: int = None,
+        web_concurrency: int = None,
+        server_port: int = None,
+        health_check_port: int = None,
+        env_var: Dict = None,
+        container_family: str = None,
+        memory_in_gbs: Optional[float] = None,
+        ocpus: Optional[float] = None,
+        model_file: Optional[str] = None,
     ) -> "AquaDeployment":
         """
         Creates a new Aqua deployment
@@ -175,6 +174,7 @@ class AquaDeploymentApp(AquaApp):
                 tags[tag] = aqua_model.freeform_tags[tag]
 
         tags.update({Tags.AQUA_MODEL_NAME_TAG: aqua_model.display_name})
+        tags.update({Tags.TASK: aqua_model.freeform_tags.get(Tags.TASK, None)})
 
         # Set up info to get deployment config
         config_source_id = model_id
@@ -231,8 +231,7 @@ class AquaDeploymentApp(AquaApp):
             env_var.update({"FT_MODEL": f"{fine_tune_output_path}"})
 
         container_type_key = self._get_container_type_key(
-            model=aqua_model,
-            container_family=container_family
+            model=aqua_model, container_family=container_family
         )
 
         # fetch image name from config
@@ -248,7 +247,11 @@ class AquaDeploymentApp(AquaApp):
         model_format = model_formats_str.split(",")
 
         # Figure out a better way to handle this in future release
-        if ModelFormat.GGUF.value in model_format and container_type_key.lower() == InferenceContainerTypeFamily.AQUA_LLAMA_CPP_CONTAINER_FAMILY:
+        if (
+            ModelFormat.GGUF.value in model_format
+            and container_type_key.lower()
+            == InferenceContainerTypeFamily.AQUA_LLAMA_CPP_CONTAINER_FAMILY
+        ):
             if model_file is not None:
                 logger.info(
                     f"Overriding {model_file} as model_file for model {aqua_model.id}."
@@ -299,8 +302,8 @@ class AquaDeploymentApp(AquaApp):
         if user_params:
             # todo: remove this check in the future version, logic to be moved to container_index
             if (
-                    container_type_key.lower()
-                    == InferenceContainerTypeFamily.AQUA_LLAMA_CPP_CONTAINER_FAMILY
+                container_type_key.lower()
+                == InferenceContainerTypeFamily.AQUA_LLAMA_CPP_CONTAINER_FAMILY
             ):
                 # AQUA_LLAMA_CPP_CONTAINER_FAMILY container uses uvicorn that required model/server params
                 # to be set as env vars
@@ -422,9 +425,8 @@ class AquaDeploymentApp(AquaApp):
                     f"for model {model.id}. For unverified Aqua models, {AQUA_DEPLOYMENT_CONTAINER_METADATA_NAME} should be"
                     f"set and value can be one of {', '.join(InferenceContainerTypeFamily.values())}."
                 ) from err
-            
+
         return container_type_key
-        
 
     @telemetry(entry_point="plugin=deployment&action=list", name="aqua")
     def list(self, **kwargs) -> List["AquaDeployment"]:
@@ -453,8 +455,8 @@ class AquaDeploymentApp(AquaApp):
         for model_deployment in model_deployments:
             oci_aqua = (
                 (
-                        Tags.AQUA_TAG in model_deployment.freeform_tags
-                        or Tags.AQUA_TAG.lower() in model_deployment.freeform_tags
+                    Tags.AQUA_TAG in model_deployment.freeform_tags
+                    or Tags.AQUA_TAG.lower() in model_deployment.freeform_tags
                 )
                 if model_deployment.freeform_tags
                 else False
@@ -508,8 +510,8 @@ class AquaDeploymentApp(AquaApp):
 
         oci_aqua = (
             (
-                    Tags.AQUA_TAG in model_deployment.freeform_tags
-                    or Tags.AQUA_TAG.lower() in model_deployment.freeform_tags
+                Tags.AQUA_TAG in model_deployment.freeform_tags
+                or Tags.AQUA_TAG.lower() in model_deployment.freeform_tags
             )
             if model_deployment.freeform_tags
             else False
@@ -526,8 +528,8 @@ class AquaDeploymentApp(AquaApp):
         log_group_name = ""
 
         logs = (
-                model_deployment.category_log_details.access
-                or model_deployment.category_log_details.predict
+            model_deployment.category_log_details.access
+            or model_deployment.category_log_details.predict
         )
         if logs:
             log_id = logs.log_id
@@ -582,9 +584,9 @@ class AquaDeploymentApp(AquaApp):
         return config
 
     def get_deployment_default_params(
-            self,
-            model_id: str,
-            instance_shape: str,
+        self,
+        model_id: str,
+        instance_shape: str,
     ) -> List[str]:
         """Gets the default params set in the deployment configs for the given model and instance shape.
 
@@ -616,8 +618,8 @@ class AquaDeploymentApp(AquaApp):
             )
 
         if (
-                container_type_key
-                and container_type_key in InferenceContainerTypeFamily.values()
+            container_type_key
+            and container_type_key in InferenceContainerTypeFamily.values()
         ):
             deployment_config = self.get_deployment_config(model_id)
             config_params = (
@@ -640,10 +642,10 @@ class AquaDeploymentApp(AquaApp):
         return default_params
 
     def validate_deployment_params(
-            self,
-            model_id: str,
-            params: List[str] = None,
-            container_family: str = None,
+        self,
+        model_id: str,
+        params: List[str] = None,
+        container_family: str = None,
     ) -> Dict:
         """Validate if the deployment parameters passed by the user can be overridden. Parameter values are not
         validated, only param keys are validated.
@@ -666,8 +668,7 @@ class AquaDeploymentApp(AquaApp):
         if params:
             model = DataScienceModel.from_id(model_id)
             container_type_key = self._get_container_type_key(
-                model=model,
-                container_family=container_family
+                model=model, container_family=container_family
             )
 
             container_config = get_container_config()
@@ -689,9 +690,9 @@ class AquaDeploymentApp(AquaApp):
 
     @staticmethod
     def _find_restricted_params(
-            default_params: Union[str, List[str]],
-            user_params: Union[str, List[str]],
-            container_family: str,
+        default_params: Union[str, List[str]],
+        user_params: Union[str, List[str]],
+        container_family: str,
     ) -> List[str]:
         """Returns a list of restricted params that user chooses to override when creating an Aqua deployment.
         The default parameters coming from the container index json file cannot be overridden.


### PR DESCRIPTION
This PR is intended to add model specific task tag in Model deployment tags while creation of model deployment.
This will reduce number of api calls in client to get the model tags for Model deployment.


## Curl command to test:

```
curl --location 'http://localhost:8888/aqua/deployments' \
--header 'Content-Type: application/json' \
--header 'Cookie: _xsrf=2|e9946301|bf91d5ae9f5db1d274d94b27e85a9e0c|1729063791; username-localhost-8888=2|1:0|10:1729063791|23:username-localhost-8888|196:eyJ1c2VybmFtZSI6ICIwYzE2NDliMGMxZjc0NmViYjdhMmFhNDAyZTVjMGFhOSIsICJuYW1lIjogIkFub255bW91cyBUYXlnZXRlIiwgImRpc3BsYXlfbmFtZSI6ICJBbm9ueW1vdXMgVGF5Z2V0ZSIsICJpbml0aWFscyI6ICJBVCIsICJjb2xvciI6IG51bGx9|620ae24da6b946a64d69e881d8934756fcbb805a109cb7b71561417cdb8bc20d' \
--data '{
    "compartment_id": "ocid1.compartment.oc1...<ocid>",
    "display_name": "gemma-2b-it-md",
    "instance_count": 1,
    "bandwidth_mbps": 10,
    "model_id": "ocid1.datasciencemodel.oc1.iad...<ocid>",
    "instance_shape": "VM.GPU.A10.1"
}'
```
