### PR TITLE
Adding cache delete method for model details

### DIFF
--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -164,12 +164,13 @@ class AquaModelHandler(AquaAPIhandler):
 
         enable_finetuning = input_data.get("enable_finetuning")
         task = input_data.get("task")
+        app=AquaModelApp()
         self.finish(
-            AquaModelApp().edit_registered_model(
+            app.edit_registered_model(
                 id, inference_container, enable_finetuning, task
             )
         )
-        AquaModelApp().clear_model_details_cache(model_id=id)
+        app.clear_model_details_cache(model_id=id)
 
 
 class AquaModelLicenseHandler(AquaAPIhandler):

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -169,6 +169,7 @@ class AquaModelHandler(AquaAPIhandler):
                 id, inference_container, enable_finetuning, task
             )
         )
+        AquaModelApp().clear_model_details_cache(model_id=id)
 
 
 class AquaModelLicenseHandler(AquaAPIhandler):

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -718,6 +718,27 @@ class AquaModelApp(AquaApp):
                 }
         return res
 
+    def clear_model_details_cache(self,model_id):
+        """
+        Allows user to clear model details cache item
+        Returns
+        -------
+            dict with the key used, and True if cache has the key that needs to be deleted.
+        """
+        res={}
+        logger.info("Clearing _service_model_details_cache")
+        with self._cache_lock:
+            if model_id in self._service_model_details_cache:
+                self._service_model_details_cache.pop(key=model_id)
+                res={
+                    "key":{
+                        "model_id":model_id
+                    },
+                    "cache_deleted":True
+                }
+
+        return res
+
     @staticmethod
     def list_valid_inference_containers():
         containers = list(

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -718,24 +718,19 @@ class AquaModelApp(AquaApp):
                 }
         return res
 
-    def clear_model_details_cache(self,model_id):
+    def clear_model_details_cache(self, model_id):
         """
         Allows user to clear model details cache item
         Returns
         -------
             dict with the key used, and True if cache has the key that needs to be deleted.
         """
-        res={}
+        res = {}
         logger.info("Clearing _service_model_details_cache")
         with self._cache_lock:
             if model_id in self._service_model_details_cache:
                 self._service_model_details_cache.pop(key=model_id)
-                res={
-                    "key":{
-                        "model_id":model_id
-                    },
-                    "cache_deleted":True
-                }
+                res = {"key": {"model_id": model_id}, "cache_deleted": True}
 
         return res
 

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -726,7 +726,7 @@ class AquaModelApp(AquaApp):
             dict with the key used, and True if cache has the key that needs to be deleted.
         """
         res = {}
-        logger.info("Clearing _service_model_details_cache")
+        logger.info(f"Clearing _service_model_details_cache for {model_id}")
         with self._cache_lock:
             if model_id in self._service_model_details_cache:
                 self._service_model_details_cache.pop(key=model_id)


### PR DESCRIPTION
This PR is intended to add delete model details cache method which will be helpful while editing default config for unverified models.  The cache needs to be deleted for the particular model for which update operation has been performed to get latest updated data in get call. 