### PR TITLE
ODSC-64654 register model artifact reference

### DIFF
--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -1405,6 +1405,26 @@ class DataScienceModel(Builder):
             restore_model_for_hours_specified=restore_model_for_hours_specified,
         )
 
+    def register_model_artifact_reference(self,bucket_uri_list: List[str]) -> None:
+        """
+        Registers model artifact references against a model.
+        Can be used for any model for which model-artifact doesn't exist yet. Requires to provide List of Object
+        Storage buckets_uri(s) which contain the artifacts.
+
+        Parameters
+        ----------
+        bucket_uri_list: List[str]
+            The list of OCI Object Storage URIs where model artifacts are present.
+            Example: [`oci://<bucket_name>@<namespace>/prefix/`, `oci://<bucket_name>@<namespace>/prefix/`].
+
+        Returns
+        -------
+        None
+        """
+        self.dsc_model.register_model_artifact_reference(
+            bucket_uri_list=bucket_uri_list
+        )
+
     def download_artifact(
         self,
         target_dir: str,

--- a/ads/model/service/oci_datascience_model.py
+++ b/ads/model/service/oci_datascience_model.py
@@ -26,7 +26,7 @@ from oci.data_science.models import (
     ExportModelArtifactDetails,
     ImportModelArtifactDetails,
     UpdateModelDetails,
-    WorkRequest,
+    WorkRequest, RegisterModelArtifactReferenceDetails, OSSModelArtifactReferenceDetails, ModelArtifactReferenceDetails,
 )
 from oci.exceptions import ServiceError
 
@@ -448,6 +448,54 @@ class OCIDataScienceModel(
         DataScienceWorkRequest(work_request_id).wait_work_request(
             progress_bar_description="Exporting model artifacts."
         )
+
+    @check_for_model_id(
+        msg="Model needs to be saved to the Model Catalog before the artifact can be registered against it."
+    )
+    def register_model_artifact_reference(self, bucket_uri_list: List[str]) -> None:
+        """
+        Registers model artifact references against a model.
+        Can be used for any model for which model-artifact doesn't exist yet. Requires to provide List of Object
+        Storage buckets_uri(s) which contain the artifacts.
+
+        Parameters
+        ----------
+        bucket_uri_list: List[str]
+            The list of OCI Object Storage URIs where model artifacts are present.
+            Example: [`oci://<bucket_name>@<namespace>/prefix/`, `oci://<bucket_name>@<namespace>/prefix/`].
+
+        Returns
+        -------
+        None
+        """
+        model_artifact_reference_details_list = []
+        for bucket_uri in bucket_uri_list:
+            bucket_details = ObjectStorageDetails.from_path(bucket_uri)
+            model_artifact_reference_details = OSSModelArtifactReferenceDetails()
+            model_artifact_reference_details.namespace = bucket_details.namespace
+            model_artifact_reference_details.bucket_name = bucket_details.bucket
+            if bucket_details.filepath is not None and bucket_details.filepath != "":
+                model_artifact_reference_details.prefix = bucket_details.filepath.strip('/')
+            model_artifact_reference_details_list.append(model_artifact_reference_details)
+
+        register_model_artifact_reference_details = RegisterModelArtifactReferenceDetails()
+        register_model_artifact_reference_details.model_artifact_references = model_artifact_reference_details_list
+
+        work_request_id = self.client.register_model_artifact_reference(
+            model_id=self.id,
+            register_model_artifact_reference_details=register_model_artifact_reference_details
+        ).headers["opc-work-request-id"]
+
+        # Show progress of model artifact references being registered
+        try :
+            DataScienceWorkRequest(work_request_id).wait_work_request(
+                progress_bar_description="Registering model artifact references."
+            )
+            logger.info("Artifact references registered successfully.")
+        except Exception as ex:
+            logger.error(f"WorkRequest: `{work_request_id}` failed. Fetching Work Request Error Logs.")
+            get_work_request_errors_response = self.client.list_work_request_errors(work_request_id)
+            logger.error(get_work_request_errors_response.data)
 
     @check_for_model_id(
         msg="Model needs to be saved to the Model Catalog before it can be updated."

--- a/docs/source/user_guide/model_catalog/model_catalog.rst
+++ b/docs/source/user_guide/model_catalog/model_catalog.rst
@@ -1554,3 +1554,44 @@ Restore Archived Model
 **********************
 
 The ``.restore_model()`` method of Model catalog restores the model for a specified number of hours. Restored models can be downloaded for 1-240 hours, defaulting to 24 hours.
+
+Register Model Artifact Reference
+**********************
+
+The ``.register_model_artifact_reference()`` method of Model catalog registers the references of your OCI Object Storage buckets where the artifact files are present against the model.
+
+By using this API, you can avoid the need to upload or export large model artifacts, and can simply give the references of the OCI Object Storage locations where your artifacts are present. The OCI Data Science will directly read artifact files from those locations when you create a deployment of the model.
+
+The input to this method is a List of bucket_uri(s). The URI syntax for the bucket_uri is:
+
+oci://<bucket_name>@<namespace>/<path>/
+
+Example -
+
+.. code-block:: python3
+
+    model.register_model_artifact_reference(
+        bucket_uri_list = ["oci://<bucket_name>@<namespace>/<path>/"]
+    )
+
+Important Points:
+
+1. The buckets provided should be of same region and have versioning enabled on them.
+
+2. The <path> is optional. If your files that you want to use for this model are within a path in the bucket, then path can be specified in the bucket_uri, else it can be skipped like below:
+
+    oci://<bucket_name>@<namespace>/
+
+3. The location specified by bucket_uri should have at-least one object within it.
+
+4. Make sure that the buckets provided has following IAM policy configured to allow the Data Science service to read artifact files from those Object Storage buckets in your tenancy. An administrator must configure these policies in `IAM <https://docs.oracle.com/iaas/Content/Identity/home1.htm>`_ in the Console.
+
+    .. parsed-literal::
+
+        allow any-user to read object-family in compartment <compartment> where ALL {target.bucket.name= '<bucket_name>', request.principal.type =  /\*datasciencemodel\*/}
+
+    If you want, you can have a more granular policy by having an additional filter on project_id like below, which will then give access to the bucket only to models present in the data science project specified in the filter.
+
+    .. parsed-literal::
+
+        allow any-user to read object-family in compartment <compartment> where ALL {target.bucket.name= '<bucket_name>', request.principal.type =  /\*datasciencemodel\*/, request.principal.project_id = '<project_ocid>'}

--- a/tests/unitary/default_setup/model/test_datascience_model.py
+++ b/tests/unitary/default_setup/model/test_datascience_model.py
@@ -817,6 +817,24 @@ class TestDataScienceModel:
                     )
                     mock_upload.assert_called()
 
+    @patch.object(OCIDataScienceModel, 'register_model_artifact_reference')
+    def test_register_model_artifact_reference(self, mock_register_model_artifact_reference):
+
+        # Sample input for the test
+        bucket_uri_list = [
+            "oci://bucket1@namespace1/prefix1/",
+            "oci://bucket2@namespace2/prefix2/"
+        ]
+
+        # Call the function with the test data
+        self.mock_dsc_model.register_model_artifact_reference(bucket_uri_list=bucket_uri_list)
+
+        # Assert that the mocked `register_model_artifact_reference` method was called once
+        # and with the expected arguments
+        mock_register_model_artifact_reference.assert_called_once_with(
+            bucket_uri_list=bucket_uri_list
+        )
+
     def test_download_artifact(self):
         """Tests downloading artifacts from the model catalog."""
         # Artifact size greater than 2GB


### PR DESCRIPTION
This Pull Request is for adding new API for Model by Reference, i.e. register_model_artifact_reference in DataScienceModel in ADS.
The new API will enable users to simply give us the object storage locations of their existing artifacts as reference for using against a newly created DataScienceModel, instead of having to upload or export artifacts which is a costly operation.
API Spec :- https://confluence.oci.oraclecorp.com/pages/viewpage.action?spaceKey=ODSC&title=API+changes+for+Model+store+for+Aqua
It has been tested in my local environment - Attached Screenshots. One screenshot is for successful scenario, and another is for one of the failure scenarios to demonstrate that in case of failure, we are fetching the work request logs and showing the same in ADS logs.
<img width="1512" alt="Screenshot 2024-11-18 at 8 57 44 PM" src="https://github.com/user-attachments/assets/c4fdb6a5-6bca-42a7-9ec0-78876075ec7d">
<img width="1512" alt="Screenshot 2024-11-18 at 8 58 51 PM" src="https://github.com/user-attachments/assets/09425f05-d6fb-4d6c-ba5d-6c99fd2f31f6">