### PR TITLE
Bug Fix for MD failure for deployment of Aqua models registered from OSS

### DIFF
--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -185,7 +185,7 @@ class AquaDeploymentApp(AquaApp):
                 tags[tag] = aqua_model.freeform_tags[tag]
 
         tags.update({Tags.AQUA_MODEL_NAME_TAG: aqua_model.display_name})
-        tags.update({Tags.TASK: aqua_model.freeform_tags.get(Tags.TASK, None)})
+        tags.update({Tags.TASK: aqua_model.freeform_tags.get(Tags.TASK, UNKNOWN)})
 
         # Set up info to get deployment config
         config_source_id = model_id
@@ -533,16 +533,22 @@ class AquaDeploymentApp(AquaApp):
         return results
 
     @telemetry(entry_point="plugin=deployment&action=delete", name="aqua")
-    def delete(self,model_deployment_id:str):
-        return self.ds_client.delete_model_deployment(model_deployment_id=model_deployment_id).data
+    def delete(self, model_deployment_id: str):
+        return self.ds_client.delete_model_deployment(
+            model_deployment_id=model_deployment_id
+        ).data
 
-    @telemetry(entry_point="plugin=deployment&action=deactivate",name="aqua")
-    def deactivate(self,model_deployment_id:str):
-        return self.ds_client.deactivate_model_deployment(model_deployment_id=model_deployment_id).data
+    @telemetry(entry_point="plugin=deployment&action=deactivate", name="aqua")
+    def deactivate(self, model_deployment_id: str):
+        return self.ds_client.deactivate_model_deployment(
+            model_deployment_id=model_deployment_id
+        ).data
 
-    @telemetry(entry_point="plugin=deployment&action=activate",name="aqua")
-    def activate(self,model_deployment_id:str):
-        return self.ds_client.activate_model_deployment(model_deployment_id=model_deployment_id).data
+    @telemetry(entry_point="plugin=deployment&action=activate", name="aqua")
+    def activate(self, model_deployment_id: str):
+        return self.ds_client.activate_model_deployment(
+            model_deployment_id=model_deployment_id
+        ).data
 
     @telemetry(entry_point="plugin=deployment&action=get", name="aqua")
     def get(self, model_deployment_id: str, **kwargs) -> "AquaDeploymentDetail":


### PR DESCRIPTION
### Description

When registering Aqua models via OSS flow, since user does not set the task, it is not available in the freeform tags. While deploying, this should be set to empty instead of None, else model deployment creation fails with "Invalid request tags" as shown below.

```
{
    "status": 400,
    "message": "Authorization Failed: Could not create resource. Operation Name: create_model_deployment.",
    "service_payload": {
        "target_service": "data_science",
        "status": 400,
        "code": "InvalidParameter",
        "message": "Invalid request tags",
        "operation_name": "create_model_deployment",
    ...
```