### PR TITLE
Removing task parameter from list models HF api

### DIFF
--- a/ads/aqua/common/utils.py
+++ b/ads/aqua/common/utils.py
@@ -1071,7 +1071,6 @@ def list_hf_models(query: str) -> List[str]:
     try:
         models = HfApi().list_models(
             model_name=query,
-            task="text-generation",
             sort="downloads",
             direction=-1,
             limit=20,


### PR DESCRIPTION
This PR is intended to remove task parameter from HF list api to allow user to register unverified vision/embedding models