### PR TITLE
ODSC 68580- Update Evaluation SDK to Support Multi-Model Deployment

### DIFF
--- a/ads/aqua/evaluation/evaluation.py
+++ b/ads/aqua/evaluation/evaluation.py
@@ -75,6 +75,7 @@ from ads.aqua.evaluation.entities import (
     CreateAquaEvaluationDetails,
 )
 from ads.aqua.evaluation.errors import EVALUATION_JOB_EXIT_CODE_MESSAGE
+from ads.aqua.model.constants import ModelCustomMetadataFields
 from ads.aqua.ui import AquaContainerConfig
 from ads.common.auth import default_signer
 from ads.common.object_storage_details import ObjectStorageDetails
@@ -183,6 +184,26 @@ class AquaEvaluationApp(AquaApp):
             evaluation_source = ModelDeployment.from_id(
                 create_aqua_evaluation_details.evaluation_source_id
             )
+            try:
+                if Tags.MULTIMODEL_TYPE_TAG in evaluation_source.freeform_tags:
+                    multi_model_id = evaluation_source.freeform_tags.get(
+                        Tags.AQUA_MODEL_ID_TAG, UNKNOWN
+                    )
+
+                    if not multi_model_id:
+                        raise AquaRuntimeError(
+                            f"Invalid multi model deployment {multi_model_id}."
+                            f"Make sure the {Tags.AQUA_MODEL_ID_TAG} tag is added to the deployment."
+                        )
+
+                    aqua_model = DataScienceModel.from_id(multi_model_id)
+                    AquaEvaluationApp.validate_name_multi_model(
+                        aqua_model, create_aqua_evaluation_details
+                    )
+
+            except (AquaRuntimeError, AquaValueError) as err:
+                raise AquaValueError(f"{err}") from err
+
             try:
                 if (
                     evaluation_source.runtime.type
@@ -549,6 +570,43 @@ class AquaEvaluationApp(AquaApp):
             },
             parameters=AquaEvalParams(),
         )
+
+    @staticmethod
+    def validate_name_multi_model(
+        evaluation_source: DataScienceModel,
+        create_aqua_evaluation_details: CreateAquaEvaluationDetails,
+    ):
+        user_model_parameters = create_aqua_evaluation_details.model_parameters
+        if "name" not in user_model_parameters:
+            logger.debug(
+                f"User did not input model name for multi model deployment evaluation with evaluation source ID: {create_aqua_evaluation_details.evaluation_source_id}"
+            )
+            raise AquaValueError(
+                "Provide the model name. For evaluation, a single model needs to be targeted using the name in the multi model deployment."
+            )
+
+        custom_metadata_list = evaluation_source.custom_metadata_list
+        user_model_name = user_model_parameters.get("name")
+
+        model_group_count = int(
+            custom_metadata_list.get(
+                ModelCustomMetadataFields.MULTIMODEL_GROUP_COUNT
+            ).value
+        )
+
+        model_names = [
+            custom_metadata_list.get(f"model-name-{idx}").value
+            for idx in range(model_group_count)
+        ]
+
+        if user_model_name not in model_names:
+            valid_model_names = ", ".join(map(str, model_names))
+            logger.debug(
+                f"User input for model name was {user_model_name}, expected {valid_model_names} evaluation source ID: {create_aqua_evaluation_details.evaluation_source_id}"
+            )
+            raise AquaValueError(
+                f"Provide the correct model name. The valid model names for this Model Deployment are {valid_model_names}."
+            )
 
     def _build_evaluation_runtime(
         self,
@@ -1392,7 +1450,7 @@ class AquaEvaluationApp(AquaApp):
             )
         except Exception as e:
             logger.debug(
-                f"Failed to retreive job run: {jobrun_id}. " f"DEBUG INFO: {str(e)}"
+                f"Failed to retreive job run: {jobrun_id}. DEBUG INFO: {str(e)}"
             )
             jobrun = None
 

--- a/ads/aqua/evaluation/evaluation.py
+++ b/ads/aqua/evaluation/evaluation.py
@@ -577,7 +577,7 @@ class AquaEvaluationApp(AquaApp):
         create_aqua_evaluation_details: CreateAquaEvaluationDetails,
     ):
         user_model_parameters = create_aqua_evaluation_details.model_parameters
-        if "name" not in user_model_parameters:
+        if "model" not in user_model_parameters:
             logger.debug(
                 f"User did not input model name for multi model deployment evaluation with evaluation source ID: {create_aqua_evaluation_details.evaluation_source_id}"
             )
@@ -586,7 +586,7 @@ class AquaEvaluationApp(AquaApp):
             )
 
         custom_metadata_list = evaluation_source.custom_metadata_list
-        user_model_name = user_model_parameters.get("name")
+        user_model_name = user_model_parameters.get("model")
 
         model_group_count = int(
             custom_metadata_list.get(

--- a/tests/unitary/with_extras/aqua/test_evaluation.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation.py
@@ -538,7 +538,7 @@ class TestAquaEvaluation(unittest.TestCase):
     @parameterized.expand(
     [
         (
-            {"name": "model_one"},
+            {"model": "model_one"},
             None
         ),
         (
@@ -546,7 +546,7 @@ class TestAquaEvaluation(unittest.TestCase):
             "Provide the model name. For evaluation, a single model needs to be targeted using the name in the multi model deployment."
         ),
         (
-            {"name": "wrong_model_name"},
+            {"model": "wrong_model_name"},
             "Provide the correct model name. The valid model names for this Model Deployment are model_one, model_two, model_three."
         )
     ])

--- a/tests/unitary/with_extras/aqua/test_evaluation.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation.py
@@ -17,6 +17,7 @@ from parameterized import parameterized
 from ads.aqua.common import utils
 from ads.aqua.common.enums import Tags
 from ads.aqua.common.errors import (
+    AquaError,
     AquaFileNotFoundError,
     AquaMissingKeyError,
     AquaRuntimeError,
@@ -451,7 +452,7 @@ class TestAquaEvaluation(unittest.TestCase):
         mock_from_id.return_value = foundation_model
 
         experiment = MagicMock()
-        experiment.id = "ocid1.datasciencemodelversionset.oc1.iad.amaaaaaav66vvniakngdzelb5hcgjd6yvfejksu2excidvvi3s5s5whtmdea"
+        experiment.id = "test_experiment_id"
         mock_mvs_create.return_value = experiment
 
         evaluation_model = MagicMock()
@@ -543,7 +544,7 @@ class TestAquaEvaluation(unittest.TestCase):
         ),
         (
             {},
-            "Provide the model name. For evaluation, a single model needs to be targeted using the name in the multi model deployment."
+            "Provide the model name. For evaluation, a single model needs to be targeted using the name in the multi model deployment. The valid model names for this Model Deployment are model_one, model_two, model_three."
         ),
         (
             {"model": "wrong_model_name"},
@@ -551,7 +552,7 @@ class TestAquaEvaluation(unittest.TestCase):
         )
     ])
     @patch("ads.aqua.evaluation.evaluation.AquaEvaluationApp.create")
-    def test_validate_multi_model_evaluation(
+    def test_validate_model_name(
         self,
         mock_model_parameters,
         expected_message,
@@ -592,8 +593,8 @@ class TestAquaEvaluation(unittest.TestCase):
         mock_create_aqua_evaluation_details = MagicMock(**create_aqua_evaluation_details, spec=CreateAquaEvaluationDetails)
 
         try:
-            AquaEvaluationApp.validate_name_multi_model(mock_model, mock_create_aqua_evaluation_details)
-        except Exception as e:
+            AquaEvaluationApp.validate_model_name(mock_model, mock_create_aqua_evaluation_details)
+        except AquaError as e:
             self.assertEqual(str(e), expected_message)
 
     def test_get_service_model_name(self):

--- a/tests/unitary/with_extras/aqua/test_evaluation.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation.py
@@ -38,6 +38,7 @@ from ads.aqua.evaluation.entities import (
     CreateAquaEvaluationDetails,
 )
 from ads.aqua.extension.base_handler import AquaAPIhandler
+from ads.aqua.model.constants import ModelCustomMetadataFields
 from ads.jobs.ads_job import DataScienceJob, DataScienceJobRun, Job
 from ads.model import DataScienceModel
 from ads.model.deployment.model_deployment import ModelDeployment
@@ -539,10 +540,6 @@ class TestAquaEvaluation(unittest.TestCase):
     @parameterized.expand(
     [
         (
-            {"model": "model_one"},
-            None
-        ),
-        (
             {},
             "Provide the model name. For evaluation, a single model needs to be targeted using the name in the multi model deployment. The valid model names for this Model Deployment are model_one, model_two, model_three."
         ),
@@ -595,6 +592,7 @@ class TestAquaEvaluation(unittest.TestCase):
         try:
             AquaEvaluationApp.validate_model_name(mock_model, mock_create_aqua_evaluation_details)
         except AquaError as e:
+            print(str(e))
             self.assertEqual(str(e), expected_message)
 
     def test_get_service_model_name(self):


### PR DESCRIPTION
The "name" parameter in the model parameters had to be updated from using the same default name for all deployments to the model's specific name.  

This PR introduces a method to validate the user's input when they specify the model name for targeting a single model for evaluation when the model is within a multi model deployment. 

Added method validate_name_multi_model():
- used in AquaEvaluationApp.create() in evaluation.py.
- assumes that the UI and evaluation handler sends back the user's input model parameters, which includes the "name" parameter with the key being the model specific name
- we check the DataScienceModel metadata for the model specific name (configuration setting) and whether this name matches the user's input.

Wrote test cases in test_deployment() in the test_validate_multi_model_evaluation() method.
- see Jira Ticket for screenshots of passed test cases.