### PR TITLE
[ODSC-66853] Load base model config by default

### DIFF
--- a/ads/aqua/app.py
+++ b/ads/aqua/app.py
@@ -23,7 +23,7 @@ from ads.aqua.common.utils import (
 from ads.aqua.constants import UNKNOWN
 from ads.common import oci_client as oc
 from ads.common.auth import default_signer
-from ads.common.utils import extract_region
+from ads.common.utils import extract_region, is_path_exists
 from ads.config import (
     AQUA_TELEMETRY_BUCKET,
     AQUA_TELEMETRY_BUCKET_NS,
@@ -317,17 +317,19 @@ class AquaApp:
             )
             return config
 
-        try:
-            config = load_config(
-                config_path,
-                config_file_name=config_file_name,
-            )
-        except Exception:
-            logger.debug(
-                f"Error loading the {config_file_name} at path {config_path}.",
-                exc_info=True,
-            )
-            pass
+        config_file_path = f"{config_path}{config_file_name}"
+        if is_path_exists(config_file_path):
+            try:
+                config = load_config(
+                    config_path,
+                    config_file_name=config_file_name,
+                )
+            except Exception:
+                logger.debug(
+                    f"Error loading the {config_file_name} at path {config_path}.",
+                    exc_info=True,
+                )
+                pass
 
         if not config:
             logger.error(

--- a/ads/aqua/app.py
+++ b/ads/aqua/app.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+import traceback
 from dataclasses import fields
 from typing import Dict, Union
 
@@ -326,13 +327,12 @@ class AquaApp:
                 )
             except Exception:
                 logger.debug(
-                    f"Error loading the {config_file_name} at path {config_path}.",
-                    exc_info=True,
+                    f"Error loading the {config_file_name} at path {config_path}.\n"
+                    f"{traceback.format_exc()}"
                 )
-                pass
 
         if not config:
-            logger.error(
+            logger.debug(
                 f"{config_file_name} is not available for the model: {model_id}. "
                 f"Check if the custom metadata has the artifact path set."
             )

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -29,7 +29,6 @@ from ads.aqua.common.utils import (
     LifecycleStatus,
     _build_resource_identifier,
     cleanup_local_hf_model_artifact,
-    copy_model_config,
     create_word_icon,
     generate_tei_cmd_var,
     get_artifact_path,
@@ -969,24 +968,6 @@ class AquaModelApp(AquaApp):
                 )
                 tags[Tags.LICENSE] = validation_result.tags.get(Tags.LICENSE, UNKNOWN)
 
-        try:
-            # If verified model already has a artifact json, use that.
-            artifact_path = metadata.get(MODEL_BY_REFERENCE_OSS_PATH_KEY).value
-            logger.info(
-                f"Found model artifact in the service bucket. "
-                f"Using artifact from service bucket instead of {os_path}."
-            )
-
-            # todo: implement generic copy_folder method
-            # copy model config from artifact path to user bucket
-            copy_model_config(
-                artifact_path=artifact_path, os_path=os_path, auth=default_signer()
-            )
-        except Exception:
-            logger.debug(
-                f"Proceeding with model registration without copying model config files at {os_path}. "
-                f"Default configuration will be used for deployment and fine-tuning."
-            )
         # Set artifact location to user bucket, and replace existing key if present.
         metadata.add(
             key=MODEL_BY_REFERENCE_OSS_PATH_KEY,

--- a/tests/unitary/with_extras/aqua/test_config.py
+++ b/tests/unitary/with_extras/aqua/test_config.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import json
 import os
-from unittest.mock import patch
+import pytest
+from unittest.mock import patch, MagicMock
+
+import oci.data_science.models
 
 from ads.aqua.common.entities import ContainerSpec
 from ads.aqua.config.config import get_evaluation_service_config
+from ads.aqua.app import AquaApp
 
 
 class TestConfig:
@@ -37,3 +41,63 @@ class TestConfig:
             test_result.to_dict()
             == expected_result[ContainerSpec.CONTAINER_SPEC]["test_container"]
         )
+
+    @pytest.mark.parametrize(
+        "custom_metadata",
+        [
+            {
+                "category": "Other",
+                "description": "test_desc",
+                "key": "artifact_location",
+                "value": "artifact_location",
+            },
+            {},
+        ],
+    )
+    @pytest.mark.parametrize("verified_model", [True, False])
+    @pytest.mark.parametrize("path_exists", [True, False])
+    @patch("ads.aqua.app.load_config")
+    def test_load_config(
+        self, mock_load_config, custom_metadata, verified_model, path_exists
+    ):
+        mock_load_config.return_value = {"config_key": "config_value"}
+        service_model_tag = (
+            {"aqua_service_model": "aqua_service_model_id"} if verified_model else {}
+        )
+
+        self.app = AquaApp()
+
+        model = {
+            "id": "mock_id",
+            "lifecycle_details": "mock_lifecycle_details",
+            "lifecycle_state": "mock_lifecycle_state",
+            "project_id": "mock_project_id",
+            "freeform_tags": {
+                **{
+                    "OCI_AQUA": "",
+                },
+                **service_model_tag,
+            },
+            "custom_metadata_list": [
+                oci.data_science.models.Metadata(**custom_metadata)
+            ],
+        }
+
+        self.app.ds_client.get_model = MagicMock(
+            return_value=oci.response.Response(
+                status=200,
+                request=MagicMock(),
+                headers=MagicMock(),
+                data=oci.data_science.models.Model(**model),
+            )
+        )
+        with patch("ads.aqua.app.is_path_exists", return_value=path_exists):
+            result = self.app.get_config(
+                model_id="test_model_id", config_file_name="test_config_file_name"
+            )
+            if not path_exists:
+                assert result == {}
+            if not custom_metadata:
+                assert result == {}
+            if path_exists and custom_metadata:
+                assert result == {"config_key": "config_value"}

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -665,7 +665,6 @@ class TestAquaModel:
     @patch("ads.model.datascience_model.DataScienceModel.sync")
     @patch("ads.model.datascience_model.DataScienceModel.upload_artifact")
     @patch.object(AquaModelApp, "_find_matching_aqua_model")
-    @patch("ads.aqua.common.utils.copy_file")
     @patch("ads.common.object_storage_details.ObjectStorageDetails.list_objects")
     @patch("ads.aqua.common.utils.load_config", return_value={})
     @patch("huggingface_hub.snapshot_download")
@@ -676,7 +675,6 @@ class TestAquaModel:
         mock_snapshot_download,
         mock_load_config,
         mock_list_objects,
-        mock_copy_file,
         mock__find_matching_aqua_model,
         mock_upload_artifact,
         mock_sync,
@@ -788,8 +786,6 @@ class TestAquaModel:
             mock_subprocess.assert_not_called()
             mock_load_config.assert_called()
 
-        if not artifact_location_set:
-            mock_copy_file.assert_called()
         ds_freeform_tags.pop(
             "ready_to_import"
         )  # The imported model should not have this tag


### PR DESCRIPTION
### Description

Currently we copy deployment_config.json and finetuning_config.json from service tenancy bucket into user bucket while registering the model. This causes inconsistency in future when new shape support is added or when we enable fine-tuning to verified models. User in this case is forced to delete and re-register the model so that the configurations get refreshed.

This PR ensures that :
- for verified models, we always refer to the service tenancy configuration so that when there is a new update, the existing registered models will pick it up. Because of this, we don't need to copy the config files in the user bucket anymore.
- for unverified models, user can create a config folder themselves and add it in artifact location. This will be a backdoor option if user wishes to customize their configuration for deployment and finetuning. If not added, then defaults from UI will be shown.

Note: this issue also comes up for freeform tags, that will be updated in a separate PR.

### Jira
https://jira.oci.oraclecorp.com/browse/ODSC-66853
