### PR TITLE
[ODSC-63971] Allow additional parameters for finetuning

### DIFF
--- a/ads/aqua/data.py
+++ b/ads/aqua/data.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from ads.common.serializer import DataClassSerializable
 
@@ -13,19 +12,3 @@ class AquaResourceIdentifier(DataClassSerializable):
     id: str = ""
     name: str = ""
     url: str = ""
-
-
-@dataclass(repr=False)
-class AquaJobSummary(DataClassSerializable):
-    """Represents an Aqua job summary."""
-
-    id: str
-    name: str
-    console_url: str
-    lifecycle_state: str
-    lifecycle_details: str
-    time_created: str
-    tags: dict
-    experiment: AquaResourceIdentifier = field(default_factory=AquaResourceIdentifier)
-    source: AquaResourceIdentifier = field(default_factory=AquaResourceIdentifier)
-    job: AquaResourceIdentifier = field(default_factory=AquaResourceIdentifier)

--- a/ads/aqua/extension/finetune_handler.py
+++ b/ads/aqua/extension/finetune_handler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 
@@ -10,7 +10,6 @@ from tornado.web import HTTPError
 from ads.aqua.common.decorator import handle_exceptions
 from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua.extension.errors import Errors
-from ads.aqua.extension.utils import validate_function_parameters
 from ads.aqua.finetuning import AquaFineTuningApp
 from ads.aqua.finetuning.entities import CreateFineTuningDetails
 
@@ -33,7 +32,7 @@ class AquaFineTuneHandler(AquaAPIhandler):
             raise HTTPError(400, f"The request {self.request.path} is invalid.")
 
     @handle_exceptions
-    def post(self, *args, **kwargs):
+    def post(self, *args, **kwargs):  # noqa: ARG002
         """Handles post request for the fine-tuning API
 
         Raises
@@ -43,15 +42,11 @@ class AquaFineTuneHandler(AquaAPIhandler):
         """
         try:
             input_data = self.get_json_body()
-        except Exception:
-            raise HTTPError(400, Errors.INVALID_INPUT_DATA_FORMAT)
+        except Exception as ex:
+            raise HTTPError(400, Errors.INVALID_INPUT_DATA_FORMAT) from ex
 
         if not input_data:
             raise HTTPError(400, Errors.NO_INPUT_DATA)
-
-        validate_function_parameters(
-            data_class=CreateFineTuningDetails, input_data=input_data
-        )
 
         self.finish(AquaFineTuningApp().create(CreateFineTuningDetails(**input_data)))
 
@@ -71,7 +66,7 @@ class AquaFineTuneParamsHandler(AquaAPIhandler):
         )
 
     @handle_exceptions
-    def post(self, *args, **kwargs):
+    def post(self, *args, **kwargs):  # noqa: ARG002
         """Handles post request for the finetuning param handler API.
 
         Raises
@@ -81,8 +76,8 @@ class AquaFineTuneParamsHandler(AquaAPIhandler):
         """
         try:
             input_data = self.get_json_body()
-        except Exception:
-            raise HTTPError(400, Errors.INVALID_INPUT_DATA_FORMAT)
+        except Exception as ex:
+            raise HTTPError(400, Errors.INVALID_INPUT_DATA_FORMAT) from ex
 
         if not input_data:
             raise HTTPError(400, Errors.NO_INPUT_DATA)

--- a/ads/aqua/extension/finetune_handler.py
+++ b/ads/aqua/extension/finetune_handler.py
@@ -11,7 +11,6 @@ from ads.aqua.common.decorator import handle_exceptions
 from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua.extension.errors import Errors
 from ads.aqua.finetuning import AquaFineTuningApp
-from ads.aqua.finetuning.entities import CreateFineTuningDetails
 
 
 class AquaFineTuneHandler(AquaAPIhandler):
@@ -48,7 +47,7 @@ class AquaFineTuneHandler(AquaAPIhandler):
         if not input_data:
             raise HTTPError(400, Errors.NO_INPUT_DATA)
 
-        self.finish(AquaFineTuningApp().create(CreateFineTuningDetails(**input_data)))
+        self.finish(AquaFineTuningApp().create(**input_data))
 
     def get_finetuning_config(self, model_id):
         """Gets the finetuning config for Aqua model."""

--- a/ads/aqua/finetuning/constants.py
+++ b/ads/aqua/finetuning/constants.py
@@ -16,7 +16,7 @@ class FineTuneCustomMetadata(str, metaclass=ExtendedEnumMeta):
     SERVICE_MODEL_FINE_TUNE_CONTAINER = "finetune-container"
 
 
-class FineTuningForbiddenParams(str, metaclass=ExtendedEnumMeta):
+class FineTuningRestrictedParams(str, metaclass=ExtendedEnumMeta):
     OPTIMIZER = "optimizer"
 
 

--- a/ads/aqua/finetuning/constants.py
+++ b/ads/aqua/finetuning/constants.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 from ads.common.extended_enum import ExtendedEnumMeta
@@ -15,6 +14,10 @@ class FineTuneCustomMetadata(str, metaclass=ExtendedEnumMeta):
     SERVICE_MODEL_ARTIFACT_LOCATION = "artifact_location"
     SERVICE_MODEL_DEPLOYMENT_CONTAINER = "deployment-container"
     SERVICE_MODEL_FINE_TUNE_CONTAINER = "finetune-container"
+
+
+class FineTuningForbiddenParams(str, metaclass=ExtendedEnumMeta):
+    OPTIMIZER = "optimizer"
 
 
 ENV_AQUA_FINE_TUNING_CONTAINER = "AQUA_FINE_TUNING_CONTAINER"

--- a/ads/aqua/finetuning/entities.py
+++ b/ads/aqua/finetuning/entities.py
@@ -31,8 +31,6 @@ class AquaFineTuningParams(Serializable):
     lora_target_modules: Optional[List[str]] = None
     early_stopping_patience: Optional[int] = None
     early_stopping_threshold: Optional[float] = None
-    load_best_model_at_end: Optional[bool] = None
-    metric_for_best_model: Optional[str] = None
 
     class Config:
         extra = "allow"

--- a/tests/unitary/with_extras/aqua/test_data/finetuning/ft_config.json
+++ b/tests/unitary/with_extras/aqua/test_data/finetuning/ft_config.json
@@ -1,28 +1,13 @@
 {
   "configuration": {
-    "adapter": "lora",
-    "bf16": true,
-    "flash_attention": true,
-    "fp16": false,
-    "gradient_accumulation_steps": 1,
-    "gradient_checkpointing": true,
     "learning_rate": 0.0002,
-    "logging_steps": 1,
     "lora_alpha": 16,
     "lora_dropout": 0.05,
     "lora_r": 32,
     "lora_target_linear": true,
-    "lora_target_modules": [
-      "q_proj",
-      "k_proj"
-    ],
-    "lr_scheduler": "cosine",
     "micro_batch_size": 1,
-    "optimizer": "adamw_torch",
     "pad_to_sequence_len": true,
-    "sample_packing": true,
     "sequence_len": 2048,
-    "tf32": false,
     "val_set_size": 0.1
   },
   "shape": {

--- a/tests/unitary/with_extras/aqua/test_finetuning.py
+++ b/tests/unitary/with_extras/aqua/test_finetuning.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*--
 
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import os
@@ -11,7 +11,6 @@ from parameterized import parameterized
 from unittest import TestCase
 from unittest.mock import MagicMock, PropertyMock
 from mock import patch
-from dataclasses import asdict
 from importlib import reload
 
 import ads.aqua
@@ -147,7 +146,7 @@ class FineTuningTestCase(TestCase):
 
         aqua_ft_summary = self.app.create(**create_aqua_ft_details)
 
-        assert asdict(aqua_ft_summary) == {
+        assert aqua_ft_summary.to_dict() == {
             "console_url": f"https://cloud.oracle.com/data-science/models/{ft_model.id}?region={self.app.region}",
             "experiment": {
                 "id": f"{mock_mvs_create.return_value[0]}",
@@ -267,15 +266,14 @@ class FineTuningTestCase(TestCase):
         params_dict = {
             "params": {
                 "batch_size": 1,
+                "val_set_size": 0.1,
                 "sequence_len": 2048,
-                "sample_packing": True,
                 "pad_to_sequence_len": True,
                 "learning_rate": 0.0002,
                 "lora_r": 32,
                 "lora_alpha": 16,
                 "lora_dropout": 0.05,
                 "lora_target_linear": True,
-                "lora_target_modules": ["q_proj", "k_proj"],
             }
         }
         config_json = os.path.join(self.curr_dir, "test_data/finetuning/ft_config.json")
@@ -309,14 +307,22 @@ class FineTuningTestCase(TestCase):
                 True,
             ),
             (
+                {"optimizer": "adamw_torch"},
+                False,
+            ),
+            (
                 {
-                    "micro_batch_size": 1,
-                    "max_sequence_len": 2048,
-                    "flash_attention": True,
-                    "pad_to_sequence_len": True,
-                    "lr_scheduler": "cosine",
+                    "epochs": [2],
                 },
                 False,
+            ),
+            (
+                {
+                    "epochs": 2,
+                    "load_best_model_at_end": True,
+                    "metric_for_best_model": "accuracy",
+                },
+                True,
             ),
         ]
     )

--- a/tests/unitary/with_extras/aqua/test_finetuning_handler.py
+++ b/tests/unitary/with_extras/aqua/test_finetuning_handler.py
@@ -1,21 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*--
 
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 from unittest import TestCase
 from unittest.mock import MagicMock
 
 from mock import patch
-from notebook.base.handlers import APIHandler, IPythonHandler
+from notebook.base.handlers import IPythonHandler
 
 from ads.aqua.extension.finetune_handler import (
     AquaFineTuneHandler,
     AquaFineTuneParamsHandler,
 )
 from ads.aqua.finetuning import AquaFineTuningApp
-from ads.aqua.finetuning.entities import CreateFineTuningDetails
 
 
 class TestDataset:
@@ -68,9 +67,7 @@ class FineTuningHandlerTestCase(TestCase):
         self.test_instance.post()
 
         self.test_instance.finish.assert_called_with(mock_create.return_value)
-        mock_create.assert_called_with(
-            CreateFineTuningDetails(**TestDataset.mock_valid_input)
-        )
+        mock_create.assert_called_with(**TestDataset.mock_valid_input)
 
     @patch.object(AquaFineTuningApp, "get_finetuning_config")
     def test_get_finetuning_config(self, mock_get_finetuning_config):


### PR DESCRIPTION
### Description

This PR allows additional parameters to be passed as inputs for fine-tuning via Aqua. 
The changes also include converting all the finetuning entities dataclasses to pydantic. For restricting parameters, we use pydantic's validator to check if any of the inputs come from a restricted set of params, but also allow to skip validation in cases we load parameters from config files.

Also, the handler is updated since input validation is now done at the create() API level. Pydantic error message adds CL/RF characters, and unless wrapped around with custom validation, throws an "Illegal character" error when calling finish() at the handler level.

### Validation examples

**1. When required param is not passed**

`Request: POST http://localhost:8888/aqua/finetuning`
```
Request payload without replica field
```
`Response`
```
{
    "status": 403,
    "message": "We're having trouble processing your request with the information provided.",
    "service_payload": {},
    "reason": "Invalid parameters for creating a fine-tuned model. Error details: {'replica': 'Field required'}.",
    "request_id": "910878b9-bdb8-43d3-b3e1-3cfcdcc8ffd4"
}
```

**2. When restricted param is passed**

`Request: GET http://localhost:8888/aqua/finetuning/params`
```
{
    "params": {
        "epochs": "1",
        "optimizer": "adamw_torch"
    }
}
```
`Response`
```
{
    "status": 403,
    "message": "We're having trouble processing your request with the information provided.",
    "service_payload": {},
    "reason": "Invalid finetuning parameters. Error details: Value error, Found restricted parameter name: ['optimizer'].",
    "request_id": "8162593e-ec23-41c2-9ef0-2f164360d89a"
}
```

**3. When incorrect param value is passed**
`Request: GET http://localhost:8888/aqua/finetuning/params`
```
{
    "params": {
        "epochs": ["1"]
    }
}
```
`Response`
```
{
    "status": 403,
    "message": "We're having trouble processing your request with the information provided.",
    "service_payload": {},
    "reason": "Invalid finetuning parameters. Error details: {'epochs': 'Input should be a valid integer'}.",
    "request_id": "034f7660-0935-449b-ac5e-eae8850acba1"
}
```

**4. When additional params are passed**
`Request: GET http://localhost:8888/aqua/finetuning/params`
```

    "params": {
        "epochs": 1,
        "load_best_model_at_end": true,
        "metric_for_best_model": "accuracy"
    }
}
```
`Response`
```
{
    "valid": true
}
```