### PR TITLE
Fix config load paths and update ads version

### DIFF
--- a/ads/aqua/app.py
+++ b/ads/aqua/app.py
@@ -306,17 +306,19 @@ class AquaApp:
             )
             base_model = self.ds_client.get_model(base_model_ocid).data
             artifact_path = get_artifact_path(base_model.custom_metadata_list)
-            config_path = f"{os.path.dirname(artifact_path)}/config/"
         else:
             logger.info(f"Loading {config_file_name} for model {oci_model.id}...")
             artifact_path = get_artifact_path(oci_model.custom_metadata_list)
-            config_path = f"{artifact_path.rstrip('/')}/config/"
 
         if not artifact_path:
             logger.debug(
                 f"Failed to get artifact path from custom metadata for the model: {model_id}"
             )
             return config
+
+        config_path = f"{os.path.dirname(artifact_path)}/config/"
+        if not is_path_exists(config_path):
+            config_path = f"{artifact_path.rstrip('/')}/config/"
 
         config_file_path = f"{config_path}{config_file_name}"
         if is_path_exists(config_file_path):

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,13 @@
 Release Notes
 =============
 
+2.12.11
+-------
+Release date: Feb 5th, 2024
+
+* Fixed bug while loading model configuration in AI Quick Actions.
+
+
 2.12.10
 -------
 Release date: Feb 5th, 2024

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "flit_core.buildapi"
 
 # Required
 name = "oracle_ads" # the install (PyPI) name; name for local build in [tool.flit.module] section below
-version = "2.12.10"
+version = "2.12.11"
 
 # Optional
 description = "Oracle Accelerated Data Science SDK"


### PR DESCRIPTION
### Description

The PR https://github.com/oracle/accelerated-data-science/pull/1053 introduced a bug in the code that loads configuration files for finetuning and deployment. The issue was that the structure of the models without service tag is inconsistent, and the code didn't account for this. The fix for this is to check the parent directory of the artifact folder first (in case of verified models), and then check the artifact directory (for unverified models). 

### Test Cases

The following applies to both `ft_config.json` and `deployment_config.json`.

1. Config for cached verified models
    * model will not have "aqua_service_model" tag, hence artifact path will be set to the service bucket location.
    * Example: `oci://service-managed-models@<namespace>/service_models/Mistral-7B-Instruct-v0.1/3dc28cf/config/ft_config.json`
2. Config for uncached and registered verified models
    * model will have the "aqua_service_model" tag, so base model's artifact path will be used, which in turn refers to the service bucket location.
    * Example: `oci://service-managed-models@<namespace>/service_models/gemma-2b-it/de144fb/config/deployment_config.json`
3. Config for unverified models 
    * model will not have "aqua_service_model" tag, hence artifact path will be set to the location of user's bucket. 
    * Example: `oci://user-bucket@<namespace>/aqua/models/BAAI/bge-m3/config/deployment_config.json`
    * The config file does not exist by default, hence the API return an empty dict. If user prefers to add their own config, they can add it in the `config` folder in the user bucket as per instructions [here](https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/model-deployment-tips.md#advanced-configuration-update-options), and the API will return the respective configs.

The above also applies to deploying fine-tuned models as the verified models will have the "aqua_service_model" tag, hence it will always refer to the base model configs for deployment.
