### PR TITLE
Skip python 3.8 tests

### DIFF
--- a/.github/workflows/run-unittests-default_setup.yml
+++ b/.github/workflows/run-unittests-default_setup.yml
@@ -58,7 +58,7 @@ jobs:
           set -x # print commands that are executed
           $CONDA/bin/conda init
           source /home/runner/.bashrc
-          conda install python=${{ matrix.python-version }}
+          conda install python=${{ matrix.python-version }} --no-deps conda-anaconda-telemetry
           pip install -r test-requirements.txt
           conda list
           python -m pytest -v -p no:warnings --durations=5 tests/unitary/default_setup

--- a/.github/workflows/run-unittests-default_setup.yml
+++ b/.github/workflows/run-unittests-default_setup.yml
@@ -1,4 +1,4 @@
-name: "[Py3.8-3.11] - Default Tests"
+name: "[Py3.9-3.11] - Default Tests"
 
 on:
   workflow_dispatch:
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
           set -x # print commands that are executed
           $CONDA/bin/conda init
           source /home/runner/.bashrc
-          conda install python=${{ matrix.python-version }} --no-deps conda-anaconda-telemetry
+          conda install python=${{ matrix.python-version }}
           pip install -r test-requirements.txt
           conda list
           python -m pytest -v -p no:warnings --durations=5 tests/unitary/default_setup


### PR DESCRIPTION
### Description

conda install fails for python 3.8 because of an issue related to version mismatch of conda-anaconda-telemetry package. This PR just disables the telemetry package install when python is set up. Anaconda has also announced end of support for python 3.8, we should eventually wind down 3.8 support in ads as well.


```
+ conda install python=3.8
Channels:
 - defaults
Platform: linux-64
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... failed

LibMambaUnsatisfiableError: Encountered problems while solving:
  - package conda-anaconda-telemetry-0.1.1-py[39](https://github.com/oracle/accelerated-data-science/actions/runs/12676202695/job/35328893851#step:5:40)h06a4308_0 requires python >=3.9,<3.10.0a0, but none of the providers can be installed

Could not solve for environment specs
The following packages are incompatible
├─ conda-anaconda-telemetry is installable with the potential options
│  ├─ conda-anaconda-telemetry 0.1.1 would require
│  │  └─ python >=3.9,<3.10.0a0 , which can be installed;
│  ├─ conda-anaconda-telemetry 0.1.1 would require
│  │  └─ python >=3.12,<3.13.0a0 , which can be installed;
│  ├─ conda-anaconda-telemetry 0.1.1 would require
│  │  └─ python >=3.10,<3.11.0a0 , which can be installed;
│  └─ conda-anaconda-telemetry 0.1.1 would require
│     └─ python >=3.11,<3.12.0a0 , which can be installed;
└─ python 3.8**  is not installable because it conflicts with any installable versions previously reported.
```