### PR TITLE
Adding task input for model registration in OSS flow

### DIFF
--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -133,6 +133,7 @@ class AquaModelHandler(AquaAPIhandler):
         ignore_patterns = input_data.get("ignore_patterns")
         freeform_tags = input_data.get("freeform_tags")
         defined_tags = input_data.get("defined_tags")
+        task=input_data.get("task")
 
         return self.finish(
             AquaModelApp().register(

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -133,7 +133,7 @@ class AquaModelHandler(AquaAPIhandler):
         ignore_patterns = input_data.get("ignore_patterns")
         freeform_tags = input_data.get("freeform_tags")
         defined_tags = input_data.get("defined_tags")
-        task=input_data.get("task")
+        task = input_data.get("task")
 
         return self.finish(
             AquaModelApp().register(

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -150,6 +150,7 @@ class AquaModelHandler(AquaAPIhandler):
                 ignore_patterns=ignore_patterns,
                 freeform_tags=freeform_tags,
                 defined_tags=defined_tags,
+                task=task
             )
         )
 

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -150,7 +150,7 @@ class AquaModelHandler(AquaAPIhandler):
                 ignore_patterns=ignore_patterns,
                 freeform_tags=freeform_tags,
                 defined_tags=defined_tags,
-                task=task
+                task=task,
             )
         )
 

--- a/ads/aqua/model/entities.py
+++ b/ads/aqua/model/entities.py
@@ -293,7 +293,7 @@ class ImportModelDetails(CLIBuilderMixin):
     ignore_patterns: Optional[List[str]] = None
     freeform_tags: Optional[dict] = None
     defined_tags: Optional[dict] = None
-    task: Optional[str]=None
+    task: Optional[str] = None
 
     def __post_init__(self):
         self._command = "model register"

--- a/ads/aqua/model/entities.py
+++ b/ads/aqua/model/entities.py
@@ -293,6 +293,7 @@ class ImportModelDetails(CLIBuilderMixin):
     ignore_patterns: Optional[List[str]] = None
     freeform_tags: Optional[dict] = None
     defined_tags: Optional[dict] = None
+    task: Optional[str]=None
 
     def __post_init__(self):
         self._command = "model register"

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -376,7 +376,7 @@ class AquaModelApp(AquaApp):
                 f"Failed to delete model:{model_id}. Only registered models or finetuned model can be deleted."
             )
 
-    @telemetry(entry_point="plugin=model&action=delete", name="aqua")
+    @telemetry(entry_point="plugin=model&action=edit", name="aqua")
     def edit_registered_model(self, id, inference_container, enable_finetuning, task):
         """Edits the default config of unverified registered model.
 

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -1120,7 +1120,11 @@ class AquaModelApp(AquaApp):
                 except Exception:
                     pass
             else:
-                validation_result.tags={Tags.TASK: import_model_details.task if import_model_details.task else UNKNOWN}
+                validation_result.tags = {
+                    Tags.TASK: import_model_details.task
+                    if import_model_details.task
+                    else UNKNOWN
+                }
 
         validation_result.model_formats = model_formats
 

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -1119,6 +1119,8 @@ class AquaModelApp(AquaApp):
                     validation_result.tags = hf_tags
                 except Exception:
                     pass
+            else:
+                validation_result.tags={Tags.TASK: import_model_details.task if import_model_details.task else UNKNOWN}
 
         validation_result.model_formats = model_formats
 

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -521,7 +521,7 @@ class TestAquaDeployment(unittest.TestCase):
         expected_result["state"] = "CREATING"
         expected_result["tags"].update(freeform_tags)
         expected_result["tags"].update(defined_tags)
-        expected_result["private_endpoint_id"]=""
+        expected_result["private_endpoint_id"] = ""
         assert actual_attributes == expected_result
 
     @patch("ads.aqua.modeldeployment.deployment.get_container_config")
@@ -754,7 +754,7 @@ class TestAquaDeployment(unittest.TestCase):
         expected_result["shape_info"] = (
             TestDataset.aqua_deployment_tei_byoc_embeddings_shape_info
         )
-        expected_result["private_endpoint_id"]=""
+        expected_result["private_endpoint_id"] = ""
         expected_result["cmd"] = TestDataset.aqua_deployment_tei_byoc_embeddings_cmd
         expected_result["environment_variables"] = (
             TestDataset.aqua_deployment_tei_byoc_embeddings_env_vars

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -253,7 +253,6 @@ class TestDataset:
         "created_on": "2024-01-01T00:00:00.000000+00:00",
         "created_by": "ocid1.user.oc1..<OCID>",
         "endpoint": MODEL_DEPLOYMENT_URL,
-        "private_endpoint_id": "",
         "environment_variables": {
             "BASE_MODEL": "service_models/model-name/artifact",
             "MODEL_DEPLOY_ENABLE_STREAMING": "true",
@@ -521,7 +520,6 @@ class TestAquaDeployment(unittest.TestCase):
         expected_result["state"] = "CREATING"
         expected_result["tags"].update(freeform_tags)
         expected_result["tags"].update(defined_tags)
-        expected_result["private_endpoint_id"] = ""
         assert actual_attributes == expected_result
 
     @patch("ads.aqua.modeldeployment.deployment.get_container_config")
@@ -594,7 +592,6 @@ class TestAquaDeployment(unittest.TestCase):
         assert set(actual_attributes) == set(expected_attributes), "Attributes mismatch"
         expected_result = copy.deepcopy(TestDataset.aqua_deployment_object)
         expected_result["state"] = "CREATING"
-        expected_result["private_endpoint_id"] = ""
         assert actual_attributes == expected_result
 
     @patch("ads.aqua.modeldeployment.deployment.get_container_config")
@@ -675,7 +672,6 @@ class TestAquaDeployment(unittest.TestCase):
         expected_result["environment_variables"] = (
             TestDataset.aqua_deployment_gguf_env_vars
         )
-        expected_result["private_endpoint_id"] = ""
         assert actual_attributes == expected_result
 
     @patch("ads.aqua.modeldeployment.deployment.get_container_config")
@@ -754,7 +750,6 @@ class TestAquaDeployment(unittest.TestCase):
         expected_result["shape_info"] = (
             TestDataset.aqua_deployment_tei_byoc_embeddings_shape_info
         )
-        expected_result["private_endpoint_id"] = ""
         expected_result["cmd"] = TestDataset.aqua_deployment_tei_byoc_embeddings_cmd
         expected_result["environment_variables"] = (
             TestDataset.aqua_deployment_tei_byoc_embeddings_env_vars

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -253,6 +253,7 @@ class TestDataset:
         "created_on": "2024-01-01T00:00:00.000000+00:00",
         "created_by": "ocid1.user.oc1..<OCID>",
         "endpoint": MODEL_DEPLOYMENT_URL,
+        "private_endpoint_id": null,
         "environment_variables": {
             "BASE_MODEL": "service_models/model-name/artifact",
             "MODEL_DEPLOY_ENABLE_STREAMING": "true",

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -253,7 +253,7 @@ class TestDataset:
         "created_on": "2024-01-01T00:00:00.000000+00:00",
         "created_by": "ocid1.user.oc1..<OCID>",
         "endpoint": MODEL_DEPLOYMENT_URL,
-        "private_endpoint_id": null,
+        "private_endpoint_id": "",
         "environment_variables": {
             "BASE_MODEL": "service_models/model-name/artifact",
             "MODEL_DEPLOY_ENABLE_STREAMING": "true",
@@ -521,6 +521,7 @@ class TestAquaDeployment(unittest.TestCase):
         expected_result["state"] = "CREATING"
         expected_result["tags"].update(freeform_tags)
         expected_result["tags"].update(defined_tags)
+        expected_result["private_endpoint_id"]=""
         assert actual_attributes == expected_result
 
     @patch("ads.aqua.modeldeployment.deployment.get_container_config")
@@ -593,6 +594,7 @@ class TestAquaDeployment(unittest.TestCase):
         assert set(actual_attributes) == set(expected_attributes), "Attributes mismatch"
         expected_result = copy.deepcopy(TestDataset.aqua_deployment_object)
         expected_result["state"] = "CREATING"
+        expected_result["private_endpoint_id"] = ""
         assert actual_attributes == expected_result
 
     @patch("ads.aqua.modeldeployment.deployment.get_container_config")
@@ -673,6 +675,7 @@ class TestAquaDeployment(unittest.TestCase):
         expected_result["environment_variables"] = (
             TestDataset.aqua_deployment_gguf_env_vars
         )
+        expected_result["private_endpoint_id"] = ""
         assert actual_attributes == expected_result
 
     @patch("ads.aqua.modeldeployment.deployment.get_container_config")
@@ -751,6 +754,7 @@ class TestAquaDeployment(unittest.TestCase):
         expected_result["shape_info"] = (
             TestDataset.aqua_deployment_tei_byoc_embeddings_shape_info
         )
+        expected_result["private_endpoint_id"]=""
         expected_result["cmd"] = TestDataset.aqua_deployment_tei_byoc_embeddings_cmd
         expected_result["environment_variables"] = (
             TestDataset.aqua_deployment_tei_byoc_embeddings_env_vars

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -1021,11 +1021,15 @@ class TestAquaModel:
                 inference_container="odsc-vllm-or-tgi-container",
                 finetuning_container="odsc-llm-fine-tuning",
                 download_from_hf=False,
+                task='text-generation'
             )
             assert model.tags == {
                 "aqua_custom_base_model": "true",
                 "model_format": "SAFETENSORS",
                 "ready_to_fine_tune": "true",
+                'license': '',
+                'organization': '',
+                'task': 'text-generation',
                 **ds_freeform_tags,
             }
             assert model.inference_container == "odsc-vllm-or-tgi-container"
@@ -1162,6 +1166,7 @@ class TestAquaModel:
                 download_from_hf=False,
                 freeform_tags={"ftag1": "fvalue1", "ftag2": "fvalue2"},
                 defined_tags={"dtag1": "dvalue1", "dtag2": "dvalue2"},
+                task="image_text_to_text"
             )
             assert model.tags == {
                 "aqua_custom_base_model": "true",
@@ -1171,6 +1176,9 @@ class TestAquaModel:
                 "dtag2": "dvalue2",
                 "ftag1": "fvalue1",
                 "ftag2": "fvalue2",
+                'license': '',
+                'organization': '',
+                'task': 'image_text_to_text',
                 **ds_freeform_tags,
             }
 

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -1021,15 +1021,15 @@ class TestAquaModel:
                 inference_container="odsc-vllm-or-tgi-container",
                 finetuning_container="odsc-llm-fine-tuning",
                 download_from_hf=False,
-                task='text-generation'
+                task="text-generation",
             )
             assert model.tags == {
                 "aqua_custom_base_model": "true",
                 "model_format": "SAFETENSORS",
                 "ready_to_fine_tune": "true",
-                'license': '',
-                'organization': '',
-                'task': 'text-generation',
+                "license": "",
+                "organization": "",
+                "task": "text-generation",
                 **ds_freeform_tags,
             }
             assert model.inference_container == "odsc-vllm-or-tgi-container"
@@ -1166,7 +1166,7 @@ class TestAquaModel:
                 download_from_hf=False,
                 freeform_tags={"ftag1": "fvalue1", "ftag2": "fvalue2"},
                 defined_tags={"dtag1": "dvalue1", "dtag2": "dvalue2"},
-                task="image_text_to_text"
+                task="image_text_to_text",
             )
             assert model.tags == {
                 "aqua_custom_base_model": "true",
@@ -1176,9 +1176,9 @@ class TestAquaModel:
                 "dtag2": "dvalue2",
                 "ftag1": "fvalue1",
                 "ftag2": "fvalue2",
-                'license': '',
-                'organization': '',
-                'task': 'image_text_to_text',
+                "license": "",
+                "organization": "",
+                "task": "image_text_to_text",
                 **ds_freeform_tags,
             }
 

--- a/tests/unitary/with_extras/aqua/test_model_handler.py
+++ b/tests/unitary/with_extras/aqua/test_model_handler.py
@@ -218,7 +218,7 @@ class ModelHandlerTestCase(TestCase):
             ignore_patterns=ignore_patterns,
             freeform_tags=freeform_tags,
             defined_tags=defined_tags,
-            task=None
+            task=None,
         )
         assert result["id"] == "test_id"
         assert result["inference_container"] == "odsc-tgi-serving"

--- a/tests/unitary/with_extras/aqua/test_model_handler.py
+++ b/tests/unitary/with_extras/aqua/test_model_handler.py
@@ -218,6 +218,7 @@ class ModelHandlerTestCase(TestCase):
             ignore_patterns=ignore_patterns,
             freeform_tags=freeform_tags,
             defined_tags=defined_tags,
+            task=None
         )
         assert result["id"] == "test_id"
         assert result["inference_container"] == "odsc-tgi-serving"


### PR DESCRIPTION
## Description
While registering from object storage, we'll have to ask for task details, which can be one of {Text Generation, Code Synthesis, Text Embedding, Image text to text}. This UI component already exists in the Edit Model page, we'll have to do the same during registering the model via OSS flow.

## Task
- Add a new task parameter for OSS flow during registration of unverified model
- Add a task parameter input for OSS flow in UI 

```
curl --location 'http://localhost:8888/aqua/model' \
--header 'Content-Type: application/json' \
--data-raw '{
    "model": "BAAI/bge-m3",
    "os_path": "oci://ft-bucket-versioned@ociodscdev/aqua/models/BAAI/bge-m3",
    "inference_container": "odsc-tei-serving",
    "inference_container_uri": "iad.ocir.io/ociodscdev/text-embeddings-inference:1.5.0",
    "task": "feature_extraction"
}'
```


### UI Mocks:
<img width="782" alt="Screenshot 2025-01-21 at 11 16 35 PM" src="https://github.com/user-attachments/assets/2774d030-d31b-42bf-bee4-55a530e1efa5" />
<img width="686" alt="Screenshot 2025-01-21 at 11 16 43 PM" src="https://github.com/user-attachments/assets/157c45c8-ff00-4035-9063-8bb79572abbd" />
<img width="699" alt="Screenshot 2025-01-21 at 11 17 21 PM" src="https://github.com/user-attachments/assets/3012e50a-7eb0-43b3-9f7d-ac741b0de52f" />
<img width="705" alt="Screenshot 2025-01-21 at 11 18 00 PM" src="https://github.com/user-attachments/assets/d79ee656-c05f-480f-9112-39ac7bf8804c" />
