### PR TITLE
Allow customizing TEI deployment

### DIFF
--- a/ads/aqua/extension/deployment_handler.py
+++ b/ads/aqua/extension/deployment_handler.py
@@ -103,6 +103,8 @@ class AquaDeploymentHandler(AquaAPIhandler):
         memory_in_gbs = input_data.get("memory_in_gbs")
         model_file = input_data.get("model_file")
         private_endpoint_id = input_data.get("private_endpoint_id")
+        container_image_uri = input_data.get("container_image_uri")
+        cmd_var = input_data.get("cmd_var")
 
         self.finish(
             AquaDeploymentApp().create(
@@ -126,6 +128,8 @@ class AquaDeploymentHandler(AquaAPIhandler):
                 memory_in_gbs=memory_in_gbs,
                 model_file=model_file,
                 private_endpoint_id=private_endpoint_id,
+                container_image_uri=container_image_uri,
+                cmd_var=cmd_var,
             )
         )
 

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -123,6 +123,7 @@ class AquaModelHandler(AquaAPIhandler):
         download_from_hf = (
             str(input_data.get("download_from_hf", "false")).lower() == "true"
         )
+        inference_container_uri = input_data.get("inference_container_uri")
 
         return self.finish(
             AquaModelApp().register(
@@ -134,6 +135,7 @@ class AquaModelHandler(AquaAPIhandler):
                 compartment_id=compartment_id,
                 project_id=project_id,
                 model_file=model_file,
+                inference_container_uri=inference_container_uri,
             )
         )
 

--- a/tests/unitary/with_extras/aqua/test_deployment_handler.py
+++ b/tests/unitary/with_extras/aqua/test_deployment_handler.py
@@ -130,6 +130,8 @@ class TestAquaDeploymentHandler(unittest.TestCase):
             ocpus=None,
             model_file=None,
             private_endpoint_id=None,
+            container_image_uri=None,
+            cmd_var=None,
         )
 
 


### PR DESCRIPTION
### Description

This PR covers the following:
- Updated handlers for TEI deployment that will let users customize container URI and add custom cmd_vars during TEI deployment. 
- The previous update missed the handler changes that were used for registering from object storage.
- Updated unit tests

### Unit Tests

```
> python -m pytest -q tests/unitary/with_extras/aqua/*
======================================== test session starts ========================================
platform darwin -- Python 3.8.19, pytest-7.4.4, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-26.0.0, cov-5.0.0, anyio-4.2.0, xdist-3.6.1
collected 249 items

tests/unitary/with_extras/aqua/test_cli.py ............................                       [  5%]
tests/unitary/with_extras/aqua/test_common_handler.py ...                                     [  6%]
tests/unitary/with_extras/aqua/test_config.py .                                               [  7%]
tests/unitary/with_extras/aqua/test_decorator.py ..........                                   [ 11%]
tests/unitary/with_extras/aqua/test_deployment.py .....................                       [ 19%]
tests/unitary/with_extras/aqua/test_deployment_handler.py ..s......                           [ 23%]
tests/unitary/with_extras/aqua/test_evaluation.py .............................               [ 34%]
tests/unitary/with_extras/aqua/test_evaluation_handler.py ......                              [ 37%]
tests/unitary/with_extras/aqua/test_evaluation_service_config.py .....................        [ 45%]
tests/unitary/with_extras/aqua/test_finetuning.py .......                                     [ 48%]
tests/unitary/with_extras/aqua/test_finetuning_handler.py .....                               [ 50%]
tests/unitary/with_extras/aqua/test_global.py ...                                             [ 51%]
tests/unitary/with_extras/aqua/test_handlers.py .................                             [ 58%]
tests/unitary/with_extras/aqua/test_model.py ..........................                       [ 69%]
tests/unitary/with_extras/aqua/test_model_handler.py .................                        [ 75%]
tests/unitary/with_extras/aqua/test_ui.py ................                                    [ 82%]
tests/unitary/with_extras/aqua/test_ui_handler.py ...............                             [ 88%]
tests/unitary/with_extras/aqua/test_ui_websocket_handler.py ....                              [ 89%]
tests/unitary/with_extras/aqua/test_utils.py ...........

================================== 248 passed, 1 skipped in 51.62s ==================================
```