### PR TITLE
Adding API to fetch list of available shapes for model deployment

### DIFF
--- a/ads/aqua/extension/ui_handler.py
+++ b/ads/aqua/extension/ui_handler.py
@@ -68,6 +68,8 @@ class AquaUIHandler(AquaAPIhandler):
             return self.list_buckets()
         elif paths.startswith("aqua/job/shapes"):
             return self.list_job_shapes()
+        elif paths.startswith("aqua/modeldeployment/shapes"):
+            return self.list_model_deployment_shapes()
         elif paths.startswith("aqua/vcn"):
             return self.list_vcn()
         elif paths.startswith("aqua/subnets"):
@@ -158,6 +160,15 @@ class AquaUIHandler(AquaAPIhandler):
         compartment_id = self.get_argument("compartment_id", default=COMPARTMENT_OCID)
         return self.finish(
             AquaUIApp().list_job_shapes(compartment_id=compartment_id, **kwargs)
+        )
+
+    def list_model_deployment_shapes(self, **kwargs):
+        """Lists model deployment shapes available in the specified compartment."""
+        compartment_id = self.get_argument("compartment_id", default=COMPARTMENT_OCID)
+        return self.finish(
+            AquaUIApp().list_model_deployment_shapes(
+                compartment_id=compartment_id, **kwargs
+            )
         )
 
     def list_vcn(self, **kwargs):
@@ -255,8 +266,9 @@ class AquaCLIHandler(AquaAPIhandler):
 __handlers__ = [
     ("logging/?([^/]*)", AquaUIHandler),
     ("compartments/?([^/]*)", AquaUIHandler),
-    # TODO: change url to evaluation/experiements/?([^/]*)
+    # TODO: change url to evaluation/experiments/?([^/]*)
     ("experiment/?([^/]*)", AquaUIHandler),
+    ("modeldeployment/?([^/]*)", AquaUIHandler),
     ("versionsets/?([^/]*)", AquaUIHandler),
     ("buckets/?([^/]*)", AquaUIHandler),
     ("job/shapes/?([^/]*)", AquaUIHandler),

--- a/ads/aqua/ui.py
+++ b/ads/aqua/ui.py
@@ -481,12 +481,12 @@ class AquaUIApp(AquaApp):
 
     @telemetry(entry_point="plugin=ui&action=list_job_shapes", name="aqua")
     def list_job_shapes(self, **kwargs) -> list:
-        """Lists all availiable job shapes for the specified compartment.
+        """Lists all available job shapes for the specified compartment.
 
         Parameters
         ----------
         **kwargs
-            Addtional arguments, such as `compartment_id`,
+            Additional arguments, such as `compartment_id`,
             for `list_job_shapes <https://docs.oracle.com/en-us/iaas/tools/python/2.122.0/api/data_science/client/oci.data_science.DataScienceClient.html#oci.data_science.DataScienceClient.list_job_shapes>`_
 
         Returns
@@ -496,6 +496,28 @@ class AquaUIApp(AquaApp):
         logger.info(f"Loading job shape summary from compartment: {compartment_id}")
 
         res = self.ds_client.list_job_shapes(
+            compartment_id=compartment_id, **kwargs
+        ).data
+        return sanitize_response(oci_client=self.ds_client, response=res)
+
+    @telemetry(entry_point="plugin=ui&action=list_model_deployment_shapes", name="aqua")
+    def list_model_deployment_shapes(self, **kwargs) -> list:
+        """Lists all available shapes for model deployment in the specified compartment.
+
+        Parameters
+        ----------
+        **kwargs
+            Additional arguments, such as `compartment_id`,
+            for `list_model_deployment_shapes <https://docs.oracle.com/en-us/iaas/api/#/en/data-science/20190101/ModelDeploymentShapeSummary/ListModelDeploymentShapes>`_
+
+        Returns
+        -------
+            str has json representation of `oci.data_science.models.ModelDeploymentShapeSummary`."""
+        compartment_id = kwargs.pop("compartment_id", COMPARTMENT_OCID)
+        logger.info(
+            f"Loading model deployment shape summary from compartment: {compartment_id}"
+        )
+        res = self.ds_client.list_model_deployment_shapes(
             compartment_id=compartment_id, **kwargs
         ).data
         return sanitize_response(oci_client=self.ds_client, response=res)


### PR DESCRIPTION
## Description
Currently, the AQUA UI for creating model deployments displays a list of all possible shapes for Model Deployment without verifying their availability in the specific region. To improve this, a new API is added to fetch the list of available shapes for Model Deployment in the selected region. The UI should then be updated to display only the shapes that are available for deployment. 

## Curl command
```
curl --location 'http://localhost:8888/aqua/modeldeployment/shapes?compartment_id=ocid1.compartment.oc1..aaaaaaaaser65kfcfht7iddoioa4s6xos3vi53d3i7bi3czjkqyluawp2itq' \
--header 'Cookie: _xsrf=2|efc33a10|4ef2f8300816f6158bf10ede03bb22c7|1732136645; username-localhost-8888=2|1:0|10:1732136645|23:username-localhost-8888|188:eyJ1c2VybmFtZSI6ICI5MzI2NzBkZmJiMWU0MTg0ODUwOGFiYzM3NGRkMWE5ZSIsICJuYW1lIjogIkFub255bW91cyBLb3JlIiwgImRpc3BsYXlfbmFtZSI6ICJBbm9ueW1vdXMgS29yZSIsICJpbml0aWFscyI6ICJBSyIsICJjb2xvciI6IG51bGx9|22413c5db97cb5d16982d052a8400d9f5253e07d5a22fa7c1292e71144971f58'
```


