### PR TITLE
Enhancing Model-Defined Metadata Handling

### DIFF
--- a/ads/model/model_metadata.py
+++ b/ads/model/model_metadata.py
@@ -1509,7 +1509,10 @@ class ModelTaxonomyMetadata(ModelMetadata):
         metadata = cls()
         for oci_item in metadata_list:
             item = ModelTaxonomyMetadataItem._from_oci_metadata(oci_item)
-            metadata[item.key].update(value=item.value)
+            if item.key in metadata.keys:
+                metadata[item.key].update(value=item.value)
+            else:
+                metadata._items.add(item)
         return metadata
 
     def to_dataframe(self) -> pd.DataFrame:
@@ -1562,7 +1565,10 @@ class ModelTaxonomyMetadata(ModelMetadata):
         metadata = cls()
         for item in data["data"]:
             item = ModelTaxonomyMetadataItem.from_dict(item)
-            metadata[item.key].update(value=item.value)
+            if item.key in metadata.keys:
+                metadata[item.key].update(value=item.value)
+            else:
+                metadata._items.add(item)
         return metadata
 
 

--- a/tests/unitary/default_setup/model/test_datascience_model.py
+++ b/tests/unitary/default_setup/model/test_datascience_model.py
@@ -26,7 +26,9 @@ from ads.model.datascience_model import (
     ModelArtifactSizeError,
     BucketNotVersionedError,
     ModelFileDescriptionError,
-    InvalidArtifactType, ModelRetentionSetting, ModelBackupSetting,
+    InvalidArtifactType,
+    ModelRetentionSetting,
+    ModelBackupSetting,
 )
 from ads.model.model_metadata import (
     ModelCustomMetadata,
@@ -44,7 +46,7 @@ from oci.object_storage.models.object_version_summary import ObjectVersionSummar
 from ads.config import AQUA_SERVICE_MODELS_BUCKET as SERVICE_MODELS_BUCKET
 
 MODEL_OCID = "ocid1.datasciencemodel.oc1.iad.<unique_ocid>"
- 
+
 OCI_MODEL_PAYLOAD = {
     "id": MODEL_OCID,
     "compartment_id": "ocid1.compartment.oc1..<unique_ocid>",
@@ -71,16 +73,17 @@ OCI_MODEL_PAYLOAD = {
         {"key": "UseCaseType", "value": "multinomial_classification"},
         {"key": "Hyperparameters"},
         {"key": "ArtifactTestResults"},
+        {"key": "UnexpectedKey", "value": "unexpected_value"},
     ],
     "backup_setting": {
         "is_backup_enabled": True,
         "backup_region": "us-phoenix-1",
-        "customer_notification_type": "ALL"
+        "customer_notification_type": "ALL",
     },
     "retention_setting": {
         "archive_after_days": 30,
         "delete_after_days": 90,
-        "customer_notification_type": "ALL"
+        "customer_notification_type": "ALL",
     },
     "input_schema": '{"schema": [{"dtype": "int64", "feature_type": "Integer", "name": 0, "domain": {"values": "", "stats": {}, "constraints": []}, "required": true, "description": "0", "order": 0}], "version": "1.1"}',
     "output_schema": '{"schema": [{"dtype": "int64", "feature_type": "Integer", "name": 0, "domain": {"values": "", "stats": {}, "constraints": []}, "required": true, "description": "0", "order": 0}], "version": "1.1"}',
@@ -148,6 +151,7 @@ DSC_MODEL_PAYLOAD = {
             {"key": "UseCaseType", "value": "multinomial_classification"},
             {"key": "Hyperparameters", "value": None},
             {"key": "ArtifactTestResults", "value": None},
+            {"key": "UnexpectedKey", "value": "unexpected_value"},
         ]
     },
     "provenanceMetadata": {
@@ -161,12 +165,12 @@ DSC_MODEL_PAYLOAD = {
     "backupSetting": {
         "is_backup_enabled": True,
         "backup_region": "us-phoenix-1",
-        "customer_notification_type": "ALL"
+        "customer_notification_type": "ALL",
     },
     "retentionSetting": {
         "archive_after_days": 30,
         "delete_after_days": 90,
-        "customer_notification_type": "ALL"
+        "customer_notification_type": "ALL",
     },
     "artifact": "ocid1.datasciencemodel.oc1.iad.<unique_ocid>.zip",
 }
@@ -327,8 +331,8 @@ class TestDataScienceModel:
             .with_defined_metadata_list(self.payload["definedMetadataList"])
             .with_provenance_metadata(self.payload["provenanceMetadata"])
             .with_artifact(self.payload["artifact"])
-            .with_backup_setting(self.payload['backupSetting'])
-            .with_retention_setting(self.payload['retentionSetting'])
+            .with_backup_setting(self.payload["backupSetting"])
+            .with_retention_setting(self.payload["retentionSetting"])
         )
         assert self.prepare_dict(dsc_model.to_dict()["spec"]) == self.prepare_dict(
             self.payload
@@ -356,8 +360,12 @@ class TestDataScienceModel:
                 ModelProvenanceMetadata.from_dict(self.payload["provenanceMetadata"])
             )
             .with_artifact(self.payload["artifact"])
-            .with_backup_setting(ModelBackupSetting.from_dict(self.payload['backupSetting']))
-            .with_retention_setting(ModelRetentionSetting.from_dict(self.payload['retentionSetting']))
+            .with_backup_setting(
+                ModelBackupSetting.from_dict(self.payload["backupSetting"])
+            )
+            .with_retention_setting(
+                ModelRetentionSetting.from_dict(self.payload["retentionSetting"])
+            )
         )
         assert self.prepare_dict(dsc_model.to_dict()["spec"]) == self.prepare_dict(
             self.payload

--- a/tests/unitary/default_setup/model/test_model_artifact.py
+++ b/tests/unitary/default_setup/model/test_model_artifact.py
@@ -7,7 +7,7 @@ import os
 import pickle
 import sys
 
-import mock
+from unittest import mock
 import pytest
 import yaml
 from ads.common.model import ADSModel

--- a/tests/unitary/default_setup/model/test_model_metadata.py
+++ b/tests/unitary/default_setup/model/test_model_metadata.py
@@ -4,10 +4,10 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 """Unit tests for model metadata module. Includes tests for:
- - ModelTaxonomyMetadataItem
- - ModelCustomMetadataItem
- - ModelTaxonomyMetadata
- - ModelCustomMetadata
+- ModelTaxonomyMetadataItem
+- ModelCustomMetadataItem
+- ModelTaxonomyMetadata
+- ModelCustomMetadata
 """
 
 import json
@@ -31,10 +31,16 @@ from ads.model.model_metadata import (
     ModelTaxonomyMetadata,
     ModelTaxonomyMetadataItem,
     MetadataTaxonomyKeys,
-    UseCaseType
+    UseCaseType,
 )
-from ads.model.datascience_model import ModelRetentionSetting, CustomerNotificationType, SettingStatus, \
-    ModelBackupSetting, ModelRetentionOperationDetails, ModelBackupOperationDetails
+from ads.model.datascience_model import (
+    ModelRetentionSetting,
+    CustomerNotificationType,
+    SettingStatus,
+    ModelBackupSetting,
+    ModelRetentionOperationDetails,
+    ModelBackupOperationDetails,
+)
 from oci.data_science.models import Metadata as OciMetadataItem
 
 try:
@@ -939,14 +945,46 @@ class TestModelTaxonomyMetadata:
         metadata_taxonomy = ModelTaxonomyMetadata._from_oci_metadata(
             test_oci_metadata_list
         )
-        assert (
-            metadata_taxonomy[MetadataTaxonomyKeys.FRAMEWORK].value
-            == test_oci_metadata_list[0].value
+
+        for item in test_oci_metadata_list:
+            assert metadata_taxonomy[item.key].value == item.value
+
+    def test__from_oci_metadata_with_unexpected_key(self):
+        """Tests converting from list of oci metadata to a list of model taxonomy metadata object."""
+        test_oci_metadata_list = [
+            OciMetadataItem(key=MetadataTaxonomyKeys.FRAMEWORK, value="test_framework"),
+            OciMetadataItem(
+                key=MetadataTaxonomyKeys.FRAMEWORK_VERSION,
+                value="test_framework_version",
+            ),
+            OciMetadataItem(
+                key="UNDEFINED_KEY",
+                value="test_undefined_key_value",
+            ),
+        ]
+        metadata_taxonomy = ModelTaxonomyMetadata._from_oci_metadata(
+            test_oci_metadata_list
         )
-        assert (
-            metadata_taxonomy[MetadataTaxonomyKeys.FRAMEWORK_VERSION].value
-            == test_oci_metadata_list[1].value
-        )
+        for item in test_oci_metadata_list:
+            assert metadata_taxonomy[item.key].value == item.value
+
+    def test__from_dict(self):
+        """Tests converting from list of oci metadata to a list of model taxonomy metadata object."""
+
+        test_data = {
+            "data": [
+                {"key": "Algorithm", "value": "test"},
+                {"key": "Framework"},
+                {"key": "FrameworkVersion"},
+                {"key": "UseCaseType", "value": "multinomial_classification"},
+                {"key": "Hyperparameters"},
+                {"key": "ArtifactTestResults"},
+                {"key": "UnexpectedKey", "value": "unexpected_value"},
+            ],
+        }
+        metadata_taxonomy = ModelTaxonomyMetadata.from_dict(test_data)
+        for item in test_data["data"]:
+            assert metadata_taxonomy[item["key"]].value == item.get("value")
 
     def test_to_dataframe(self):
         # test to_dataframe model metadata
@@ -1015,6 +1053,7 @@ class TestModelTaxonomyMetadata:
         open_mock.assert_called_with(mock_file_path, mode="w", **mock_storage_options)
         open_mock.return_value.write.assert_called_with(metadata_taxonomy.to_json())
 
+
 class TestModelBackupSetting:
     """Unit tests for ModelBackupSetting class."""
 
@@ -1023,13 +1062,15 @@ class TestModelBackupSetting:
         backup_setting = ModelBackupSetting()
         assert backup_setting.is_backup_enabled == False
         assert backup_setting.backup_region is None
-        assert backup_setting.customer_notification_type == CustomerNotificationType.NONE
+        assert (
+            backup_setting.customer_notification_type == CustomerNotificationType.NONE
+        )
 
         # Test with parameters
         backup_setting = ModelBackupSetting(
             is_backup_enabled=True,
             backup_region="us-west-1",
-            customer_notification_type=CustomerNotificationType.ALL
+            customer_notification_type=CustomerNotificationType.ALL,
         )
         assert backup_setting.is_backup_enabled == True
         assert backup_setting.backup_region == "us-west-1"
@@ -1040,12 +1081,12 @@ class TestModelBackupSetting:
         backup_setting = ModelBackupSetting(
             is_backup_enabled=True,
             backup_region="us-west-1",
-            customer_notification_type=CustomerNotificationType.ALL
+            customer_notification_type=CustomerNotificationType.ALL,
         )
         expected_dict = {
             "is_backup_enabled": True,
             "backup_region": "us-west-1",
-            "customer_notification_type": "ALL"
+            "customer_notification_type": "ALL",
         }
         assert backup_setting.to_dict() == expected_dict
 
@@ -1054,7 +1095,7 @@ class TestModelBackupSetting:
         data = {
             "is_backup_enabled": True,
             "backup_region": "us-west-1",
-            "customer_notification_type": "ALL"
+            "customer_notification_type": "ALL",
         }
         backup_setting = ModelBackupSetting.from_dict(data)
         assert backup_setting.is_backup_enabled == True
@@ -1066,22 +1107,26 @@ class TestModelBackupSetting:
         backup_setting = ModelBackupSetting(
             is_backup_enabled=True,
             backup_region="us-west-1",
-            customer_notification_type=CustomerNotificationType.ALL
+            customer_notification_type=CustomerNotificationType.ALL,
         )
-        expected_json = json.dumps({
-            "is_backup_enabled": True,
-            "backup_region": "us-west-1",
-            "customer_notification_type": "ALL"
-        })
+        expected_json = json.dumps(
+            {
+                "is_backup_enabled": True,
+                "backup_region": "us-west-1",
+                "customer_notification_type": "ALL",
+            }
+        )
         assert backup_setting.to_json() == expected_json
 
     def test_from_json(self):
         """Test constructing from JSON."""
-        json_str = json.dumps({
-            "is_backup_enabled": True,
-            "backup_region": "us-west-1",
-            "customer_notification_type": "ALL"
-        })
+        json_str = json.dumps(
+            {
+                "is_backup_enabled": True,
+                "backup_region": "us-west-1",
+                "customer_notification_type": "ALL",
+            }
+        )
         backup_setting = ModelBackupSetting.from_json(json_str)
         assert backup_setting.is_backup_enabled == True
         assert backup_setting.backup_region == "us-west-1"
@@ -1092,13 +1137,15 @@ class TestModelBackupSetting:
         backup_setting = ModelBackupSetting(
             is_backup_enabled=True,
             backup_region="us-west-1",
-            customer_notification_type=CustomerNotificationType.ALL
+            customer_notification_type=CustomerNotificationType.ALL,
         )
-        expected_yaml = yaml.dump({
-            "is_backup_enabled": True,
-            "backup_region": "us-west-1",
-            "customer_notification_type": "ALL"
-        })
+        expected_yaml = yaml.dump(
+            {
+                "is_backup_enabled": True,
+                "backup_region": "us-west-1",
+                "customer_notification_type": "ALL",
+            }
+        )
         assert backup_setting.to_yaml() == expected_yaml
 
     def test_validate(self):
@@ -1107,7 +1154,7 @@ class TestModelBackupSetting:
         backup_setting = ModelBackupSetting(
             is_backup_enabled=True,
             backup_region="us-west-1",
-            customer_notification_type=CustomerNotificationType.ALL
+            customer_notification_type=CustomerNotificationType.ALL,
         )
         assert backup_setting.validate() == True
 
@@ -1120,19 +1167,26 @@ class TestModelBackupSetting:
         assert backup_setting.validate() == False
 
         backup_setting.backup_region = "us-west-1"
-        backup_setting.customer_notification_type = "all_notif"  # Should be CustomerNotificationType Enum
+        backup_setting.customer_notification_type = (
+            "all_notif"  # Should be CustomerNotificationType Enum
+        )
         assert backup_setting.validate() == False
+
 
 class TestModelRetentionSetting:
     """Test cases for ModelRetentionSetting class."""
 
     def test_to_dict(self):
         """Test that to_dict method returns the correct dictionary."""
-        setting = ModelRetentionSetting(archive_after_days=30, delete_after_days=60, customer_notification_type=CustomerNotificationType.ALL)
+        setting = ModelRetentionSetting(
+            archive_after_days=30,
+            delete_after_days=60,
+            customer_notification_type=CustomerNotificationType.ALL,
+        )
         expected_dict = {
             "archive_after_days": 30,
             "delete_after_days": 60,
-            "customer_notification_type": "ALL"
+            "customer_notification_type": "ALL",
         }
         assert setting.to_dict() == expected_dict
 
@@ -1141,7 +1195,7 @@ class TestModelRetentionSetting:
         data = {
             "archive_after_days": 30,
             "delete_after_days": 60,
-            "customer_notification_type": "ALL"
+            "customer_notification_type": "ALL",
         }
         setting = ModelRetentionSetting.from_dict(data)
         assert setting.archive_after_days == 30
@@ -1153,21 +1207,26 @@ class TestModelRetentionSetting:
         setting = ModelRetentionSetting(
             archive_after_days=30,
             delete_after_days=60,
-            customer_notification_type=CustomerNotificationType.ALL)
-        expected_json = json.dumps({
-            "archive_after_days": 30,
-            "delete_after_days": 60,
-            "customer_notification_type": "ALL"
-        })
+            customer_notification_type=CustomerNotificationType.ALL,
+        )
+        expected_json = json.dumps(
+            {
+                "archive_after_days": 30,
+                "delete_after_days": 60,
+                "customer_notification_type": "ALL",
+            }
+        )
         assert setting.to_json() == expected_json
 
     def test_from_json(self):
         """Test that from_json correctly deserializes the settings from a JSON string."""
-        json_str = json.dumps({
-            "archive_after_days": 30,
-            "delete_after_days": 60,
-            "customer_notification_type": "ALL"
-        })
+        json_str = json.dumps(
+            {
+                "archive_after_days": 30,
+                "delete_after_days": 60,
+                "customer_notification_type": "ALL",
+            }
+        )
         setting = ModelRetentionSetting.from_json(json_str)
         assert setting.archive_after_days == 30
         assert setting.delete_after_days == 60
@@ -1175,31 +1234,54 @@ class TestModelRetentionSetting:
 
     def test_to_yaml(self):
         """Test that to_yaml serializes the settings to a YAML string."""
-        setting = ModelRetentionSetting(archive_after_days=30, delete_after_days=60, customer_notification_type=CustomerNotificationType.ALL)
-        expected_yaml = yaml.dump({
-            "archive_after_days": 30,
-            "delete_after_days": 60,
-            "customer_notification_type": "ALL"
-        })
+        setting = ModelRetentionSetting(
+            archive_after_days=30,
+            delete_after_days=60,
+            customer_notification_type=CustomerNotificationType.ALL,
+        )
+        expected_yaml = yaml.dump(
+            {
+                "archive_after_days": 30,
+                "delete_after_days": 60,
+                "customer_notification_type": "ALL",
+            }
+        )
         assert setting.to_yaml() == expected_yaml
 
     def test_validate_valid(self):
         """Test that validate method returns True for valid retention settings."""
-        setting = ModelRetentionSetting(archive_after_days=30, delete_after_days=60, customer_notification_type=CustomerNotificationType.ALL)
+        setting = ModelRetentionSetting(
+            archive_after_days=30,
+            delete_after_days=60,
+            customer_notification_type=CustomerNotificationType.ALL,
+        )
         assert setting.validate() is True
 
     def test_validate_invalid_days(self):
         """Test that validate returns False for invalid archive or delete days."""
-        setting = ModelRetentionSetting(archive_after_days=-1, delete_after_days=60, customer_notification_type=CustomerNotificationType.ALL)
+        setting = ModelRetentionSetting(
+            archive_after_days=-1,
+            delete_after_days=60,
+            customer_notification_type=CustomerNotificationType.ALL,
+        )
         assert setting.validate() is False
 
-        setting = ModelRetentionSetting(archive_after_days=30, delete_after_days=-10, customer_notification_type=CustomerNotificationType.ALL)
+        setting = ModelRetentionSetting(
+            archive_after_days=30,
+            delete_after_days=-10,
+            customer_notification_type=CustomerNotificationType.ALL,
+        )
         assert setting.validate() is False
 
     def test_validate_invalid_customer_notification_type(self):
         """Test that validate method returns False for an invalid notification type."""
-        setting = ModelRetentionSetting(archive_after_days=30, delete_after_days=60, customer_notification_type="INVALID")
+        setting = ModelRetentionSetting(
+            archive_after_days=30,
+            delete_after_days=60,
+            customer_notification_type="INVALID",
+        )
         assert setting.validate() is False
+
 
 class TestModelRetentionOperationDetails:
     """Test cases for ModelRetentionOperationDetails class."""
@@ -1212,7 +1294,7 @@ class TestModelRetentionOperationDetails:
             delete_state=SettingStatus.PENDING,
             delete_state_details="Deletion pending",
             time_archival_scheduled=1633046400,
-            time_deletion_scheduled=1635638400
+            time_deletion_scheduled=1635638400,
         )
         expected_dict = {
             "archive_state": "SUCCEEDED",
@@ -1220,7 +1302,7 @@ class TestModelRetentionOperationDetails:
             "delete_state": "PENDING",
             "delete_state_details": "Deletion pending",
             "time_archival_scheduled": 1633046400,
-            "time_deletion_scheduled": 1635638400
+            "time_deletion_scheduled": 1635638400,
         }
         assert details.to_dict() == expected_dict
 
@@ -1232,7 +1314,7 @@ class TestModelRetentionOperationDetails:
             "delete_state": "PENDING",
             "delete_state_details": "Deletion pending",
             "time_archival_scheduled": 1633046400,
-            "time_deletion_scheduled": 1635638400
+            "time_deletion_scheduled": 1635638400,
         }
         details = ModelRetentionOperationDetails.from_dict(data)
         assert details.archive_state == SettingStatus.SUCCEEDED
@@ -1250,28 +1332,32 @@ class TestModelRetentionOperationDetails:
             delete_state=SettingStatus.PENDING,
             delete_state_details="Deletion pending",
             time_archival_scheduled=1633046400,
-            time_deletion_scheduled=1635638400
+            time_deletion_scheduled=1635638400,
         )
-        expected_json = json.dumps({
-            "archive_state": "SUCCEEDED",
-            "archive_state_details": "Archived successfully",
-            "delete_state": "PENDING",
-            "delete_state_details": "Deletion pending",
-            "time_archival_scheduled": 1633046400,
-            "time_deletion_scheduled": 1635638400
-        })
+        expected_json = json.dumps(
+            {
+                "archive_state": "SUCCEEDED",
+                "archive_state_details": "Archived successfully",
+                "delete_state": "PENDING",
+                "delete_state_details": "Deletion pending",
+                "time_archival_scheduled": 1633046400,
+                "time_deletion_scheduled": 1635638400,
+            }
+        )
         assert details.to_json() == expected_json
 
     def test_from_json(self):
         """Test that from_json correctly deserializes the details from a JSON string."""
-        json_str = json.dumps({
-            "archive_state": "SUCCEEDED",
-            "archive_state_details": "Archived successfully",
-            "delete_state": "PENDING",
-            "delete_state_details": "Deletion pending",
-            "time_archival_scheduled": 1633046400,
-            "time_deletion_scheduled": 1635638400
-        })
+        json_str = json.dumps(
+            {
+                "archive_state": "SUCCEEDED",
+                "archive_state_details": "Archived successfully",
+                "delete_state": "PENDING",
+                "delete_state_details": "Deletion pending",
+                "time_archival_scheduled": 1633046400,
+                "time_deletion_scheduled": 1635638400,
+            }
+        )
         details = ModelRetentionOperationDetails.from_json(json_str)
         assert details.archive_state == SettingStatus.SUCCEEDED
         assert details.archive_state_details == "Archived successfully"
@@ -1288,16 +1374,18 @@ class TestModelRetentionOperationDetails:
             delete_state=SettingStatus.PENDING,
             delete_state_details="Deletion pending",
             time_archival_scheduled=1633046400,
-            time_deletion_scheduled=1635638400
+            time_deletion_scheduled=1635638400,
         )
-        expected_yaml = yaml.dump({
-            "archive_state": "SUCCEEDED",
-            "archive_state_details": "Archived successfully",
-            "delete_state": "PENDING",
-            "delete_state_details": "Deletion pending",
-            "time_archival_scheduled": 1633046400,
-            "time_deletion_scheduled": 1635638400
-        })
+        expected_yaml = yaml.dump(
+            {
+                "archive_state": "SUCCEEDED",
+                "archive_state_details": "Archived successfully",
+                "delete_state": "PENDING",
+                "delete_state_details": "Deletion pending",
+                "time_archival_scheduled": 1633046400,
+                "time_deletion_scheduled": 1635638400,
+            }
+        )
         assert details.to_yaml() == expected_yaml
 
     def test_validate_valid(self):
@@ -1306,7 +1394,7 @@ class TestModelRetentionOperationDetails:
             archive_state=SettingStatus.SUCCEEDED,
             delete_state=SettingStatus.PENDING,
             time_archival_scheduled=1633046400,
-            time_deletion_scheduled=1635638400
+            time_deletion_scheduled=1635638400,
         )
         assert details.validate() is True
 
@@ -1316,7 +1404,7 @@ class TestModelRetentionOperationDetails:
             archive_state="INVALID_STATE",  # Invalid state
             delete_state=SettingStatus.PENDING,
             time_archival_scheduled=1633046400,
-            time_deletion_scheduled=1635638400
+            time_deletion_scheduled=1635638400,
         )
         assert details.validate() is False
 
@@ -1326,9 +1414,10 @@ class TestModelRetentionOperationDetails:
             archive_state=SettingStatus.SUCCEEDED,
             delete_state=SettingStatus.PENDING,
             time_archival_scheduled="invalid_time",  # Invalid time
-            time_deletion_scheduled=1635638400
+            time_deletion_scheduled=1635638400,
         )
         assert details.validate() is False
+
 
 class TestModelBackupOperationDetails:
     """Test cases for ModelBackupOperationDetails class."""
@@ -1338,12 +1427,12 @@ class TestModelBackupOperationDetails:
         details = ModelBackupOperationDetails(
             backup_state=SettingStatus.SUCCEEDED,
             backup_state_details="Backup completed successfully",
-            time_last_backup=1633046400
+            time_last_backup=1633046400,
         )
         expected_dict = {
             "backup_state": "SUCCEEDED",
             "backup_state_details": "Backup completed successfully",
-            "time_last_backup": 1633046400
+            "time_last_backup": 1633046400,
         }
         assert details.to_dict() == expected_dict
 
@@ -1352,7 +1441,7 @@ class TestModelBackupOperationDetails:
         data = {
             "backup_state": "SUCCEEDED",
             "backup_state_details": "Backup completed successfully",
-            "time_last_backup": 1633046400
+            "time_last_backup": 1633046400,
         }
         details = ModelBackupOperationDetails.from_dict(data)
         assert details.backup_state == SettingStatus.SUCCEEDED
@@ -1364,22 +1453,26 @@ class TestModelBackupOperationDetails:
         details = ModelBackupOperationDetails(
             backup_state=SettingStatus.SUCCEEDED,
             backup_state_details="Backup completed successfully",
-            time_last_backup=1633046400
+            time_last_backup=1633046400,
         )
-        expected_json = json.dumps({
-            "backup_state": "SUCCEEDED",
-            "backup_state_details": "Backup completed successfully",
-            "time_last_backup": 1633046400
-        })
+        expected_json = json.dumps(
+            {
+                "backup_state": "SUCCEEDED",
+                "backup_state_details": "Backup completed successfully",
+                "time_last_backup": 1633046400,
+            }
+        )
         assert details.to_json() == expected_json
 
     def test_from_json(self):
         """Test that from_json correctly deserializes the details from a JSON string."""
-        json_str = json.dumps({
-            "backup_state": "SUCCEEDED",
-            "backup_state_details": "Backup completed successfully",
-            "time_last_backup": 1633046400
-        })
+        json_str = json.dumps(
+            {
+                "backup_state": "SUCCEEDED",
+                "backup_state_details": "Backup completed successfully",
+                "time_last_backup": 1633046400,
+            }
+        )
         details = ModelBackupOperationDetails.from_json(json_str)
         assert details.backup_state == SettingStatus.SUCCEEDED
         assert details.backup_state_details == "Backup completed successfully"
@@ -1390,28 +1483,28 @@ class TestModelBackupOperationDetails:
         details = ModelBackupOperationDetails(
             backup_state=SettingStatus.SUCCEEDED,
             backup_state_details="Backup completed successfully",
-            time_last_backup=1633046400
+            time_last_backup=1633046400,
         )
-        expected_yaml = yaml.dump({
-            "backup_state": "SUCCEEDED",
-            "backup_state_details": "Backup completed successfully",
-            "time_last_backup": 1633046400
-        })
+        expected_yaml = yaml.dump(
+            {
+                "backup_state": "SUCCEEDED",
+                "backup_state_details": "Backup completed successfully",
+                "time_last_backup": 1633046400,
+            }
+        )
         assert details.to_yaml() == expected_yaml
 
     def test_validate_valid(self):
         """Test that validate method returns True for valid backup operation details."""
         details = ModelBackupOperationDetails(
-            backup_state=SettingStatus.SUCCEEDED,
-            time_last_backup=1633046400
+            backup_state=SettingStatus.SUCCEEDED, time_last_backup=1633046400
         )
         assert details.validate() is True
 
     def test_validate_invalid_state(self):
         """Test that validate method returns False for an invalid backup state."""
         details = ModelBackupOperationDetails(
-            backup_state="INVALID_STATE",
-            time_last_backup=1633046400
+            backup_state="INVALID_STATE", time_last_backup=1633046400
         )
         assert details.validate() is False
 
@@ -1419,8 +1512,6 @@ class TestModelBackupOperationDetails:
         """Test that validate method returns False for an invalid time value."""
         details = ModelBackupOperationDetails(
             backup_state=SettingStatus.SUCCEEDED,
-            time_last_backup="invalid_time"  # Invalid time
+            time_last_backup="invalid_time",  # Invalid time
         )
         assert details.validate() is False
-
-


### PR DESCRIPTION
## Description

This PR updates the **model-defined metadata implementation** to accept **non-predefined keys**.  

### **Background & Issue**  
In the original implementation, the **defined metadata keys** were **hardcoded**, meaning only a predefined set of keys were accepted. However, the **Model Catalog (MC) service** plans to introduce additional metadata keys, which could cause compatibility issues for **ADS**.  

Currently, if users attempt to **load a model from the Model Catalog** using:  
```python
DataScienceModel.from_id("<OCID>")
```  
they will encounter an **error** if unexpected metadata keys are present.  

### **Solution**  
This PR **removes the restriction** on predefined metadata keys, allowing **non-predefined keys** to be accepted without causing failures.  

### **Previously Supported Keys**  
```python
class MetadataTaxonomyKeys(ExtendedEnum):
    USE_CASE_TYPE = "UseCaseType"
    FRAMEWORK = "Framework"
    FRAMEWORK_VERSION = "FrameworkVersion"
    ALGORITHM = "Algorithm"
    HYPERPARAMETERS = "Hyperparameters"
    ARTIFACT_TEST_RESULT = "ArtifactTestResults"
```

### **Additional Updates**  
- The **unit tests** have been updated to validate this new behavior.  

This change ensures that **future metadata additions** by MC will not break ADS functionality.