### PR TITLE
[ODSC-56699] Update MD entities to pydantic models

### DIFF
--- a/ads/aqua/common/entities.py
+++ b/ads/aqua/common/entities.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+from typing import Optional
+
+from ads.aqua.config.utils.serializer import Serializable
 
 
 class ContainerSpec:
@@ -15,3 +19,13 @@ class ContainerSpec:
     ENV_VARS = "envVars"
     RESTRICTED_PARAMS = "restrictedParams"
     EVALUATION_CONFIGURATION = "evaluationConfiguration"
+
+
+class ShapeInfo(Serializable):
+    instance_shape: Optional[str] = None
+    instance_count: Optional[int] = None
+    ocpus: Optional[float] = None
+    memory_in_gbs: Optional[float] = None
+
+    class Config:
+        extra = "ignore"

--- a/ads/aqua/extension/deployment_handler.py
+++ b/ads/aqua/extension/deployment_handler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 from urllib.parse import urlparse
@@ -11,7 +11,7 @@ from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua.extension.errors import Errors
 from ads.aqua.modeldeployment import AquaDeploymentApp, MDInferenceResponse
 from ads.aqua.modeldeployment.entities import ModelParams
-from ads.config import COMPARTMENT_OCID, PROJECT_OCID
+from ads.config import COMPARTMENT_OCID
 
 
 class AquaDeploymentHandler(AquaAPIhandler):
@@ -98,71 +98,7 @@ class AquaDeploymentHandler(AquaAPIhandler):
         if not input_data:
             raise HTTPError(400, Errors.NO_INPUT_DATA)
 
-        # required input parameters
-        display_name = input_data.get("display_name")
-        if not display_name:
-            raise HTTPError(
-                400, Errors.MISSING_REQUIRED_PARAMETER.format("display_name")
-            )
-        instance_shape = input_data.get("instance_shape")
-        if not instance_shape:
-            raise HTTPError(
-                400, Errors.MISSING_REQUIRED_PARAMETER.format("instance_shape")
-            )
-        model_id = input_data.get("model_id")
-        if not model_id:
-            raise HTTPError(400, Errors.MISSING_REQUIRED_PARAMETER.format("model_id"))
-
-        compartment_id = input_data.get("compartment_id", COMPARTMENT_OCID)
-        project_id = input_data.get("project_id", PROJECT_OCID)
-        log_group_id = input_data.get("log_group_id")
-        access_log_id = input_data.get("access_log_id")
-        predict_log_id = input_data.get("predict_log_id")
-        description = input_data.get("description")
-        instance_count = input_data.get("instance_count")
-        bandwidth_mbps = input_data.get("bandwidth_mbps")
-        web_concurrency = input_data.get("web_concurrency")
-        server_port = input_data.get("server_port")
-        health_check_port = input_data.get("health_check_port")
-        env_var = input_data.get("env_var")
-        container_family = input_data.get("container_family")
-        ocpus = input_data.get("ocpus")
-        memory_in_gbs = input_data.get("memory_in_gbs")
-        model_file = input_data.get("model_file")
-        private_endpoint_id = input_data.get("private_endpoint_id")
-        container_image_uri = input_data.get("container_image_uri")
-        cmd_var = input_data.get("cmd_var")
-        freeform_tags = input_data.get("freeform_tags")
-        defined_tags = input_data.get("defined_tags")
-
-        self.finish(
-            AquaDeploymentApp().create(
-                compartment_id=compartment_id,
-                project_id=project_id,
-                model_id=model_id,
-                display_name=display_name,
-                description=description,
-                instance_count=instance_count,
-                instance_shape=instance_shape,
-                log_group_id=log_group_id,
-                access_log_id=access_log_id,
-                predict_log_id=predict_log_id,
-                bandwidth_mbps=bandwidth_mbps,
-                web_concurrency=web_concurrency,
-                server_port=server_port,
-                health_check_port=health_check_port,
-                env_var=env_var,
-                container_family=container_family,
-                ocpus=ocpus,
-                memory_in_gbs=memory_in_gbs,
-                model_file=model_file,
-                private_endpoint_id=private_endpoint_id,
-                container_image_uri=container_image_uri,
-                cmd_var=cmd_var,
-                freeform_tags=freeform_tags,
-                defined_tags=defined_tags,
-            )
-        )
+        self.finish(AquaDeploymentApp().create(**input_data))
 
     def read(self, id):
         """Read the information of an Aqua model deployment."""

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -162,16 +162,8 @@ class AquaDeploymentApp(AquaApp):
                 ) from err
 
         # set up env and cmd var
-        env_var = (
-            create_deployment_details.env_var
-            if create_deployment_details.env_var
-            else {}
-        )
-        cmd_var = (
-            create_deployment_details.cmd_var
-            if create_deployment_details.cmd_var
-            else []
-        )
+        env_var = create_deployment_details.env_var or {}
+        cmd_var = create_deployment_details.cmd_var or []
 
         try:
             model_path_prefix = aqua_model.custom_metadata_list.get(

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -117,7 +117,7 @@ class AquaDeploymentApp(AquaApp):
             except ValidationError as ex:
                 custom_errors = build_pydantic_error_message(ex)
                 raise AquaValueError(
-                    f"Invalid parameters for creating a model deployment. \nError details: {custom_errors}."
+                    f"Invalid parameters for creating a model deployment. Error details: {custom_errors}."
                 ) from ex
 
         # Create a model catalog entry in the user compartment

--- a/ads/aqua/modeldeployment/entities.py
+++ b/ads/aqua/modeldeployment/entities.py
@@ -1,59 +1,65 @@
 #!/usr/bin/env python
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-from dataclasses import dataclass, field
 from typing import List, Optional, Union
 
 from oci.data_science.models import (
     ModelDeployment,
     ModelDeploymentSummary,
 )
+from pydantic import Field, model_validator
 
 from ads.aqua.common.enums import Tags
+from ads.aqua.common.errors import AquaValueError
+from ads.aqua.config.utils.serializer import Serializable
 from ads.aqua.constants import UNKNOWN, UNKNOWN_DICT
 from ads.aqua.data import AquaResourceIdentifier
 from ads.common.serializer import DataClassSerializable
 from ads.common.utils import get_console_link
 
 
-@dataclass
-class ModelParams:
-    max_tokens: int = None
-    temperature: float = None
-    top_k: float = None
-    top_p: float = None
-    model: str = None
+class ModelParams(Serializable):
+    max_tokens: Optional[int] = None
+    temperature: Optional[float] = None
+    top_k: Optional[float] = None
+    top_p: Optional[float] = None
+    model: Optional[str] = None
+
+    class Config:
+        extra = "ignore"
+        protected_namespaces = ()
 
 
-@dataclass
-class ShapeInfo:
-    instance_shape: str = None
-    instance_count: int = None
-    ocpus: float = None
-    memory_in_gbs: float = None
+class ShapeInfo(Serializable):
+    instance_shape: Optional[str] = None
+    instance_count: Optional[int] = None
+    ocpus: Optional[float] = None
+    memory_in_gbs: Optional[float] = None
+
+    class Config:
+        extra = "ignore"
 
 
-@dataclass(repr=False)
-class AquaDeployment(DataClassSerializable):
+class AquaDeployment(Serializable):
     """Represents an Aqua Model Deployment"""
 
-    id: str = None
-    display_name: str = None
-    aqua_service_model: bool = None
-    aqua_model_name: str = None
-    state: str = None
-    description: str = None
-    created_on: str = None
-    created_by: str = None
-    endpoint: str = None
-    private_endpoint_id: str = None
-    console_link: str = None
-    lifecycle_details: str = None
+    id: Optional[str] = None
+    display_name: Optional[str] = None
+    aqua_service_model: Optional[bool] = None
+    aqua_model_name: Optional[str] = None
+    state: Optional[str] = None
+    description: Optional[str] = None
+    created_on: Optional[str] = None
+    created_by: Optional[str] = None
+    endpoint: Optional[str] = None
+    private_endpoint_id: Optional[str] = None
+    console_link: Optional[str] = None
+    lifecycle_details: Optional[str] = None
     shape_info: Optional[ShapeInfo] = None
-    tags: dict = None
-    environment_variables: dict = None
-    cmd: List[str] = None
+    tags: Optional[dict] = None
+    environment_variables: Optional[dict] = None
+    cmd: Optional[List[str]] = None
 
     @classmethod
     def from_oci_model_deployment(
@@ -133,10 +139,126 @@ class AquaDeployment(DataClassSerializable):
             cmd=cmd,
         )
 
+    class Config:
+        extra = "ignore"
 
-@dataclass(repr=False)
+
 class AquaDeploymentDetail(AquaDeployment, DataClassSerializable):
     """Represents a details of Aqua deployment."""
 
-    log_group: AquaResourceIdentifier = field(default_factory=AquaResourceIdentifier)
-    log: AquaResourceIdentifier = field(default_factory=AquaResourceIdentifier)
+    log_group: AquaResourceIdentifier = Field(default_factory=AquaResourceIdentifier)
+    log: AquaResourceIdentifier = Field(default_factory=AquaResourceIdentifier)
+
+    class Config:
+        extra = "ignore"
+
+
+class ModelInfo(Serializable):
+    """Class for maintaining details of model to be deployed, usually for multi-model deployment."""
+
+    model_id: str
+    gpu_count: Optional[int] = None
+    env_var: Optional[dict] = None
+
+    class Config:
+        extra = "ignore"
+
+
+class CreateModelDeploymentDetails(Serializable):
+    """Class for creating aqua model deployment.
+
+    Properties
+    ----------
+    compartment_id: str
+        The compartment OCID
+    project_id: str
+        Target project to list deployments from.
+    display_name: str
+        The name of model deployment.
+    description: str
+        The description of the deployment.
+    model_id: (str, optional)
+        The model OCID to deploy. Either model_id or model_info should be set.
+    model_info: (List[ModelInfo], optional)
+        The model info to deploy, used for multimodel deployment. Either model_id or model_info should be set.
+    instance_count: (int, optional). Defaults to 1.
+        The number of instance used for deployment.
+    instance_shape: (str).
+        The shape of the instance used for deployment.
+    log_group_id: (str)
+        The oci logging group id. The access log and predict log share the same log group.
+    access_log_id: (str).
+        The access log OCID for the access logs. https://docs.oracle.com/en-us/iaas/data-science/using/model_dep_using_logging.htm
+    predict_log_id: (str).
+        The predict log OCID for the predict logs. https://docs.oracle.com/en-us/iaas/data-science/using/model_dep_using_logging.htm
+    bandwidth_mbps: (int). Defaults to 10.
+        The bandwidth limit on the load balancer in Mbps.
+    web_concurrency: str
+        The number of worker processes/threads to handle incoming requests
+    with_bucket_uri(bucket_uri)
+        Sets the bucket uri when uploading large size model.
+    server_port: (int).
+        The server port for docker container image.
+    health_check_port: (int).
+        The health check port for docker container image.
+    env_var : dict, optional
+        Environment variable for the deployment, by default None.
+    container_family: str
+        The image family of model deployment container runtime.
+    memory_in_gbs: float
+        The memory in gbs for the shape selected.
+    ocpus: float
+        The ocpu count for the shape selected.
+    model_file: str
+        The file used for model deployment.
+    private_endpoint_id: str
+        The private endpoint id of model deployment.
+    container_image_uri: str
+        The image of model deployment container runtime, ignored for service managed containers.
+        Required parameter for BYOC based deployments if this parameter was not set during model registration.
+    cmd_var: List[str]
+        The cmd of model deployment container runtime.
+    freeform_tags: dict
+        Freeform tags for the model deployment
+    defined_tags: dict
+        Defined tags for the model deployment
+    """
+
+    instance_shape: str
+    display_name: str
+    model_id: Optional[str] = None
+    model_info: Optional[List[ModelInfo]] = None
+    instance_count: Optional[int] = None
+    log_group_id: Optional[str] = None
+    access_log_id: Optional[str] = None
+    predict_log_id: Optional[str] = None
+    compartment_id: Optional[str] = None
+    project_id: Optional[str] = None
+    description: Optional[str] = None
+    bandwidth_mbps: Optional[int] = None
+    web_concurrency: Optional[int] = None
+    server_port: Optional[int] = None
+    health_check_port: Optional[int] = None
+    env_var: Optional[dict] = None
+    container_family: Optional[str] = None
+    memory_in_gbs: Optional[float] = None
+    ocpus: Optional[float] = None
+    model_file: Optional[str] = None
+    private_endpoint_id: Optional[str] = None
+    container_image_uri: Optional[None] = None
+    cmd_var: Optional[List[str]] = None
+    freeform_tags: Optional[dict] = None
+    defined_tags: Optional[dict] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_model_fields(cls, values):
+        model_id, model_info = values.get("model_id"), values.get("model_info")
+        if bool(model_id) == bool(model_info):  # either both are set or unset
+            raise AquaValueError(
+                "Exactly one of `model_id` or `model_info` must be set to create a model deployment"
+            )
+        return values
+
+    class Config:
+        extra = "ignore"

--- a/ads/aqua/modeldeployment/entities.py
+++ b/ads/aqua/modeldeployment/entities.py
@@ -10,6 +10,7 @@ from oci.data_science.models import (
 )
 from pydantic import Field, model_validator
 
+from ads.aqua.common.entities import ShapeInfo
 from ads.aqua.common.enums import Tags
 from ads.aqua.common.errors import AquaValueError
 from ads.aqua.config.utils.serializer import Serializable
@@ -27,18 +28,8 @@ class ModelParams(Serializable):
     model: Optional[str] = None
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
         protected_namespaces = ()
-
-
-class ShapeInfo(Serializable):
-    instance_shape: Optional[str] = None
-    instance_count: Optional[int] = None
-    ocpus: Optional[float] = None
-    memory_in_gbs: Optional[float] = None
-
-    class Config:
-        extra = "ignore"
 
 
 class AquaDeployment(Serializable):

--- a/ads/aqua/modeldeployment/inference.py
+++ b/ads/aqua/modeldeployment/inference.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*--
 
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 
 import requests
 
-from ads.aqua.app import AquaApp, logger
+from ads.aqua.app import AquaApp
 from ads.aqua.modeldeployment.entities import ModelParams
 from ads.common.auth import default_signer
 from ads.telemetry import telemetry
@@ -63,7 +62,7 @@ class MDInferenceResponse(AquaApp):
         model_response_content
         """
 
-        params_dict = asdict(self.model_params)
+        params_dict = self.model_params.to_dict()
         params_dict = {
             key: value for key, value in params_dict.items() if value is not None
         }

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*--
 
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import copy
 import json
 import os
 import unittest
-from dataclasses import asdict
 from importlib import reload
 from unittest.mock import MagicMock, patch
 
@@ -35,6 +34,7 @@ null = None
 class TestDataset:
     SERVICE_COMPARTMENT_ID = "ocid1.compartment.oc1..<OCID>"
     USER_COMPARTMENT_ID = "ocid1.compartment.oc1..<USER_COMPARTMENT_OCID>"
+    USER_PROJECT_ID = "ocid1.project.oc1..<USER_PROJECT_OCID>"
     COMPARTMENT_ID = "ocid1.compartment.oc1..<UNIQUE_OCID>"
     MODEL_DEPLOYMENT_ID = "ocid1.datasciencemodeldeployment.oc1.<region>.<MD_OCID>"
     MODEL_DEPLOYMENT_URL = "https://modeldeployment.customer-oci.com/ocid1.datasciencemodeldeployment.oc1.<region>.<MD_OCID>"
@@ -107,7 +107,7 @@ class TestDataset:
                 }
             ),
             "model_deployment_url": MODEL_DEPLOYMENT_URL,
-            "project_id": "ocid1.datascienceproject.oc1.<region>.<OCID>",
+            "project_id": USER_PROJECT_ID,
             "time_created": "2024-01-01T00:00:00.000000+00:00",
         }
     ]
@@ -166,7 +166,7 @@ class TestDataset:
                 }
             ),
             "model_deployment_url": MODEL_DEPLOYMENT_URL,
-            "project_id": "ocid1.datascienceproject.oc1.<region>.<OCID>",
+            "project_id": USER_PROJECT_ID,
             "time_created": "2024-01-01T00:00:00.000000+00:00",
         }
     ]
@@ -238,7 +238,7 @@ class TestDataset:
                 }
             ),
             "model_deployment_url": MODEL_DEPLOYMENT_URL,
-            "project_id": "ocid1.datascienceproject.oc1.<region>.<OCID>",
+            "project_id": USER_PROJECT_ID,
             "time_created": "2024-01-01T00:00:00.000000+00:00",
         }
     ]
@@ -288,7 +288,7 @@ class TestDataset:
     }
 
     aqua_deployment_detail = {
-        **vars(AquaDeployment(**aqua_deployment_object)),
+        **(AquaDeployment(**aqua_deployment_object).to_dict()),
         "log_group": {
             "id": "ocid1.loggroup.oc1.<region>.<OCID>",
             "name": "log-group-name",
@@ -340,6 +340,7 @@ class TestAquaDeployment(unittest.TestCase):
         os.environ["CONDA_BUCKET_NS"] = "test-namespace"
         os.environ["ODSC_MODEL_COMPARTMENT_OCID"] = TestDataset.SERVICE_COMPARTMENT_ID
         os.environ["PROJECT_COMPARTMENT_OCID"] = TestDataset.USER_COMPARTMENT_ID
+        os.environ["PROJECT_OCID"] = TestDataset.USER_PROJECT_ID
         reload(ads.config)
         reload(ads.aqua)
         reload(ads.aqua.modeldeployment.deployment)
@@ -350,6 +351,7 @@ class TestAquaDeployment(unittest.TestCase):
         os.environ.pop("CONDA_BUCKET_NS", None)
         os.environ.pop("ODSC_MODEL_COMPARTMENT_OCID", None)
         os.environ.pop("PROJECT_COMPARTMENT_OCID", None)
+        os.environ.pop("PROJECT_OCID", None)
         reload(ads.config)
         reload(ads.aqua)
         reload(ads.aqua.modeldeployment.deployment)
@@ -370,7 +372,7 @@ class TestAquaDeployment(unittest.TestCase):
         assert len(results) == 1
         expected_attributes = AquaDeployment.__annotations__.keys()
         for r in results:
-            actual_attributes = asdict(r)
+            actual_attributes = r.to_dict()
             assert set(actual_attributes) == set(
                 expected_attributes
             ), "Attributes mismatch"
@@ -401,7 +403,9 @@ class TestAquaDeployment(unittest.TestCase):
         expected_attributes = set(AquaDeploymentDetail.__annotations__.keys()) | set(
             AquaDeployment.__annotations__.keys()
         )
-        actual_attributes = asdict(result)
+        actual_attributes = result.to_dict()
+        # print(actual_attributes)
+        print(TestDataset.aqua_deployment_detail)
         assert set(actual_attributes) == set(expected_attributes), "Attributes mismatch"
         assert actual_attributes == TestDataset.aqua_deployment_detail
         assert result.log.name == "log-name"
@@ -506,8 +510,8 @@ class TestAquaDeployment(unittest.TestCase):
 
         mock_create.assert_called_with(
             model_id=TestDataset.MODEL_ID,
-            compartment_id=None,
-            project_id=None,
+            compartment_id=TestDataset.USER_COMPARTMENT_ID,
+            project_id=TestDataset.USER_PROJECT_ID,
             freeform_tags=freeform_tags,
             defined_tags=defined_tags,
         )
@@ -515,7 +519,7 @@ class TestAquaDeployment(unittest.TestCase):
         mock_deploy.assert_called()
 
         expected_attributes = set(AquaDeployment.__annotations__.keys())
-        actual_attributes = asdict(result)
+        actual_attributes = result.to_dict()
         assert set(actual_attributes) == set(expected_attributes), "Attributes mismatch"
         expected_result = copy.deepcopy(TestDataset.aqua_deployment_object)
         expected_result["state"] = "CREATING"
@@ -580,8 +584,8 @@ class TestAquaDeployment(unittest.TestCase):
 
         mock_create.assert_called_with(
             model_id=TestDataset.MODEL_ID,
-            compartment_id=None,
-            project_id=None,
+            compartment_id=TestDataset.USER_COMPARTMENT_ID,
+            project_id=TestDataset.USER_PROJECT_ID,
             freeform_tags=None,
             defined_tags=None,
         )
@@ -589,7 +593,7 @@ class TestAquaDeployment(unittest.TestCase):
         mock_deploy.assert_called()
 
         expected_attributes = set(AquaDeployment.__annotations__.keys())
-        actual_attributes = asdict(result)
+        actual_attributes = result.to_dict()
         assert set(actual_attributes) == set(expected_attributes), "Attributes mismatch"
         expected_result = copy.deepcopy(TestDataset.aqua_deployment_object)
         expected_result["state"] = "CREATING"
@@ -656,8 +660,8 @@ class TestAquaDeployment(unittest.TestCase):
 
         mock_create.assert_called_with(
             model_id=TestDataset.MODEL_ID,
-            compartment_id=None,
-            project_id=None,
+            compartment_id=TestDataset.USER_COMPARTMENT_ID,
+            project_id=TestDataset.USER_PROJECT_ID,
             freeform_tags=None,
             defined_tags=None,
         )
@@ -665,7 +669,7 @@ class TestAquaDeployment(unittest.TestCase):
         mock_deploy.assert_called()
 
         expected_attributes = set(AquaDeployment.__annotations__.keys())
-        actual_attributes = asdict(result)
+        actual_attributes = result.to_dict()
         assert set(actual_attributes) == set(expected_attributes), "Attributes mismatch"
         expected_result = copy.deepcopy(TestDataset.aqua_deployment_object)
         expected_result["state"] = "CREATING"
@@ -735,8 +739,8 @@ class TestAquaDeployment(unittest.TestCase):
 
         mock_create.assert_called_with(
             model_id=TestDataset.MODEL_ID,
-            compartment_id=None,
-            project_id=None,
+            compartment_id=TestDataset.USER_COMPARTMENT_ID,
+            project_id=TestDataset.USER_PROJECT_ID,
             freeform_tags=None,
             defined_tags=None,
         )
@@ -744,7 +748,7 @@ class TestAquaDeployment(unittest.TestCase):
         mock_deploy.assert_called()
 
         expected_attributes = set(AquaDeployment.__annotations__.keys())
-        actual_attributes = asdict(result)
+        actual_attributes = result.to_dict()
         assert set(actual_attributes) == set(expected_attributes), "Attributes mismatch"
         expected_result = copy.deepcopy(TestDataset.aqua_deployment_object)
         expected_result["state"] = "CREATING"

--- a/tests/unitary/with_extras/aqua/test_deployment_handler.py
+++ b/tests/unitary/with_extras/aqua/test_deployment_handler.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*--
 
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import os
@@ -31,6 +31,8 @@ class TestDataset:
         "display_name": "test-deployment-name",
         "freeform_tags": {"ftag1": "fvalue1", "ftag2": "fvalue2"},
         "defined_tags": {"dtag1": "dvalue1", "dtag2": "dvalue2"},
+        "project_id": USER_PROJECT_ID,
+        "compartment_id": USER_COMPARTMENT_ID,
     }
     inference_request = {
         "prompt": "What is 1+1?",
@@ -140,24 +142,7 @@ class TestAquaDeploymentHandler(unittest.TestCase):
             project_id=TestDataset.USER_PROJECT_ID,
             model_id=TestDataset.deployment_request["model_id"],
             display_name=TestDataset.deployment_request["display_name"],
-            description=None,
-            instance_count=None,
             instance_shape=TestDataset.deployment_request["instance_shape"],
-            log_group_id=None,
-            access_log_id=None,
-            predict_log_id=None,
-            bandwidth_mbps=None,
-            web_concurrency=None,
-            server_port=None,
-            health_check_port=None,
-            env_var=None,
-            container_family=None,
-            memory_in_gbs=None,
-            ocpus=None,
-            model_file=None,
-            private_endpoint_id=None,
-            container_image_uri=None,
-            cmd_var=None,
             freeform_tags=TestDataset.deployment_request["freeform_tags"],
             defined_tags=TestDataset.deployment_request["defined_tags"],
         )


### PR DESCRIPTION
### Description

This PR covers the following:
- Move aqua create deployment function inputs from function to pydantic model.
- Update aqua model deployment entities to pydantic models.
- Introduce `model_info` field for creating multi-model deployment.
- Update unit tests

### Jira
https://jira.oci.oraclecorp.com/browse/ODSC-56699

### Usage of model_info
The new `model_info` field can be used for multi-model deployment. The PR only adds the field, the implementation in the create method is needed in order for this to work. The current `model_id` field can still be used for single model deployment.

#### Handler request
```
POST /aqua/deployments/
{
    "model_info": [
        {"model_id": "test_model_ocid_1", "gpu_count": 2},
        {"model_id": "test_model_ocid_2", "gpu_count": 2}
    ],
    "instance_shape": "VM.GPU.A10.4",
    "display_name": "model name",
}
```
#### Handler request with validation
```
POST /aqua/deployments/
{
    "instance_shape": "VM.GPU.A10.4",
    "display_name": "model name",
}
```
##### Response
```
{
    "status": 403,
    "message": "We're having trouble processing your request with the information provided.",
    "service_payload": {},
    "reason": "Invalid parameters for creating a model deployment. Error details: Value error, Exactly one of `model_id` or `model_info` must be set to create a model deployment.",
    "request_id": "44318f9a-e784-4efd-8d7d-1e741b700edc"
}
```

#### CLI request
```
ads aqua deployment create  --instance_shape VM.GPU.A10.2 
--display_name "model name"
--model_info '[{"model_id": "model_id_1", "gpu_count": 1, "env_var": {"PARAMS": "param_value1"}}, {"model_id": "model_id_2"}]'
```

### Unit Tests

```
> python -m pytest -q tests/unitary/with_extras/aqua/*
============================== test session starts ==============================
platform darwin -- Python 3.9.7, pytest-7.4.4, pluggy-1.5.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: cov-6.0.0, Faker-33.1.0, anyio-4.8.0, dash-2.18.2, xdist-3.6.1
collected 317 items

tests/unitary/with_extras/aqua/test_cli.py ............................   [  4%]
tests/unitary/with_extras/aqua/test_client.py ........................... [ 12%]
....ssssssssssss                                                          [ 17%]
tests/unitary/with_extras/aqua/test_common_handler.py ...                 [ 18%]
tests/unitary/with_extras/aqua/test_config.py .........                   [ 21%]
tests/unitary/with_extras/aqua/test_decorator.py ..........               [ 24%]
tests/unitary/with_extras/aqua/test_deployment.py ......................  [ 31%]
tests/unitary/with_extras/aqua/test_deployment_handler.py .....s......    [ 35%]
tests/unitary/with_extras/aqua/test_evaluation.py ....................... [ 42%]
......                                                                    [ 44%]
tests/unitary/with_extras/aqua/test_evaluation_handler.py ......          [ 46%]
tests/unitary/with_extras/aqua/test_evaluation_service_config.py ........ [ 49%]
.............                                                             [ 53%]
tests/unitary/with_extras/aqua/test_finetuning.py ..........              [ 56%]
tests/unitary/with_extras/aqua/test_finetuning_handler.py .....           [ 58%]
tests/unitary/with_extras/aqua/test_global.py ...                         [ 58%]
tests/unitary/with_extras/aqua/test_handlers.py .................         [ 64%]
tests/unitary/with_extras/aqua/test_model.py ............................ [ 73%]
.....                                                                     [ 74%]
tests/unitary/with_extras/aqua/test_model_handler.py .................... [ 81%]
                                                                          [ 81%]
tests/unitary/with_extras/aqua/test_ui.py ................                [ 86%]
tests/unitary/with_extras/aqua/test_ui_handler.py ...............         [ 90%]
tests/unitary/with_extras/aqua/test_ui_websocket_handler.py ....          [ 92%]
tests/unitary/with_extras/aqua/test_utils.py ...........

================== 304 passed, 13 skipped in 62.36s (0:01:02) ===================
```
