### PR TITLE
Update params to allow choosing best model for FT

### DIFF
--- a/ads/aqua/finetuning/entities.py
+++ b/ads/aqua/finetuning/entities.py
@@ -26,7 +26,7 @@ class AquaFineTuningParams(DataClassSerializable):
     early_stopping_patience: Optional[int] = None
     early_stopping_threshold: Optional[float] = None
     load_best_model_at_end: Optional[bool] = None
-    metric_for_best_model: Optional[bool] = None
+    metric_for_best_model: Optional[str] = None
 
 
 @dataclass(repr=False)

--- a/ads/aqua/finetuning/entities.py
+++ b/ads/aqua/finetuning/entities.py
@@ -25,6 +25,8 @@ class AquaFineTuningParams(DataClassSerializable):
     lora_target_modules: Optional[List] = None
     early_stopping_patience: Optional[int] = None
     early_stopping_threshold: Optional[float] = None
+    load_best_model_at_end: Optional[bool] = None
+    metric_for_best_model: Optional[bool] = None
 
 
 @dataclass(repr=False)

--- a/tests/unitary/with_extras/aqua/test_finetuning.py
+++ b/tests/unitary/with_extras/aqua/test_finetuning.py
@@ -302,6 +302,14 @@ class FineTuningTestCase(TestCase):
                 },
                 False,
             ),
+            (
+                {
+                    "epochs": 2,
+                    "load_best_model_at_end": True,
+                    "metric_for_best_model": "accuracy",
+                },
+                True,
+            ),
         ]
     )
     def test_validate_finetuning_params(self, params, is_valid):


### PR DESCRIPTION
### Description

This PR adds two parameters to allow user to choose the best finetuned model. 
When `load_best_model_at_end` parameter is set as True, the best model is chosen using lowest validation loss by default. User can also customize other metrics like accuracy/rouge by using the parameter `metric_for_best_model` if needed.

### Parameters 

1. Model from last epoch is used
```
--ft_parameters '{"batch_size": 1, "epochs": 4}'
```

2. Best model is used based on default metric, i.e. validation loss
```
--ft_parameters '{"batch_size": 1, "epochs": 4, "load_best_model_at_end": true}'
```

3. Best model is used based on custom metric, i.e. accuracy
```
--ft_parameters '{"batch_size": 1,  "epochs": 4, "load_best_model_at_end": true, "metric_for_best_model": "accuracy"}'
```

### Unit Tests

```
> python -m pytest -q tests/unitary/with_extras/aqua/*
=========================================== test session starts ============================================
platform darwin -- Python 3.8.19, pytest-7.4.4, pluggy-1.0.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-26.0.0, cov-5.0.0, anyio-4.2.0, xdist-3.6.1
collected 255 items

tests/unitary/with_extras/aqua/test_cli.py ............................                              [  5%]
tests/unitary/with_extras/aqua/test_common_handler.py ...                                            [  6%]
tests/unitary/with_extras/aqua/test_config.py .                                                      [  7%]
tests/unitary/with_extras/aqua/test_decorator.py ..........                                          [ 10%]
tests/unitary/with_extras/aqua/test_deployment.py .....................                              [ 19%]
tests/unitary/with_extras/aqua/test_deployment_handler.py .....s......                               [ 23%]
tests/unitary/with_extras/aqua/test_evaluation.py .............................                      [ 35%]
tests/unitary/with_extras/aqua/test_evaluation_handler.py ......                                     [ 37%]
tests/unitary/with_extras/aqua/test_evaluation_service_config.py .....................               [ 45%]
tests/unitary/with_extras/aqua/test_finetuning.py ........                                           [ 49%]
tests/unitary/with_extras/aqua/test_finetuning_handler.py .....                                      [ 50%]
tests/unitary/with_extras/aqua/test_global.py ...                                                    [ 52%]
tests/unitary/with_extras/aqua/test_handlers.py .................                                    [ 58%]
tests/unitary/with_extras/aqua/test_model.py ..........................                              [ 69%]
tests/unitary/with_extras/aqua/test_model_handler.py ...................                             [ 76%]
tests/unitary/with_extras/aqua/test_ui.py ................                                           [ 82%]
tests/unitary/with_extras/aqua/test_ui_handler.py ...............                                    [ 88%]
tests/unitary/with_extras/aqua/test_ui_websocket_handler.py ....                                     [ 90%]
tests/unitary/with_extras/aqua/test_utils.py ...........

===================================== 254 passed, 1 skipped in 51.81s ======================================
```