### PR TITLE
Standardize outputs & report for single-series forecasts without target_category_columns

### DIFF
--- a/ads/opctl/operator/lowcode/forecast/model/arima.py
+++ b/ads/opctl/operator/lowcode/forecast/model/arima.py
@@ -164,11 +164,11 @@ class ArimaOperatorModel(ForecastOperatorBaseModel):
             blocks = [
                 rc.Html(
                     m.summary().as_html(),
-                    label=s_id,
+                    label=s_id if self.target_cat_col else None,
                 )
                 for i, (s_id, m) in enumerate(self.models.items())
             ]
-            sec5 = rc.Select(blocks=blocks)
+            sec5 = rc.Select(blocks=blocks) if len(blocks) > 1 else blocks[0]
             all_sections = [sec5_text, sec5]
 
         if self.spec.generate_explanations:
@@ -188,6 +188,21 @@ class ArimaOperatorModel(ForecastOperatorBaseModel):
                         axis=1,
                     )
                 )
+                aggregate_local_explanations = pd.DataFrame()
+                for s_id, local_ex_df in self.local_explanation.items():
+                    local_ex_df_copy = local_ex_df.copy()
+                    local_ex_df_copy["Series"] = s_id
+                    aggregate_local_explanations = pd.concat(
+                        [aggregate_local_explanations, local_ex_df_copy], axis=0
+                    )
+                self.formatted_local_explanation = aggregate_local_explanations
+
+                if not self.target_cat_col:
+                    self.formatted_global_explanation = self.formatted_global_explanation.rename(
+                        {"Series 1": self.original_target_column},
+                        axis=1,
+                    )
+                    self.formatted_local_explanation.drop("Series", axis=1, inplace=True)
 
                 # Create a markdown section for the global explainability
                 global_explanation_section = rc.Block(
@@ -198,26 +213,17 @@ class ArimaOperatorModel(ForecastOperatorBaseModel):
                     rc.DataTable(self.formatted_global_explanation, index=True),
                 )
 
-                aggregate_local_explanations = pd.DataFrame()
-                for s_id, local_ex_df in self.local_explanation.items():
-                    local_ex_df_copy = local_ex_df.copy()
-                    local_ex_df_copy["Series"] = s_id
-                    aggregate_local_explanations = pd.concat(
-                        [aggregate_local_explanations, local_ex_df_copy], axis=0
-                    )
-                self.formatted_local_explanation = aggregate_local_explanations
-
                 blocks = [
                     rc.DataTable(
                         local_ex_df.div(local_ex_df.abs().sum(axis=1), axis=0) * 100,
-                        label=s_id,
+                        label=s_id if self.target_cat_col else None,
                         index=True,
                     )
                     for s_id, local_ex_df in self.local_explanation.items()
                 ]
                 local_explanation_section = rc.Block(
                     rc.Heading("Local Explanation of Models", level=2),
-                    rc.Select(blocks=blocks),
+                    rc.Select(blocks=blocks) if len(blocks) > 1 else blocks[0],
                 )
 
                 # Append the global explanation text and section to the "all_sections" list

--- a/ads/opctl/operator/lowcode/forecast/model/automlx.py
+++ b/ads/opctl/operator/lowcode/forecast/model/automlx.py
@@ -223,6 +223,8 @@ class AutoMLXOperatorModel(ForecastOperatorBaseModel):
                 selected_models.items(), columns=["series_id", "best_selected_model"]
             )
             selected_df = selected_models_df["best_selected_model"].apply(pd.Series)
+            if not self.target_cat_col:
+                selected_df = selected_df.drop("series_id", axis=1)
             selected_models_section = rc.Block(
                 rc.Heading("Selected Models Overview", level=2),
                 rc.Text(
@@ -252,15 +254,6 @@ class AutoMLXOperatorModel(ForecastOperatorBaseModel):
                     )
                 )
 
-                # Create a markdown section for the global explainability
-                global_explanation_section = rc.Block(
-                    rc.Heading("Global Explanation of Models", level=2),
-                    rc.Text(
-                        "The following tables provide the feature attribution for the global explainability."
-                    ),
-                    rc.DataTable(self.formatted_global_explanation, index=True),
-                )
-
                 aggregate_local_explanations = pd.DataFrame()
                 for s_id, local_ex_df in self.local_explanation.items():
                     local_ex_df_copy = local_ex_df.copy()
@@ -270,17 +263,33 @@ class AutoMLXOperatorModel(ForecastOperatorBaseModel):
                     )
                 self.formatted_local_explanation = aggregate_local_explanations
 
+                if not self.target_cat_col:
+                    self.formatted_global_explanation = self.formatted_global_explanation.rename(
+                        {"Series 1": self.original_target_column},
+                        axis=1,
+                    )
+                    self.formatted_local_explanation.drop("Series", axis=1, inplace=True)
+
+                # Create a markdown section for the global explainability
+                global_explanation_section = rc.Block(
+                    rc.Heading("Global Explanation of Models", level=2),
+                    rc.Text(
+                        "The following tables provide the feature attribution for the global explainability."
+                    ),
+                    rc.DataTable(self.formatted_global_explanation, index=True),
+                )
+
                 blocks = [
                     rc.DataTable(
                         local_ex_df.div(local_ex_df.abs().sum(axis=1), axis=0) * 100,
-                        label=s_id,
+                        label=s_id if self.target_cat_col else None,
                         index=True,
                     )
                     for s_id, local_ex_df in self.local_explanation.items()
                 ]
                 local_explanation_section = rc.Block(
                     rc.Heading("Local Explanation of Models", level=2),
-                    rc.Select(blocks=blocks),
+                    rc.Select(blocks=blocks) if len(blocks) > 1 else blocks[0],
                 )
 
                 # Append the global explanation text and section to the "other_sections" list

--- a/ads/opctl/operator/lowcode/forecast/model/autots.py
+++ b/ads/opctl/operator/lowcode/forecast/model/autots.py
@@ -242,6 +242,7 @@ class AutoTSOperatorModel(ForecastOperatorBaseModel):
                     self.models.df_wide_numeric, series=s_id
                 ),
                 self.datasets.list_series_ids(),
+                target_category_column=self.target_cat_col
             )
             section_1 = rc.Block(
                 rc.Heading("Forecast Overview", level=2),

--- a/ads/opctl/operator/lowcode/forecast/model/base_model.py
+++ b/ads/opctl/operator/lowcode/forecast/model/base_model.py
@@ -28,6 +28,7 @@ from ads.opctl.operator.lowcode.common.utils import (
     seconds_to_datetime,
     write_data,
 )
+from ads.opctl.operator.lowcode.common.const import DataColumns
 from ads.opctl.operator.lowcode.forecast.model.forecast_datasets import TestData
 from ads.opctl.operator.lowcode.forecast.utils import (
     _build_metrics_df,
@@ -69,7 +70,7 @@ class ForecastOperatorBaseModel(ABC):
         self.config: ForecastOperatorConfig = config
         self.spec: ForecastOperatorSpec = config.spec
         self.datasets: ForecastDatasets = datasets
-
+        self.target_cat_col = self.spec.target_category_columns
         self.full_data_dict = datasets.get_data_by_series()
 
         self.test_eval_metrics = None
@@ -124,6 +125,9 @@ class ForecastOperatorBaseModel(ABC):
 
             if self.spec.generate_report or self.spec.generate_metrics:
                 self.eval_metrics = self.generate_train_metrics()
+                if not self.target_cat_col:
+                    self.eval_metrics.rename({"Series 1": self.original_target_column},
+                                             axis=1, inplace=True)
 
                 if self.spec.test_data:
                     try:
@@ -134,6 +138,9 @@ class ForecastOperatorBaseModel(ABC):
                         ) = self._test_evaluate_metrics(
                             elapsed_time=elapsed_time,
                         )
+                        if not self.target_cat_col:
+                            self.test_eval_metrics.rename({"Series 1": self.original_target_column},
+                                                     axis=1, inplace=True)
                     except Exception:
                         logger.warn("Unable to generate Test Metrics.")
                         logger.debug(f"Full Traceback: {traceback.format_exc()}")
@@ -179,7 +186,7 @@ class ForecastOperatorBaseModel(ABC):
                 first_5_rows_blocks = [
                     rc.DataTable(
                         df.head(5),
-                        label=s_id,
+                        label=s_id if self.target_cat_col else None,
                         index=True,
                     )
                     for s_id, df in self.full_data_dict.items()
@@ -188,7 +195,7 @@ class ForecastOperatorBaseModel(ABC):
                 last_5_rows_blocks = [
                     rc.DataTable(
                         df.tail(5),
-                        label=s_id,
+                        label=s_id if self.target_cat_col else None,
                         index=True,
                     )
                     for s_id, df in self.full_data_dict.items()
@@ -197,7 +204,7 @@ class ForecastOperatorBaseModel(ABC):
                 data_summary_blocks = [
                     rc.DataTable(
                         df.describe(),
-                        label=s_id,
+                        label=s_id if self.target_cat_col else None,
                         index=True,
                     )
                     for s_id, df in self.full_data_dict.items()
@@ -215,17 +222,17 @@ class ForecastOperatorBaseModel(ABC):
                     rc.Block(
                         first_10_title,
                         # series_subtext,
-                        rc.Select(blocks=first_5_rows_blocks),
+                        rc.Select(blocks=first_5_rows_blocks) if self.target_cat_col else first_5_rows_blocks[0],
                     ),
                     rc.Block(
                         last_10_title,
                         # series_subtext,
-                        rc.Select(blocks=last_5_rows_blocks),
+                        rc.Select(blocks=last_5_rows_blocks) if self.target_cat_col else last_5_rows_blocks[0],
                     ),
                     rc.Block(
                         summary_title,
                         # series_subtext,
-                        rc.Select(blocks=data_summary_blocks),
+                        rc.Select(blocks=data_summary_blocks) if self.target_cat_col else data_summary_blocks[0],
                     ),
                     rc.Separator(),
                 )
@@ -288,6 +295,7 @@ class ForecastOperatorBaseModel(ABC):
                         horizon=self.spec.horizon,
                         test_data=test_data,
                         ci_interval_width=self.spec.confidence_interval_width,
+                        target_category_column=self.target_cat_col
                     )
                     if (
                         series_name is not None
@@ -463,6 +471,7 @@ class ForecastOperatorBaseModel(ABC):
                         f2.write(f1.read())
 
         # forecast csv report
+        result_df = result_df if self.target_cat_col else result_df.drop(DataColumns.Series, axis=1)
         write_data(
             data=result_df,
             filename=os.path.join(unique_output_dir, self.spec.forecast_filename),

--- a/ads/opctl/operator/lowcode/forecast/model/prophet.py
+++ b/ads/opctl/operator/lowcode/forecast/model/prophet.py
@@ -256,6 +256,7 @@ class ProphetOperatorModel(ForecastOperatorBaseModel):
                     self.outputs[s_id], include_legend=True
                 ),
                 series_ids=series_ids,
+                target_category_column=self.target_cat_col
             )
             section_1 = rc.Block(
                 rc.Heading("Forecast Overview", level=2),
@@ -268,6 +269,7 @@ class ProphetOperatorModel(ForecastOperatorBaseModel):
             sec2 = _select_plot_list(
                 lambda s_id: self.models[s_id].plot_components(self.outputs[s_id]),
                 series_ids=series_ids,
+                target_category_column=self.target_cat_col
             )
             section_2 = rc.Block(
                 rc.Heading("Forecast Broken Down by Trend Component", level=2), sec2
@@ -281,7 +283,9 @@ class ProphetOperatorModel(ForecastOperatorBaseModel):
                     sec3_figs[s_id].gca(), self.models[s_id], self.outputs[s_id]
                 )
             sec3 = _select_plot_list(
-                lambda s_id: sec3_figs[s_id], series_ids=series_ids
+                lambda s_id: sec3_figs[s_id],
+                series_ids=series_ids,
+                target_category_column=self.target_cat_col
             )
             section_3 = rc.Block(rc.Heading("Forecast Changepoints", level=2), sec3)
 
@@ -295,7 +299,7 @@ class ProphetOperatorModel(ForecastOperatorBaseModel):
                     pd.Series(
                         m.seasonalities,
                         index=pd.Index(m.seasonalities.keys(), dtype="object"),
-                        name=s_id,
+                        name=s_id if self.target_cat_col else self.original_target_column,
                         dtype="object",
                     )
                 )
@@ -316,15 +320,6 @@ class ProphetOperatorModel(ForecastOperatorBaseModel):
                     global_explanation_df / global_explanation_df.sum(axis=0) * 100
                 )
 
-                # Create a markdown section for the global explainability
-                global_explanation_section = rc.Block(
-                    rc.Heading("Global Explanation of Models", level=2),
-                    rc.Text(
-                        "The following tables provide the feature attribution for the global explainability."
-                    ),
-                    rc.DataTable(self.formatted_global_explanation, index=True),
-                )
-
                 aggregate_local_explanations = pd.DataFrame()
                 for s_id, local_ex_df in self.local_explanation.items():
                     local_ex_df_copy = local_ex_df.copy()
@@ -334,17 +329,33 @@ class ProphetOperatorModel(ForecastOperatorBaseModel):
                     )
                 self.formatted_local_explanation = aggregate_local_explanations
 
+                if not self.target_cat_col:
+                    self.formatted_global_explanation = self.formatted_global_explanation.rename(
+                        {"Series 1": self.original_target_column},
+                        axis=1,
+                    )
+                    self.formatted_local_explanation.drop("Series", axis=1, inplace=True)
+
+                # Create a markdown section for the global explainability
+                global_explanation_section = rc.Block(
+                    rc.Heading("Global Explanation of Models", level=2),
+                    rc.Text(
+                        "The following tables provide the feature attribution for the global explainability."
+                    ),
+                    rc.DataTable(self.formatted_global_explanation, index=True),
+                )
+
                 blocks = [
                     rc.DataTable(
                         local_ex_df.div(local_ex_df.abs().sum(axis=1), axis=0) * 100,
-                        label=s_id,
+                        label=s_id if self.target_cat_col else None,
                         index=True,
                     )
                     for s_id, local_ex_df in self.local_explanation.items()
                 ]
                 local_explanation_section = rc.Block(
                     rc.Heading("Local Explanation of Models", level=2),
-                    rc.Select(blocks=blocks),
+                    rc.Select(blocks=blocks) if len(blocks) > 1 else blocks[0],
                 )
 
                 # Append the global explanation text and section to the "all_sections" list

--- a/ads/opctl/operator/lowcode/forecast/utils.py
+++ b/ads/opctl/operator/lowcode/forecast/utils.py
@@ -250,8 +250,8 @@ def evaluate_train_metrics(output):
     return total_metrics
 
 
-def _select_plot_list(fn, series_ids):
-    blocks = [rc.Widget(fn(s_id=s_id), label=s_id) for s_id in series_ids]
+def _select_plot_list(fn, series_ids, target_category_column):
+    blocks = [rc.Widget(fn(s_id=s_id), label=s_id if target_category_column else None) for s_id in series_ids]
     return rc.Select(blocks=blocks) if len(blocks) > 1 else blocks[0]
 
 
@@ -283,6 +283,7 @@ def get_forecast_plots(
     horizon,
     test_data=None,
     ci_interval_width=0.95,
+    target_category_column=None
 ):
     def plot_forecast_plotly(s_id):
         fig = go.Figure()
@@ -379,7 +380,7 @@ def get_forecast_plots(
         )
         return fig
 
-    return _select_plot_list(plot_forecast_plotly, forecast_output.list_series_ids())
+    return _select_plot_list(plot_forecast_plotly, forecast_output.list_series_ids(), target_category_column)
 
 
 def convert_target(target: str, target_col: str):

--- a/tests/operators/forecast/test_datasets.py
+++ b/tests/operators/forecast/test_datasets.py
@@ -73,16 +73,18 @@ for dataset_i in DATASETS_LIST:  #  + [DATASETS_LIST[-2]]
             parameters_short.append((model, dataset_i))
 
 
-def verify_explanations(tmpdirname, additional_cols):
+def verify_explanations(tmpdirname, additional_cols, target_category_columns):
     glb_expl = pd.read_csv(f"{tmpdirname}/results/global_explanation.csv", index_col=0)
     loc_expl = pd.read_csv(f"{tmpdirname}/results/local_explanation.csv")
     assert loc_expl.shape[0] == PERIODS
-    for x in ["Date", "Series"]:
+    columns = ["Date", "Series"]
+    if not target_category_columns:
+        columns.remove("Series")
+    for x in columns:
         assert x in set(loc_expl.columns)
     # for x in additional_cols:
     #     assert x in set(loc_expl.columns)
     #     assert x in set(glb_expl.index)
-    assert "Series 1" in set(glb_expl.columns)
 
 
 @pytest.mark.parametrize("model, data_details", parameters_short)
@@ -151,6 +153,7 @@ def test_load_datasets(model, data_details):
             verify_explanations(
                 tmpdirname=tmpdirname,
                 additional_cols=additional_cols,
+                target_category_columns=yaml_i["spec"]['target_category_columns']
             )
         if include_test_data:
             test_metrics = pd.read_csv(f"{tmpdirname}/results/test_metrics.csv")

--- a/tests/operators/forecast/test_errors.py
+++ b/tests/operators/forecast/test_errors.py
@@ -403,10 +403,23 @@ def test_0_series(operator_setup, model):
             tmpdirname=tmpdirname, yaml_i=yaml_i, output_data_path=output_data_path
         )
     yaml_i["spec"].pop("target_category_columns")
+    yaml_i["spec"]["generate_explanations"] = True
     run_yaml(tmpdirname=tmpdirname, yaml_i=yaml_i, output_data_path=output_data_path)
-    add_data = yaml_i["spec"].pop("additional_data")
+    output_files = ['forecast.csv', 'metrics.csv', 'test_metrics.csv',
+                    'report.html', 'local_explanation.csv', 'global_explanation.csv']
+    if model == "autots":
+        # explanations are not supported for autots
+        output_files.remove("local_explanation.csv")
+        output_files.remove("global_explanation.csv")
+    for file in output_files:
+        file_path = os.path.join(output_data_path, file)
+        with open(file_path, 'r', encoding='utf-8') as cur_file:
+            content = cur_file.read()
+            assert "Series 1" not in content, f"'Series 1' found in file: {file}"
+    yaml_i["spec"].pop("additional_data")
+    yaml_i["spec"].pop("generate_explanations")
     run_yaml(tmpdirname=tmpdirname, yaml_i=yaml_i, output_data_path=output_data_path)
-    test_data = yaml_i["spec"].pop("test_data")
+    yaml_i["spec"].pop("test_data")
     run_yaml(tmpdirname=tmpdirname, yaml_i=yaml_i, output_data_path=output_data_path)
     # Todo test horizon mismatch with add data and/or test data
 


### PR DESCRIPTION
[ODSC-64830](https://jira.oci.oraclecorp.com/browse/ODSC-64830)
This PR maintain consistency in the input and output files across various components when performing single-series forecasts, particularly when the target_category_column parameter is not provided. The updates impact the following files:

- forecast.csv
- metrics.csv
- test_metrics.csv
- report.html
- local_explanation.csv
- global_explanation.csv