### PR TITLE
[ODSC-65517] Support freeform and defined tags for resource creation in Aqua

### DIFF
--- a/ads/aqua/evaluation/entities.py
+++ b/ads/aqua/evaluation/entities.py
@@ -64,6 +64,10 @@ class CreateAquaEvaluationDetails(Serializable):
         The metrics for the evaluation.
     force_overwrite: (bool, optional). Defaults to `False`.
         Whether to force overwrite the existing file in object storage.
+    freeform_tags: (dict, optional)
+        Freeform tags for the evaluation model
+    defined_tags: (dict, optional)
+        Defined tags for the evaluation model
     """
 
     evaluation_source_id: str
@@ -85,6 +89,8 @@ class CreateAquaEvaluationDetails(Serializable):
     log_id: Optional[str] = None
     metrics: Optional[List[Dict[str, Any]]] = None
     force_overwrite: Optional[bool] = False
+    freeform_tags: Optional[dict] = None
+    defined_tags: Optional[dict] = None
 
     class Config:
         extra = "ignore"

--- a/ads/aqua/evaluation/evaluation.py
+++ b/ads/aqua/evaluation/evaluation.py
@@ -459,9 +459,6 @@ class AquaEvaluationApp(AquaApp):
 
         evaluation_model_freeform_tags = {
             Tags.AQUA_EVALUATION: Tags.AQUA_EVALUATION,
-        }
-        evaluation_model_freeform_tags = {
-            **evaluation_model_freeform_tags,
             **(create_aqua_evaluation_details.freeform_tags or {}),
         }
         evaluation_model_defined_tags = (

--- a/ads/aqua/evaluation/evaluation.py
+++ b/ads/aqua/evaluation/evaluation.py
@@ -543,12 +543,10 @@ class AquaEvaluationApp(AquaApp):
                 ),
             ),
             tags={
-                **{
-                    "aqua_evaluation": Tags.AQUA_EVALUATION,
-                    "evaluation_job_id": evaluation_job.id,
-                    "evaluation_source": create_aqua_evaluation_details.evaluation_source_id,
-                    "evaluation_experiment_id": experiment_model_version_set_id,
-                },
+                "aqua_evaluation": Tags.AQUA_EVALUATION,
+                "evaluation_job_id": evaluation_job.id,
+                "evaluation_source": create_aqua_evaluation_details.evaluation_source_id,
+                "evaluation_experiment_id": experiment_model_version_set_id,
                 **evaluation_model_freeform_tags,
                 **evaluation_model_defined_tags,
             },

--- a/ads/aqua/evaluation/evaluation.py
+++ b/ads/aqua/evaluation/evaluation.py
@@ -297,6 +297,10 @@ class AquaEvaluationApp(AquaApp):
                 evaluation_mvs_freeform_tags = {
                     Tags.AQUA_EVALUATION: Tags.AQUA_EVALUATION,
                 }
+                evaluation_mvs_freeform_tags = {
+                    **evaluation_mvs_freeform_tags,
+                    **(create_aqua_evaluation_details.freeform_tags or {}),
+                }
 
                 model_version_set = (
                     ModelVersionSet()
@@ -307,6 +311,9 @@ class AquaEvaluationApp(AquaApp):
                         create_aqua_evaluation_details.experiment_description
                     )
                     .with_freeform_tags(**evaluation_mvs_freeform_tags)
+                    .with_defined_tags(
+                        **(create_aqua_evaluation_details.defined_tags or {})
+                    )
                     # TODO: decide what parameters will be needed
                     .create(**kwargs)
                 )
@@ -369,6 +376,10 @@ class AquaEvaluationApp(AquaApp):
             Tags.AQUA_EVALUATION: Tags.AQUA_EVALUATION,
             Tags.AQUA_EVALUATION_MODEL_ID: evaluation_model.id,
         }
+        evaluation_job_freeform_tags = {
+            **evaluation_job_freeform_tags,
+            **(create_aqua_evaluation_details.freeform_tags or {}),
+        }
 
         evaluation_job = Job(name=evaluation_model.display_name).with_infrastructure(
             DataScienceJob()
@@ -379,6 +390,7 @@ class AquaEvaluationApp(AquaApp):
             .with_shape_name(create_aqua_evaluation_details.shape_name)
             .with_block_storage_size(create_aqua_evaluation_details.block_storage_size)
             .with_freeform_tag(**evaluation_job_freeform_tags)
+            .with_defined_tag(**(create_aqua_evaluation_details.defined_tags or {}))
         )
         if (
             create_aqua_evaluation_details.memory_in_gbs
@@ -425,6 +437,7 @@ class AquaEvaluationApp(AquaApp):
         evaluation_job_run = evaluation_job.run(
             name=evaluation_model.display_name,
             freeform_tags=evaluation_job_freeform_tags,
+            defined_tags=(create_aqua_evaluation_details.defined_tags or {}),
             wait=False,
         )
         logger.debug(
@@ -444,13 +457,23 @@ class AquaEvaluationApp(AquaApp):
             for metadata in evaluation_model_custom_metadata.to_dict()["data"]
         ]
 
+        evaluation_model_freeform_tags = {
+            Tags.AQUA_EVALUATION: Tags.AQUA_EVALUATION,
+        }
+        evaluation_model_freeform_tags = {
+            **evaluation_model_freeform_tags,
+            **(create_aqua_evaluation_details.freeform_tags or {}),
+        }
+        evaluation_model_defined_tags = (
+            create_aqua_evaluation_details.defined_tags or {}
+        )
+
         self.ds_client.update_model(
             model_id=evaluation_model.id,
             update_model_details=UpdateModelDetails(
                 custom_metadata_list=updated_custom_metadata_list,
-                freeform_tags={
-                    Tags.AQUA_EVALUATION: Tags.AQUA_EVALUATION,
-                },
+                freeform_tags=evaluation_model_freeform_tags,
+                defined_tags=evaluation_model_defined_tags,
             ),
         )
 
@@ -520,10 +543,14 @@ class AquaEvaluationApp(AquaApp):
                 ),
             ),
             tags={
-                "aqua_evaluation": Tags.AQUA_EVALUATION,
-                "evaluation_job_id": evaluation_job.id,
-                "evaluation_source": create_aqua_evaluation_details.evaluation_source_id,
-                "evaluation_experiment_id": experiment_model_version_set_id,
+                **{
+                    "aqua_evaluation": Tags.AQUA_EVALUATION,
+                    "evaluation_job_id": evaluation_job.id,
+                    "evaluation_source": create_aqua_evaluation_details.evaluation_source_id,
+                    "evaluation_experiment_id": experiment_model_version_set_id,
+                },
+                **evaluation_model_freeform_tags,
+                **evaluation_model_defined_tags,
             },
             parameters=AquaEvalParams(),
         )

--- a/ads/aqua/extension/deployment_handler.py
+++ b/ads/aqua/extension/deployment_handler.py
@@ -59,7 +59,7 @@ class AquaDeploymentHandler(AquaAPIhandler):
         return self.finish(AquaDeploymentApp().delete(model_deployment_id))
 
     @handle_exceptions
-    def put(self, *args, **kwargs):
+    def put(self, *args, **kwargs):  # noqa: ARG002
         """
         Handles put request for the activating and deactivating OCI datascience model deployments
         Raises
@@ -82,7 +82,7 @@ class AquaDeploymentHandler(AquaAPIhandler):
             raise HTTPError(400, f"The request {self.request.path} is invalid.")
 
     @handle_exceptions
-    def post(self, *args, **kwargs):
+    def post(self, *args, **kwargs):  # noqa: ARG002
         """
         Handles post request for the deployment APIs
         Raises
@@ -132,6 +132,8 @@ class AquaDeploymentHandler(AquaAPIhandler):
         private_endpoint_id = input_data.get("private_endpoint_id")
         container_image_uri = input_data.get("container_image_uri")
         cmd_var = input_data.get("cmd_var")
+        freeform_tags = input_data.get("freeform_tags")
+        defined_tags = input_data.get("defined_tags")
 
         self.finish(
             AquaDeploymentApp().create(
@@ -157,6 +159,8 @@ class AquaDeploymentHandler(AquaAPIhandler):
                 private_endpoint_id=private_endpoint_id,
                 container_image_uri=container_image_uri,
                 cmd_var=cmd_var,
+                freeform_tags=freeform_tags,
+                defined_tags=defined_tags,
             )
         )
 
@@ -196,7 +200,7 @@ class AquaDeploymentInferenceHandler(AquaAPIhandler):
             return False
 
     @handle_exceptions
-    def post(self, *args, **kwargs):
+    def post(self, *args, **kwargs):  # noqa: ARG002
         """
         Handles inference request for the Active Model Deployments
         Raises
@@ -262,7 +266,7 @@ class AquaDeploymentParamsHandler(AquaAPIhandler):
         )
 
     @handle_exceptions
-    def post(self, *args, **kwargs):
+    def post(self, *args, **kwargs):  # noqa: ARG002
         """Handles post request for the deployment param handler API.
 
         Raises

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -96,7 +96,7 @@ class AquaModelHandler(AquaAPIhandler):
         )
 
     @handle_exceptions
-    def post(self, *args, **kwargs):
+    def post(self, *args, **kwargs):  # noqa: ARG002
         """
         Handles post request for the registering any Aqua model.
         Raises
@@ -131,6 +131,8 @@ class AquaModelHandler(AquaAPIhandler):
         inference_container_uri = input_data.get("inference_container_uri")
         allow_patterns = input_data.get("allow_patterns")
         ignore_patterns = input_data.get("ignore_patterns")
+        freeform_tags = input_data.get("freeform_tags")
+        defined_tags = input_data.get("defined_tags")
 
         return self.finish(
             AquaModelApp().register(
@@ -145,6 +147,8 @@ class AquaModelHandler(AquaAPIhandler):
                 inference_container_uri=inference_container_uri,
                 allow_patterns=allow_patterns,
                 ignore_patterns=ignore_patterns,
+                freeform_tags=freeform_tags,
+                defined_tags=defined_tags,
             )
         )
 
@@ -170,11 +174,9 @@ class AquaModelHandler(AquaAPIhandler):
 
         enable_finetuning = input_data.get("enable_finetuning")
         task = input_data.get("task")
-        app=AquaModelApp()
+        app = AquaModelApp()
         self.finish(
-            app.edit_registered_model(
-                id, inference_container, enable_finetuning, task
-            )
+            app.edit_registered_model(id, inference_container, enable_finetuning, task)
         )
         app.clear_model_details_cache(model_id=id)
 
@@ -218,7 +220,7 @@ class AquaHuggingFaceHandler(AquaAPIhandler):
         return None
 
     @handle_exceptions
-    def get(self, *args, **kwargs):
+    def get(self, *args, **kwargs):  # noqa: ARG002
         """
         Finds a list of matching models from hugging face based on query string provided from users.
 
@@ -239,7 +241,7 @@ class AquaHuggingFaceHandler(AquaAPIhandler):
         return self.finish({"models": models})
 
     @handle_exceptions
-    def post(self, *args, **kwargs):
+    def post(self, *args, **kwargs):  # noqa: ARG002
         """Handles post request for the HF Models APIs
 
         Raises

--- a/ads/aqua/finetuning/entities.py
+++ b/ads/aqua/finetuning/entities.py
@@ -80,6 +80,10 @@ class CreateFineTuningDetails(DataClassSerializable):
         The log id for fine tuning job infrastructure.
     force_overwrite: (bool, optional). Defaults to `False`.
         Whether to force overwrite the existing file in object storage.
+    freeform_tags: (dict, optional)
+        Freeform tags for the fine-tuning model
+    defined_tags: (dict, optional)
+        Defined tags for the fine-tuning model
     """
 
     ft_source_id: str
@@ -101,3 +105,5 @@ class CreateFineTuningDetails(DataClassSerializable):
     log_id: Optional[str] = None
     log_group_id: Optional[str] = None
     force_overwrite: Optional[bool] = False
+    freeform_tags: Optional[dict] = None
+    defined_tags: Optional[dict] = None

--- a/ads/aqua/finetuning/finetuning.py
+++ b/ads/aqua/finetuning/finetuning.py
@@ -277,9 +277,6 @@ class AquaFineTuningApp(AquaApp):
         ft_job_freeform_tags = {
             Tags.AQUA_TAG: UNKNOWN,
             Tags.AQUA_FINE_TUNED_MODEL_TAG: f"{source.id}#{source.display_name}",
-        }
-        ft_job_freeform_tags = {
-            **ft_job_freeform_tags,
             **(create_fine_tuning_details.freeform_tags or {}),
         }
 

--- a/ads/aqua/finetuning/finetuning.py
+++ b/ads/aqua/finetuning/finetuning.py
@@ -477,12 +477,10 @@ class AquaFineTuningApp(AquaApp):
                 ),
             ),
             tags={
-                **{
-                    "aqua_finetuning": Tags.AQUA_FINE_TUNING,
-                    "finetuning_job_id": ft_job.id,
-                    "finetuning_source": source.id,
-                    "finetuning_experiment_id": experiment_model_version_set_id,
-                },
+                "aqua_finetuning": Tags.AQUA_FINE_TUNING,
+                "finetuning_job_id": ft_job.id,
+                "finetuning_source": source.id,
+                "finetuning_experiment_id": experiment_model_version_set_id,
                 **model_freeform_tags,
                 **model_defined_tags,
             },

--- a/ads/aqua/model/entities.py
+++ b/ads/aqua/model/entities.py
@@ -291,6 +291,8 @@ class ImportModelDetails(CLIBuilderMixin):
     inference_container_uri: Optional[str] = None
     allow_patterns: Optional[List[str]] = None
     ignore_patterns: Optional[List[str]] = None
+    freeform_tags: Optional[dict] = None
+    defined_tags: Optional[dict] = None
 
     def __post_init__(self):
         self._command = "model register"

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -110,6 +110,8 @@ class AquaDeploymentApp(AquaApp):
         private_endpoint_id: Optional[str] = None,
         container_image_uri: Optional[None] = None,
         cmd_var: List[str] = None,
+        freeform_tags: Optional[dict] = None,
+        defined_tags: Optional[dict] = None,
     ) -> "AquaDeployment":
         """
         Creates a new Aqua deployment
@@ -163,6 +165,10 @@ class AquaDeploymentApp(AquaApp):
             Required parameter for BYOC based deployments if this parameter was not set during model registration.
         cmd_var: List[str]
             The cmd of model deployment container runtime.
+        freeform_tags: dict
+            Freeform tags for the model deployment
+        defined_tags: dict
+            Defined tags for the model deployment
         Returns
         -------
         AquaDeployment
@@ -172,7 +178,11 @@ class AquaDeploymentApp(AquaApp):
         # TODO validate if the service model has no artifact and if it requires import step before deployment.
         # Create a model catalog entry in the user compartment
         aqua_model = AquaModelApp().create(
-            model_id=model_id, compartment_id=compartment_id, project_id=project_id
+            model_id=model_id,
+            compartment_id=compartment_id,
+            project_id=project_id,
+            freeform_tags=freeform_tags,
+            defined_tags=defined_tags,
         )
 
         tags = {}
@@ -418,12 +428,14 @@ class AquaDeploymentApp(AquaApp):
         if cmd_var:
             container_runtime.with_cmd(cmd_var)
 
+        tags = {**tags, **(freeform_tags or {})}
         # configure model deployment and deploy model on container runtime
         deployment = (
             ModelDeployment()
             .with_display_name(display_name)
             .with_description(description)
             .with_freeform_tags(**tags)
+            .with_defined_tags(**(defined_tags or {}))
             .with_infrastructure(infrastructure)
             .with_runtime(container_runtime)
         ).deploy(wait_for_completion=False)

--- a/ads/aqua/modeldeployment/entities.py
+++ b/ads/aqua/modeldeployment/entities.py
@@ -98,9 +98,12 @@ class AquaDeployment(DataClassSerializable):
             ),
         )
 
-        freeform_tags = oci_model_deployment.freeform_tags or UNKNOWN_DICT
-        aqua_service_model_tag = freeform_tags.get(Tags.AQUA_SERVICE_MODEL_TAG, None)
-        aqua_model_name = freeform_tags.get(Tags.AQUA_MODEL_NAME_TAG, UNKNOWN)
+        tags = {}
+        tags.update(oci_model_deployment.freeform_tags or UNKNOWN_DICT)
+        tags.update(oci_model_deployment.defined_tags or UNKNOWN_DICT)
+
+        aqua_service_model_tag = tags.get(Tags.AQUA_SERVICE_MODEL_TAG, None)
+        aqua_model_name = tags.get(Tags.AQUA_MODEL_NAME_TAG, UNKNOWN)
         private_endpoint_id = getattr(
             instance_configuration, "private_endpoint_id", UNKNOWN
         )
@@ -125,7 +128,7 @@ class AquaDeployment(DataClassSerializable):
                 ocid=oci_model_deployment.id,
                 region=region,
             ),
-            tags=freeform_tags,
+            tags=tags,
             environment_variables=environment_variables,
             cmd=cmd,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
   "psutil>=5.7.2",
   "python_jsonschema_objects>=0.3.13",
   "requests",
-  "scikit-learn>=1.0",
+  "scikit-learn>=1.0,<1.6.0",
   "tabulate>=0.8.9",
   "tqdm>=4.59.0",
   "pydantic>=2.6.3",
@@ -179,7 +179,7 @@ anomaly  = [
   "oracledb",
   "report-creator==1.0.28",
   "rrcf==0.4.4",
-  "scikit-learn",
+  "scikit-learn<1.6.0",
   "salesforce-merlion[all]==2.0.4"
 ]
 recommender = [

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -469,6 +469,9 @@ class TestAquaDeployment(unittest.TestCase):
 
         self.app.get_deployment_config = MagicMock(return_value=config)
 
+        freeform_tags = {"ftag1": "fvalue1", "ftag2": "fvalue2"}
+        defined_tags = {"dtag1": "dvalue1", "dtag2": "dvalue2"}
+
         container_index_json = os.path.join(
             self.curr_dir, "test_data/ui/container_index.json"
         )
@@ -483,6 +486,8 @@ class TestAquaDeployment(unittest.TestCase):
         model_deployment_obj = ModelDeployment.from_yaml(uri=aqua_deployment)
         model_deployment_dsc_obj = copy.deepcopy(TestDataset.model_deployment_object[0])
         model_deployment_dsc_obj["lifecycle_state"] = "CREATING"
+        model_deployment_dsc_obj["defined_tags"] = defined_tags
+        model_deployment_dsc_obj["freeform_tags"].update(freeform_tags)
         model_deployment_obj.dsc_model_deployment = (
             oci.data_science.models.ModelDeploymentSummary(**model_deployment_dsc_obj)
         )
@@ -495,10 +500,16 @@ class TestAquaDeployment(unittest.TestCase):
             log_group_id="ocid1.loggroup.oc1.<region>.<OCID>",
             access_log_id="ocid1.log.oc1.<region>.<OCID>",
             predict_log_id="ocid1.log.oc1.<region>.<OCID>",
+            freeform_tags=freeform_tags,
+            defined_tags=defined_tags,
         )
 
         mock_create.assert_called_with(
-            model_id=TestDataset.MODEL_ID, compartment_id=None, project_id=None
+            model_id=TestDataset.MODEL_ID,
+            compartment_id=None,
+            project_id=None,
+            freeform_tags=freeform_tags,
+            defined_tags=defined_tags,
         )
         mock_get_container_image.assert_called()
         mock_deploy.assert_called()
@@ -508,6 +519,8 @@ class TestAquaDeployment(unittest.TestCase):
         assert set(actual_attributes) == set(expected_attributes), "Attributes mismatch"
         expected_result = copy.deepcopy(TestDataset.aqua_deployment_object)
         expected_result["state"] = "CREATING"
+        expected_result["tags"].update(freeform_tags)
+        expected_result["tags"].update(defined_tags)
         assert actual_attributes == expected_result
 
     @patch("ads.aqua.modeldeployment.deployment.get_container_config")
@@ -566,7 +579,11 @@ class TestAquaDeployment(unittest.TestCase):
         )
 
         mock_create.assert_called_with(
-            model_id=TestDataset.MODEL_ID, compartment_id=None, project_id=None
+            model_id=TestDataset.MODEL_ID,
+            compartment_id=None,
+            project_id=None,
+            freeform_tags=None,
+            defined_tags=None,
         )
         mock_get_container_image.assert_called()
         mock_deploy.assert_called()
@@ -638,7 +655,11 @@ class TestAquaDeployment(unittest.TestCase):
         )
 
         mock_create.assert_called_with(
-            model_id=TestDataset.MODEL_ID, compartment_id=None, project_id=None
+            model_id=TestDataset.MODEL_ID,
+            compartment_id=None,
+            project_id=None,
+            freeform_tags=None,
+            defined_tags=None,
         )
         mock_get_container_image.assert_called()
         mock_deploy.assert_called()
@@ -654,83 +675,87 @@ class TestAquaDeployment(unittest.TestCase):
         )
         assert actual_attributes == expected_result
 
-    # @patch("ads.aqua.modeldeployment.deployment.get_container_config")
-    # @patch("ads.aqua.model.AquaModelApp.create")
-    # @patch("ads.aqua.modeldeployment.deployment.get_container_image")
-    # @patch("ads.model.deployment.model_deployment.ModelDeployment.deploy")
-    # def test_create_deployment_for_tei_byoc_embedding_model(
-    #     self,
-    #     mock_deploy,
-    #     mock_get_container_image,
-    #     mock_create,
-    #     mock_get_container_config,
-    # ):
-    #     """Test to create a deployment for fine-tuned model"""
-    #     aqua_model = os.path.join(
-    #         self.curr_dir, "test_data/deployment/aqua_tei_byoc_embedding_model.yaml"
-    #     )
-    #     datascience_model = DataScienceModel.from_yaml(uri=aqua_model)
-    #     mock_create.return_value = datascience_model
-    #
-    #     config_json = os.path.join(
-    #         self.curr_dir, "test_data/deployment/deployment_config.json"
-    #     )
-    #     with open(config_json, "r") as _file:
-    #         config = json.load(_file)
-    #
-    #     self.app.get_deployment_config = MagicMock(return_value=config)
-    #
-    #     container_index_json = os.path.join(
-    #         self.curr_dir, "test_data/ui/container_index.json"
-    #     )
-    #     with open(container_index_json, "r") as _file:
-    #         container_index_config = json.load(_file)
-    #     mock_get_container_config.return_value = container_index_config
-    #
-    #     mock_get_container_image.return_value = TestDataset.DEPLOYMENT_IMAGE_NAME
-    #     aqua_deployment = os.path.join(
-    #         self.curr_dir, "test_data/deployment/aqua_create_embedding_deployment.yaml"
-    #     )
-    #     model_deployment_obj = ModelDeployment.from_yaml(uri=aqua_deployment)
-    #     model_deployment_dsc_obj = copy.deepcopy(
-    #         TestDataset.model_deployment_object_tei_byoc[0]
-    #     )
-    #     model_deployment_dsc_obj["lifecycle_state"] = "CREATING"
-    #     model_deployment_obj.dsc_model_deployment = (
-    #         oci.data_science.models.ModelDeploymentSummary(**model_deployment_dsc_obj)
-    #     )
-    #     mock_deploy.return_value = model_deployment_obj
-    #
-    #     result = self.app.create(
-    #         model_id=TestDataset.MODEL_ID,
-    #         instance_shape=TestDataset.DEPLOYMENT_SHAPE_NAME,
-    #         display_name="model-deployment-name",
-    #         log_group_id="ocid1.loggroup.oc1.<region>.<OCID>",
-    #         access_log_id="ocid1.log.oc1.<region>.<OCID>",
-    #         predict_log_id="ocid1.log.oc1.<region>.<OCID>",
-    #         container_family="odsc-tei-serving",
-    #         cmd_var=[],
-    #     )
-    #
-    #     mock_create.assert_called_with(
-    #         model_id=TestDataset.MODEL_ID, compartment_id=None, project_id=None
-    #     )
-    #     mock_get_container_image.assert_called()
-    #     mock_deploy.assert_called()
-    #
-    #     expected_attributes = set(AquaDeployment.__annotations__.keys())
-    #     actual_attributes = asdict(result)
-    #     assert set(actual_attributes) == set(expected_attributes), "Attributes mismatch"
-    #     expected_result = copy.deepcopy(TestDataset.aqua_deployment_object)
-    #     expected_result["state"] = "CREATING"
-    #     expected_result["shape_info"] = (
-    #         TestDataset.aqua_deployment_tei_byoc_embeddings_shape_info
-    #     )
-    #     expected_result["cmd"] = TestDataset.aqua_deployment_tei_byoc_embeddings_cmd
-    #     expected_result["environment_variables"] = (
-    #         TestDataset.aqua_deployment_tei_byoc_embeddings_env_vars
-    #     )
-    #     assert actual_attributes == expected_result
+    @patch("ads.aqua.modeldeployment.deployment.get_container_config")
+    @patch("ads.aqua.model.AquaModelApp.create")
+    @patch("ads.aqua.modeldeployment.deployment.get_container_image")
+    @patch("ads.model.deployment.model_deployment.ModelDeployment.deploy")
+    def test_create_deployment_for_tei_byoc_embedding_model(
+        self,
+        mock_deploy,
+        mock_get_container_image,
+        mock_create,
+        mock_get_container_config,
+    ):
+        """Test to create a deployment for fine-tuned model"""
+        aqua_model = os.path.join(
+            self.curr_dir, "test_data/deployment/aqua_tei_byoc_embedding_model.yaml"
+        )
+        datascience_model = DataScienceModel.from_yaml(uri=aqua_model)
+        mock_create.return_value = datascience_model
+
+        config_json = os.path.join(
+            self.curr_dir, "test_data/deployment/deployment_config.json"
+        )
+        with open(config_json, "r") as _file:
+            config = json.load(_file)
+
+        self.app.get_deployment_config = MagicMock(return_value=config)
+
+        container_index_json = os.path.join(
+            self.curr_dir, "test_data/ui/container_index.json"
+        )
+        with open(container_index_json, "r") as _file:
+            container_index_config = json.load(_file)
+        mock_get_container_config.return_value = container_index_config
+
+        mock_get_container_image.return_value = TestDataset.DEPLOYMENT_IMAGE_NAME
+        aqua_deployment = os.path.join(
+            self.curr_dir, "test_data/deployment/aqua_create_embedding_deployment.yaml"
+        )
+        model_deployment_obj = ModelDeployment.from_yaml(uri=aqua_deployment)
+        model_deployment_dsc_obj = copy.deepcopy(
+            TestDataset.model_deployment_object_tei_byoc[0]
+        )
+        model_deployment_dsc_obj["lifecycle_state"] = "CREATING"
+        model_deployment_obj.dsc_model_deployment = (
+            oci.data_science.models.ModelDeploymentSummary(**model_deployment_dsc_obj)
+        )
+        mock_deploy.return_value = model_deployment_obj
+
+        result = self.app.create(
+            model_id=TestDataset.MODEL_ID,
+            instance_shape=TestDataset.DEPLOYMENT_SHAPE_NAME,
+            display_name="model-deployment-name",
+            log_group_id="ocid1.loggroup.oc1.<region>.<OCID>",
+            access_log_id="ocid1.log.oc1.<region>.<OCID>",
+            predict_log_id="ocid1.log.oc1.<region>.<OCID>",
+            container_family="odsc-tei-serving",
+            cmd_var=[],
+        )
+
+        mock_create.assert_called_with(
+            model_id=TestDataset.MODEL_ID,
+            compartment_id=None,
+            project_id=None,
+            freeform_tags=None,
+            defined_tags=None,
+        )
+        mock_get_container_image.assert_called()
+        mock_deploy.assert_called()
+
+        expected_attributes = set(AquaDeployment.__annotations__.keys())
+        actual_attributes = asdict(result)
+        assert set(actual_attributes) == set(expected_attributes), "Attributes mismatch"
+        expected_result = copy.deepcopy(TestDataset.aqua_deployment_object)
+        expected_result["state"] = "CREATING"
+        expected_result["shape_info"] = (
+            TestDataset.aqua_deployment_tei_byoc_embeddings_shape_info
+        )
+        expected_result["cmd"] = TestDataset.aqua_deployment_tei_byoc_embeddings_cmd
+        expected_result["environment_variables"] = (
+            TestDataset.aqua_deployment_tei_byoc_embeddings_env_vars
+        )
+        assert actual_attributes == expected_result
 
     @parameterized.expand(
         [

--- a/tests/unitary/with_extras/aqua/test_deployment_handler.py
+++ b/tests/unitary/with_extras/aqua/test_deployment_handler.py
@@ -29,6 +29,8 @@ class TestDataset:
         "model_id": "ocid1.datasciencemodel.oc1.iad.<OCID>",
         "instance_shape": "VM.GPU.A10.1",
         "display_name": "test-deployment-name",
+        "freeform_tags": {"ftag1": "fvalue1", "ftag2": "fvalue2"},
+        "defined_tags": {"dtag1": "dvalue1", "dtag2": "dvalue2"},
     }
     inference_request = {
         "prompt": "What is 1+1?",
@@ -156,6 +158,8 @@ class TestAquaDeploymentHandler(unittest.TestCase):
             private_endpoint_id=None,
             container_image_uri=None,
             cmd_var=None,
+            freeform_tags=TestDataset.deployment_request["freeform_tags"],
+            defined_tags=TestDataset.deployment_request["defined_tags"],
         )
 
 

--- a/tests/unitary/with_extras/aqua/test_evaluation.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation.py
@@ -475,6 +475,9 @@ class TestAquaEvaluation(unittest.TestCase):
         self.app.ds_client.update_model = MagicMock()
         self.app.ds_client.update_model_provenance = MagicMock()
 
+        eval_model_freeform_tags = {"ftag1": "fvalue1", "ftag2": "fvalue2"}
+        eval_model_defined_tags = {"dtag1": "dvalue1", "dtag2": "dvalue2"}
+
         create_aqua_evaluation_details = dict(
             evaluation_source_id="ocid1.datasciencemodel.oc1.iad.<OCID>",
             evaluation_name="test_evaluation_name",
@@ -486,6 +489,8 @@ class TestAquaEvaluation(unittest.TestCase):
             experiment_name="test_experiment_name",
             memory_in_gbs=1,
             ocpus=1,
+            freeform_tags=eval_model_freeform_tags,
+            defined_tags=eval_model_defined_tags,
         )
         aqua_evaluation_summary = self.app.create(**create_aqua_evaluation_details)
 
@@ -516,10 +521,14 @@ class TestAquaEvaluation(unittest.TestCase):
                 "url": f"https://cloud.oracle.com/data-science/models/ocid1.datasciencemodel.oc1.iad.<OCID>?region={self.app.region}",
             },
             "tags": {
-                "aqua_evaluation": "aqua_evaluation",
-                "evaluation_experiment_id": f"{experiment.id}",
-                "evaluation_job_id": f"{mock_job_id.return_value}",
-                "evaluation_source": "ocid1.datasciencemodel.oc1.iad.<OCID>",
+                **{
+                    "aqua_evaluation": "aqua_evaluation",
+                    "evaluation_experiment_id": f"{experiment.id}",
+                    "evaluation_job_id": f"{mock_job_id.return_value}",
+                    "evaluation_source": "ocid1.datasciencemodel.oc1.iad.<OCID>",
+                },
+                **eval_model_freeform_tags,
+                **eval_model_defined_tags,
             },
             "time_created": f"{oci_dsc_model.time_created}",
         }

--- a/tests/unitary/with_extras/aqua/test_finetuning.py
+++ b/tests/unitary/with_extras/aqua/test_finetuning.py
@@ -119,6 +119,9 @@ class FineTuningTestCase(TestCase):
         self.app.ds_client.update_model = MagicMock()
         self.app.ds_client.update_model_provenance = MagicMock()
 
+        ft_model_freeform_tags = {"ftag1": "fvalue1", "ftag2": "fvalue2"}
+        ft_model_defined_tags = {"dtag1": "dvalue1", "dtag2": "dvalue2"}
+
         create_aqua_ft_details = dict(
             ft_source_id="ocid1.datasciencemodel.oc1.iad.<OCID>",
             ft_name="test_ft_name",
@@ -134,6 +137,8 @@ class FineTuningTestCase(TestCase):
             validation_set_size=0.2,
             block_storage_size=1,
             experiment_name="test_experiment_name",
+            freeform_tags=ft_model_freeform_tags,
+            defined_tags=ft_model_defined_tags,
         )
 
         aqua_ft_summary = self.app.create(**create_aqua_ft_details)
@@ -167,10 +172,14 @@ class FineTuningTestCase(TestCase):
                 "url": f"https://cloud.oracle.com/data-science/models/{ft_source.id}?region={self.app.region}",
             },
             "tags": {
-                "aqua_finetuning": "aqua_finetuning",
-                "finetuning_experiment_id": f"{mock_mvs_create.return_value[0]}",
-                "finetuning_job_id": f"{mock_job_id.return_value}",
-                "finetuning_source": f"{ft_source.id}",
+                **{
+                    "aqua_finetuning": "aqua_finetuning",
+                    "finetuning_experiment_id": f"{mock_mvs_create.return_value[0]}",
+                    "finetuning_job_id": f"{mock_job_id.return_value}",
+                    "finetuning_source": f"{ft_source.id}",
+                },
+                **ft_model_freeform_tags,
+                **ft_model_defined_tags,
             },
             "time_created": f"{ft_model.time_created}",
         }

--- a/tests/unitary/with_extras/aqua/test_finetuning.py
+++ b/tests/unitary/with_extras/aqua/test_finetuning.py
@@ -90,6 +90,10 @@ class FineTuningTestCase(TestCase):
         ft_source.compartment_id = self.SERVICE_COMPARTMENT_ID
         ft_source.display_name = "test_ft_source_model"
         ft_source.custom_metadata_list = custom_metadata_list
+        ft_source.freeform_tags = {
+            "license": "Some license text",
+            "aqua_custom_base_model": "base_model_info",
+        }
         mock_get_source.return_value = ft_source
 
         mock_mvs_create.return_value = ("test_experiment_id", "test_experiment_name")
@@ -177,6 +181,9 @@ class FineTuningTestCase(TestCase):
                     "finetuning_experiment_id": f"{mock_mvs_create.return_value[0]}",
                     "finetuning_job_id": f"{mock_job_id.return_value}",
                     "finetuning_source": f"{ft_source.id}",
+                    "ready_to_fine_tune": "false",
+                    "OCI_AQUA": "",
+                    "aqua_fine_tuned_model": f"{ft_source.id}#{ft_source.display_name}",
                 },
                 **ft_model_freeform_tags,
                 **ft_model_defined_tags,

--- a/tests/unitary/with_extras/aqua/test_model_handler.py
+++ b/tests/unitary/with_extras/aqua/test_model_handler.py
@@ -132,10 +132,38 @@ class ModelHandlerTestCase(TestCase):
 
     @parameterized.expand(
         [
-            (None, None, False, None, None, None),
-            ("odsc-llm-fine-tuning", None, False, None, None, ["test.json"]),
-            (None, "test.gguf", True, None, ["*.json"], None),
-            (None, None, True, "iad.ocir.io/<namespace>/<image>:<tag>", ["*.json"], ["test.json"]),
+            (None, None, False, None, None, None, None, None),
+            (
+                "odsc-llm-fine-tuning",
+                None,
+                False,
+                None,
+                None,
+                ["test.json"],
+                None,
+                None,
+            ),
+            (None, "test.gguf", True, None, ["*.json"], None, None, None),
+            (
+                None,
+                None,
+                True,
+                "iad.ocir.io/<namespace>/<image>:<tag>",
+                ["*.json"],
+                ["test.json"],
+                None,
+                None,
+            ),
+            (
+                None,
+                None,
+                False,
+                None,
+                None,
+                None,
+                {"ftag1": "fvalue1"},
+                {"dtag1": "dvalue1"},
+            ),
         ],
     )
     @patch("notebook.base.handlers.APIHandler.finish")
@@ -148,6 +176,8 @@ class ModelHandlerTestCase(TestCase):
         inference_container_uri,
         allow_patterns,
         ignore_patterns,
+        freeform_tags,
+        defined_tags,
         mock_register,
         mock_finish,
     ):
@@ -168,7 +198,9 @@ class ModelHandlerTestCase(TestCase):
                 download_from_hf=download_from_hf,
                 inference_container_uri=inference_container_uri,
                 allow_patterns=allow_patterns,
-                ignore_patterns=ignore_patterns
+                ignore_patterns=ignore_patterns,
+                freeform_tags=freeform_tags,
+                defined_tags=defined_tags,
             )
         )
         result = self.model_handler.post()
@@ -183,7 +215,9 @@ class ModelHandlerTestCase(TestCase):
             download_from_hf=download_from_hf,
             inference_container_uri=inference_container_uri,
             allow_patterns=allow_patterns,
-            ignore_patterns=ignore_patterns
+            ignore_patterns=ignore_patterns,
+            freeform_tags=freeform_tags,
+            defined_tags=defined_tags,
         )
         assert result["id"] == "test_id"
         assert result["inference_container"] == "odsc-tgi-serving"


### PR DESCRIPTION
### Description

This PR supports defined and freeform tags as inputs when creating resources in AI Quick Actions. The following have been updated:
- Creating model from verified models
- Registering new models (verified or unverified)
- Creating deployment
- Creating evaluation model, job and job run
- Creating finetuning model, job and job run
- Updated model and deployment handlers to accept freeform_tags and defined_tags, finetuning and evaluation accepts a json dict, so no updated needed.
- Unit tests to support all the changes

Following changes will be a part of subsequent PR:
- Improve deployment parameters (use dataclass)
- Update model and deployment handler to accept dict instead of individual params

Note:
hpo tests were failing since scikit-learn has updated `fit_params`  to `params` in `sklearn.model_selection.cross_validate`, and  `sktime` has restricted the `scikit-learn` version to `<1.6.0`. We can relax the scikit-learn version once this restriction is removed.


### Testing 

1. Register Model
```
aqua model register --model <model_name> --os_path <oci_path> --download_from_hf True --compartment_id $PROJECT_COMPARTMENT_OCID --defined_tags '{"test": {"testType": "aquaRegisterTest"}}' --freeform_tags '{"testFreeform": "aquaRegisterTest"}' 
```

Model is created with the above freeform and defined tags.

2. Deploy Model
```
ads aqua deployment create --model_id ocid1.datasciencemodel.oc1.iad.<ocid> --instance_shape VM.GPU.A10.1 --display_name "MD with Tags" --defined_tags '{"test": {"testType": "aquaDeployTest"}}' --freeform_tags '{"testFreeform": "aquaDeployTest"}'
```
Deployment is created with the above freeform and defined tags. If same tags are present in the model, them they are copied to the deployment but overridden with new values.


3. FineTune Model
```
ads aqua fine_tuning create --ft_source_id ocid1.datasciencemodel.oc1.iad.<ocid> --ft_name "FT with Tags" --dataset_path <oci_path> --report_path <oci_path>  --ft_parameters '{"batch_size": 1, "sequence_len": 2048, "pad_to_sequence_len": true, "learning_rate": 0.0002, "lora_r": 32, "lora_alpha": 16, "lora_dropout": 0.05, "lora_target_linear": true, "epochs": 1}' --shape_name VM.GPU.A10.1 --replica 1 --validation_set_size 0.1 --log_group_id ocid1.loggroup.oc1.iad.<ocid> --log_id ocid1.log.oc1.iad.<ocid> --experiment_id ocid1.datasciencemodelversionset.oc1.iad.<ocid> --defined_tags '{"test": {"testType": "aquaFTTest"}}' --freeform_tags '{"testAnotherFreeform": "aquaFTTest"}'
```
MVS, Model, Job and Job Run are created with the above freeform and defined tags.


4. Evaluating Model

```
ads aqua evaluation create --evaluation_name "Eval with Tags" --evaluation_description "Eval with Tags" --dataset_path <oci_path> --report_path <oci_path> --model_parameters '{"max_tokens": 500, "top_p": 0.99, "top_k": 50, "temperature": 0.7, "frequency_penalty": 0, "presence_penalty": 0}' --shape_name "VM.Standard.E4.Flex" --memory_in_gbs 128 --ocpus 8 --block_storage_size 50 --experiment_name "Eval Tags" --log_group_id ocid1.loggroup.oc1.iad.<ocid> --log_id ocid1.log.oc1.iad.<ocid> --metrics '[{"name": "bertscore", "args": {}}, {"name": "rouge", "args": {}}, {"name": "bleu", "args": {}}]' --evaluation_source_id ocid1.datasciencemodeldeploymentint.oc1.iad.<ocid>  --defined_tags '{"test": {"testType": "aquaEvalTest"}}' --freeform_tags '{"testFreeform": "aquaEvalTest"}'
```
MVS, Model, Job and Job Run are created with the above freeform and defined tags.