### PR TITLE
Fix loglevel pr

### DIFF
--- a/ads/aqua/__init__.py
+++ b/ads/aqua/__init__.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 
 import os
-from logging import getLogger
+from logging import StreamHandler, getLogger
 
 from ads import set_auth
 from ads.aqua.common.utils import fetch_service_compartment
@@ -19,6 +18,7 @@ def get_logger_level():
     level = os.environ.get(ENV_VAR_LOG_LEVEL, "INFO").upper()
     return level
 
+
 logger = getLogger(__name__)
 logger.setLevel(get_logger_level())
 
@@ -28,7 +28,6 @@ def set_log_level(log_level: str):
 
     log_level = log_level.upper()
     logger.setLevel(log_level.upper())
-    logger.handlers[0].setLevel(log_level)
 
 
 if OCI_RESOURCE_PRINCIPAL_VERSION:

--- a/ads/aqua/__init__.py
+++ b/ads/aqua/__init__.py
@@ -4,7 +4,7 @@
 
 
 import os
-from logging import StreamHandler, getLogger
+from logging import getLogger
 
 from ads import set_auth
 from ads.aqua.common.utils import fetch_service_compartment


### PR DESCRIPTION
When accessing logger.handlers[0], it throws an IndexError since the handlers list is empty.