### PR TITLE
Modify get deployment config as pydantic

### DIFF
--- a/ads/aqua/extension/deployment_handler.py
+++ b/ads/aqua/extension/deployment_handler.py
@@ -48,10 +48,7 @@ class AquaDeploymentHandler(AquaAPIhandler):
                     400,
                     f"The request to {self.request.path} must include either a single model ID or a list of model IDs.",
                 )
-            if isinstance(id, list):
-                return self.get_multimodel_deployment_config(id)
-            else:
-                return self.get_deployment_config(id)
+            return self.get_deployment_config(id)
         elif paths.startswith("aqua/deployments"):
             if not id:
                 return self.list()

--- a/ads/aqua/modeldeployment/entities.py
+++ b/ads/aqua/modeldeployment/entities.py
@@ -258,7 +258,7 @@ class ShapeInfoConfig(Serializable):
         extra = "allow"
 
 
-class ShapeInfo(Serializable):
+class DeploymentShapeInfo(Serializable):
     """Describes the shape information to this model for specific shape.
 
     Attributes:
@@ -306,7 +306,7 @@ class ConfigurationItem(Serializable):
         parameters (Dict[str, str], optional): A dictionary of parameters (e.g., VLLM_PARAMS) to
             configure the behavior of a particular GPU shape.
         multi_model_deployment (List[MultiModelConfig], optional): A list of multi model configuration details.
-        shape_info (ShapeInfo, optional): The shape information to this model for specific CPU shape.
+        shape_info (DeploymentShapeInfo, optional): The shape information to this model for specific CPU shape.
     """
 
     parameters: Optional[Dict[str, str]] = Field(
@@ -316,8 +316,8 @@ class ConfigurationItem(Serializable):
     multi_model_deployment: Optional[List[MultiModelConfig]] = Field(
         default_factory=list, description="A list of multi model configuration details."
     )
-    shape_info: Optional[ShapeInfo] = Field(
-        default_factory=ShapeInfo,
+    shape_info: Optional[DeploymentShapeInfo] = Field(
+        default_factory=DeploymentShapeInfo,
         description="The shape information to this model for specific shape",
     )
 

--- a/ads/aqua/modeldeployment/entities.py
+++ b/ads/aqua/modeldeployment/entities.py
@@ -255,16 +255,57 @@ class CreateModelDeploymentDetails(Serializable):
         extra = "ignore"
 
 
+class ShapeInfoConfig(Serializable):
+    """Describes how many memory and cpu to this model for specific shape.
+
+    Attributes:
+        memory_in_gbs (int, optional): The number of memory in gbs to this model of the shape.
+        ocpu (int, optional): The number of ocpus to this model of the shape.
+    """
+
+    memory_in_gbs: Optional[int] = Field(
+        default_factory=int,
+        description="The number of memory in gbs to this model of the shape.",
+    )
+    ocpu: Optional[int] = Field(
+        default_factory=int,
+        description="The number of ocpus to this model of the shape.",
+    )
+
+    class Config:
+        extra = "allow"
+
+
+class ShapeInfo(Serializable):
+    """Describes the shape information to this model for specific shape.
+
+    Attributes:
+        configs (List[ShapeInfoConfig], optional): A list of memory and cpu number details to this model of the shape.
+        type (str, optional): The type of the shape.
+    """
+
+    configs: Optional[List[ShapeInfoConfig]] = Field(
+        default_factory=list,
+        description="A list of memory and cpu number details to this model of the shape.",
+    )
+    type: Optional[str] = Field(
+        default_factory=str, description="The type of the shape."
+    )
+
+    class Config:
+        extra = "allow"
+
+
 class MultiModelConfig(Serializable):
     """Describes how many GPUs and the parameters of specific shape for multi model deployment.
 
     Attributes:
-        gpu_count (int): Number of GPUs count to this model of this shape.
+        gpu_count (int, optional): Number of GPUs count to this model of this shape.
         parameters (Dict[str, str], optional): A dictionary of parameters (e.g., VLLM_PARAMS) to
             configure the behavior of a particular GPU shape.
     """
 
-    gpu_count: int = Field(
+    gpu_count: Optional[int] = Field(
         default_factory=int, description="The number of GPUs allocated to the model."
     )
     parameters: Optional[Dict[str, str]] = Field(
@@ -273,115 +314,109 @@ class MultiModelConfig(Serializable):
     )
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
 
 
 class ConfigurationItem(Serializable):
-    """Holds key-value parameter pairs for a specific GPU shape.
+    """Holds key-value parameter pairs for a specific GPU or CPU shape.
 
     Attributes:
         parameters (Dict[str, str], optional): A dictionary of parameters (e.g., VLLM_PARAMS) to
             configure the behavior of a particular GPU shape.
         multi_model_deployment (List[MultiModelConfig], optional): A list of multi model configuration details.
+        shape_info (ShapeInfo, optional): The shape information to this model for specific CPU shape.
     """
 
     parameters: Optional[Dict[str, str]] = Field(
         default_factory=dict,
-        description="Key-value pairs for GPU shape parameters (e.g., VLLM_PARAMS).",
+        description="Key-value pairs for shape parameters.",
     )
     multi_model_deployment: Optional[List[MultiModelConfig]] = Field(
         default_factory=list, description="A list of multi model configuration details."
     )
-
-    class Config:
-        extra = "ignore"
-
-
-class ModelDeploymentConfig(Serializable):
-    """Represents one model's shape list and detailed configuration.
-
-    Attributes:
-        shape (List[str]): A list of shape names (e.g., BM.GPU.A10.4).
-        configuration (Dict[str, ConfigurationItem]): Maps each shape to its configuration details.
-    """
-
-    shape: List[str] = Field(
-        default_factory=list, description="List of supported shapes for the model."
-    )
-    configuration: Dict[str, ConfigurationItem] = Field(
-        default_factory=dict, description="Configuration details keyed by shape."
+    shape_info: Optional[ShapeInfo] = Field(
+        default_factory=ShapeInfo,
+        description="The shape information to this model for specific shape",
     )
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
 
 
-class AquaDeploymentConfig(ModelDeploymentConfig):
+class AquaDeploymentConfig(Serializable):
     """Represents multi model's shape list and detailed configuration.
 
     Attributes:
-        shape (List[str]): A list of shape names (e.g., BM.GPU.A10.4).
-        configuration (Dict[str, ConfigurationItem]): Maps each shape to its configuration details.
+        shape (List[str], optional): A list of shape names (e.g., BM.GPU.A10.4).
+        configuration (Dict[str, ConfigurationItem], optional): Maps each shape to its configuration details.
     """
 
-    configuration: Dict[str, ConfigurationItem] = Field(
+    shape: Optional[List[str]] = Field(
+        default_factory=list, description="List of supported shapes for the model."
+    )
+    configuration: Optional[Dict[str, ConfigurationItem]] = Field(
         default_factory=dict, description="Configuration details keyed by shape."
     )
+
+    class Config:
+        extra = "allow"
 
 
 class GPUModelAllocation(Serializable):
     """Describes how many GPUs are allocated to a particular model.
 
     Attributes:
-        ocid (str): The unique identifier of the model.
-        gpu_count (int): Number of GPUs allocated to this model.
+        ocid (str, optional): The unique identifier of the model.
+        gpu_count (int, optional): Number of GPUs allocated to this model.
     """
 
-    ocid: str = Field(default_factory=str, description="The unique model OCID.")
-    gpu_count: int = Field(
+    ocid: Optional[str] = Field(
+        default_factory=str, description="The unique model OCID."
+    )
+    gpu_count: Optional[int] = Field(
         default_factory=int, description="The number of GPUs allocated to the model."
     )
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
 
 
 class GPUShapeAllocation(Serializable):
     """Allocation details for a specific GPU shape.
 
     Attributes:
-        models (List[GPUModelAllocation]): List of model GPU allocations for this shape.
-        total_gpus_available (int): The total number of GPUs available for this shape.
+        models (List[GPUModelAllocation], optional): List of model GPU allocations for this shape.
+        total_gpus_available (int, optional): The total number of GPUs available for this shape.
     """
 
-    models: List[GPUModelAllocation] = Field(
+    models: Optional[List[GPUModelAllocation]] = Field(
         default_factory=list, description="List of model allocations for this shape."
     )
-    total_gpus_available: int = Field(
+    total_gpus_available: Optional[int] = Field(
         default_factory=int, description="Total GPUs available for this shape."
     )
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
 
 
 class ModelDeploymentConfigSummary(Serializable):
     """Top-level configuration model for OCI-based deployments.
 
     Attributes:
-        deployment_config (Dict[str, ModelDeploymentConfig]): Deployment configurations
+        deployment_config (Dict[str, AquaDeploymentConfig], optional): Deployment configurations
             keyed by model OCID.
-        gpu_allocation (Dict[str, GPUShapeAllocation]): GPU allocations keyed by GPU shape.
+        gpu_allocation (Dict[str, GPUShapeAllocation], optional): GPU allocations keyed by GPU shape.
     """
 
-    deployment_config: Dict[str, ModelDeploymentConfig] = Field(
+    deployment_config: Optional[Dict[str, AquaDeploymentConfig]] = Field(
         default_factory=dict,
         description=(
             "Deployment configuration details for each model, including supported shapes "
             "and shape-specific parameters."
         ),
     )
-    gpu_allocation: Dict[str, GPUShapeAllocation] = Field(
+    gpu_allocation: Optional[Dict[str, GPUShapeAllocation]] = Field(
         default_factory=dict,
         description=(
             "Details on how GPUs are allocated per shape, including the total "
@@ -390,4 +425,4 @@ class ModelDeploymentConfigSummary(Serializable):
     )
 
     class Config:
-        extra = "ignore"
+        extra = "allow"

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import oci
 import pytest
+from ads.aqua.modeldeployment.utils import MultiModelDeploymentConfigLoader
 from parameterized import parameterized
 
 import ads.aqua.modeldeployment.deployment
@@ -616,13 +617,15 @@ class TestAquaDeployment(unittest.TestCase):
             self.app.get_multimodel_deployment_config(["model_a"])
 
     def test_verify_compatibility(self):
-        result = self.app._verify_compatibility(TestDataset.model_gpu_dict)
+        result = MultiModelDeploymentConfigLoader(self.app)._verify_compatibility(
+            TestDataset.model_gpu_dict
+        )
 
         assert result[0] == True
         assert result[1] == 8
         assert len(result[2]) == 3
 
-        result = self.app._verify_compatibility(
+        result = MultiModelDeploymentConfigLoader(self.app)._verify_compatibility(
             model_gpu_dict=TestDataset.model_gpu_dict, primary_model_id="model_b"
         )
 
@@ -635,7 +638,9 @@ class TestAquaDeployment(unittest.TestCase):
                 # model_b gets the maximum gpu count
                 assert item.gpu_count == 4
 
-        result = self.app._verify_compatibility(TestDataset.incompatible_model_gpu_dict)
+        result = MultiModelDeploymentConfigLoader(self.app)._verify_compatibility(
+            TestDataset.incompatible_model_gpu_dict
+        )
 
         assert result[0] == False
         assert result[1] == 0

--- a/tests/unitary/with_extras/aqua/test_deployment_handler.py
+++ b/tests/unitary/with_extras/aqua/test_deployment_handler.py
@@ -96,7 +96,7 @@ class TestAquaDeploymentHandler(unittest.TestCase):
         self, mock_get_multimodel_deployment_config
     ):
         """Test get method to return multi model deployment config"""
-        self.deployment_handler.request.path = "aqua/deployments/modelconfig"
+        self.deployment_handler.request.path = "aqua/deployments/config"
         self.deployment_handler.get(id=["mock-model-id-one", "mock-model-id-two"])
         mock_get_multimodel_deployment_config.assert_called_with(
             model_ids=["mock-model-id-one", "mock-model-id-two"], primary_model_id=None


### PR DESCRIPTION
### Modify get deployment config as pydantic

- Modified get deployment config as pydantic class `AquaDeploymentConfig` and made all fields as optional.
- Added checker for `get_multimodel_deployment_config` to handle deployment config when some fields are empty.
- Fixed unit tests