### PR TITLE
Replace hide_index to hide in ads

### DIFF
--- a/ads/dataset/dataset.py
+++ b/ads/dataset/dataset.py
@@ -202,7 +202,7 @@ class ADSDataset(PandasDataset):
                     self.sampled_df.head(5)
                     .style.set_table_styles(utils.get_dataframe_styles())
                     .set_table_attributes("class=table")
-                    .hide_index()
+                    .hide()
                     .to_html()
                 )
             )
@@ -261,7 +261,7 @@ class ADSDataset(PandasDataset):
                         utils.horizontal_scrollable_div(
                             self.style.set_table_styles(utils.get_dataframe_styles())
                             .set_table_attributes("class=table")
-                            .hide_index()
+                            .hide()
                             .to_html()
                         )
                     )

--- a/ads/dataset/factory.py
+++ b/ads/dataset/factory.py
@@ -366,7 +366,7 @@ class DatasetFactory:
             display(
                 HTML(
                     list_df.style.set_table_attributes("class=table")
-                    .hide_index()
+                    .hide()
                     .to_html()
                 )
             )


### PR DESCRIPTION
### Description

Bug Fix for issue #987 

`hide_index()` has been deprecated in pandas and has been replaced with `hide()`. This PR updates all occurrences of `hide_index` in ads.

![image](https://github.com/user-attachments/assets/d71b1a75-d490-4247-8837-47007d6723c8)


