### PR TITLE
Extract Available GPU Count from list_model_deployment_shapes API for Multi-Model Deployment

### DIFF
--- a/ads/aqua/common/constants.py
+++ b/ads/aqua/common/constants.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# Copyright (c) 2025 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+GPU_SPECS = {
+    "VM.GPU2.1": {
+        "gpu_type": "P100",
+        "gpu_count": 1,
+        "gpu_memory_in_gbs": 16,
+    },
+    "VM.GPU3.1": {
+        "gpu_type": "V100",
+        "gpu_count": 1,
+        "gpu_memory_in_gbs": 16,
+    },
+    "VM.GPU3.2": {
+        "gpu_type": "V100",
+        "gpu_count": 2,
+        "gpu_memory_in_gbs": 32,
+    },
+    "VM.GPU3.4": {
+        "gpu_type": "V100",
+        "gpu_count": 4,
+        "gpu_memory_in_gbs": 64,
+    },
+    "BM.GPU2.2": {
+        "gpu_type": "P100",
+        "gpu_count": 2,
+        "gpu_memory_in_gbs": 32,
+    },
+    "BM.GPU3.8": {
+        "gpu_type": "V100",
+        "gpu_count": 8,
+        "gpu_memory_in_gbs": 128,
+    },
+    "BM.GPU4.8": {
+        "gpu_type": "A100",
+        "gpu_count": 8,
+        "gpu_memory_in_gbs": 320,
+    },
+    "BM.GPU.A10.4": {
+        "gpu_type": "A10",
+        "gpu_count": 4,
+        "gpu_memory_in_gbs": 96,
+    },
+    "VM.GPU.A10.4": {
+        "gpu_type": "A10",
+        "gpu_count": 4,
+        "gpu_memory_in_gbs": 96,
+    },
+    "BM.GPU.H100.8": {
+        "gpu_type": "H100",
+        "gpu_count": 8,
+        "gpu_memory_in_gbs": 640,
+    },
+    "VM.GPU.A10.1": {
+        "gpu_type": "A10",
+        "gpu_count": 1,
+        "gpu_memory_in_gbs": 24,
+    },
+    "VM.GPU.A10.2": {
+        "gpu_type": "A10",
+        "gpu_count": 2,
+        "gpu_memory_in_gbs": 48,
+    },
+    "BM.GPU.L40S-NC.4": {
+        "gpu_type": "L40S",
+        "gpu_count": 4,
+        "gpu_memory_in_gbs": 192,
+    },
+    "BM.GPU.H200.8": {
+        "gpu_type": "H200",
+        "gpu_count": 8,
+        "gpu_memory_in_gbs": 1128,
+    },
+    "BM.GPU.A100-v2.8": {
+        "gpu_type": "A100",
+        "gpu_count": 8,
+        "gpu_memory_in_gbs": 320,
+    },
+}

--- a/ads/aqua/common/constants.py
+++ b/ads/aqua/common/constants.py
@@ -76,6 +76,16 @@ GPU_SPECS = {
     "BM.GPU.A100-v2.8": {
         "gpu_type": "A100",
         "gpu_count": 8,
-        "gpu_memory_in_gbs": 320,
+        "gpu_memory_in_gbs": 640,
+    },
+    "BM.GPU.MI300X.8": {
+        "gpu_type": "MI300X",
+        "gpu_count": 8,
+        "gpu_memory_in_gbs": 1536,
+    },
+    "BM.GPU.L40S.4": {
+        "gpu_type": "L40S",
+        "gpu_count": 4,
+        "gpu_memory_in_gbs": 192,
     },
 }

--- a/ads/aqua/common/entities.py
+++ b/ads/aqua/common/entities.py
@@ -65,7 +65,8 @@ class ComputeShapeSummary(Serializable):
     )
 
     @model_validator(mode="after")
-    def set_gpu_specs(self, model: "ComputeShapeSummary") -> "ComputeShapeSummary":
+    @classmethod
+    def set_gpu_specs(cls, model: "ComputeShapeSummary") -> "ComputeShapeSummary":
         """
         Validates and populates GPU specifications if the shape_series indicates a GPU-based shape.
 

--- a/ads/aqua/common/entities.py
+++ b/ads/aqua/common/entities.py
@@ -2,10 +2,13 @@
 # Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
+import re
 from typing import Optional
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
+from ads.aqua.app import logger
+from ads.aqua.common.constants import GPU_SPECS
 from ads.aqua.config.utils.serializer import Serializable
 
 
@@ -23,14 +26,76 @@ class ContainerSpec:
     EVALUATION_CONFIGURATION = "evaluationConfiguration"
 
 
-class ShapeInfo(Serializable):
-    instance_shape: Optional[str] = None
-    instance_count: Optional[int] = None
-    ocpus: Optional[float] = None
-    memory_in_gbs: Optional[float] = None
+class GPUSpecs(Serializable):
+    """
+    Represents the GPU specifications for a compute instance.
+    """
 
-    class Config:
-        extra = "ignore"
+    gpu_memory_in_gbs: Optional[int] = Field(
+        default=None, description="The amount of GPU memory available (in GB)."
+    )
+    gpu_count: Optional[int] = Field(
+        default=None, description="The number of GPUs available."
+    )
+    gpu_type: Optional[str] = Field(
+        default=None, description="The type of GPU (e.g., 'V100, A100, H100')."
+    )
+
+
+class ComputeShapeSummary(Serializable):
+    """
+    Represents the specifications of a compute instance's shape.
+    """
+
+    core_count: Optional[int] = Field(
+        default=None, description="The number of CPU cores available."
+    )
+    memory_in_gbs: Optional[int] = Field(
+        default=None, description="The amount of memory (in GB) available."
+    )
+    name: Optional[str] = Field(
+        default=None, description="The name identifier of the compute shape."
+    )
+    shape_series: Optional[str] = Field(
+        default=None, description="The series or category of the compute shape."
+    )
+    gpu_specs: Optional[GPUSpecs] = Field(
+        default=None,
+        description="The GPU specifications associated with the compute shape.",
+    )
+
+    @model_validator(mode="after")
+    def set_gpu_specs(self, model: "ComputeShapeSummary") -> "ComputeShapeSummary":
+        """
+        Validates and populates GPU specifications if the shape_series indicates a GPU-based shape.
+
+        - If the shape_series contains "GPU", the validator first checks if the shape name exists
+          in the GPU_SPECS dictionary. If found, it creates a GPUSpecs instance with the corresponding data.
+        - If the shape is not found in the GPU_SPECS, it attempts to extract the GPU count from the shape name
+          using a regex pattern (looking for a number following a dot at the end of the name).
+
+        The information about shapes is taken from: https://docs.oracle.com/en-us/iaas/data-science/using/supported-shapes.htm
+
+        Returns:
+            ComputeShapeSummary: The updated instance with gpu_specs populated if applicable.
+        """
+        try:
+            if model.shape_series and "GPU" in model.shape_series.upper():
+                if model.name and model.name in GPU_SPECS:
+                    gpu_info = GPU_SPECS[model.name]
+                    model.gpu_specs = GPUSpecs(**gpu_info)
+                elif model.name:
+                    # Try to extract gpu_count from the shape name using a regex (e.g., "VM.GPU3.2" -> gpu_count=2)
+                    match = re.search(r"\.(\d+)$", model.name)
+                    if match:
+                        gpu_count = int(match.group(1))
+                        model.gpu_specs = GPUSpecs(gpu_count=gpu_count)
+        except Exception as err:
+            logger.info(
+                f"Error occurred in attempt to extract GPU specification for the f{model.name}. "
+                f"Details: {err}"
+            )
+        return model
 
 
 class AquaMultiModelRef(Serializable):

--- a/ads/aqua/common/enums.py
+++ b/ads/aqua/common/enums.py
@@ -52,6 +52,7 @@ class InferenceContainerType(ExtendedEnum):
 
 class InferenceContainerTypeFamily(ExtendedEnum):
     AQUA_VLLM_CONTAINER_FAMILY = "odsc-vllm-serving"
+    AQUA_VLLM_V1_CONTAINER_FAMILY = "odsc-vllm-serving-v1"
     AQUA_TGI_CONTAINER_FAMILY = "odsc-tgi-serving"
     AQUA_LLAMA_CPP_CONTAINER_FAMILY = "odsc-llama-cpp-serving"
 

--- a/ads/aqua/common/utils.py
+++ b/ads/aqua/common/utils.py
@@ -33,7 +33,7 @@ from huggingface_hub.utils import (
 )
 from oci.data_science.models import JobRun, Model
 from oci.object_storage.models import ObjectSummary
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from ads.aqua.common.enums import (
     InferenceContainerParamType,
@@ -1238,3 +1238,17 @@ def build_pydantic_error_message(ex: ValidationError):
         for e in ex.errors()
         if "loc" in e and e["loc"]
     } or "; ".join(e["msg"] for e in ex.errors())
+
+
+def is_pydantic_model(obj: object) -> bool:
+    """
+    Returns True if obj is a Pydantic model class or an instance of a Pydantic model.
+
+    Args:
+        obj: The object or class to check.
+
+    Returns:
+        bool: True if obj is a subclass or instance of BaseModel, False otherwise.
+    """
+    cls = obj if isinstance(obj, type) else type(obj)
+    return issubclass(cls, BaseModel)

--- a/ads/aqua/extension/base_handler.py
+++ b/ads/aqua/extension/base_handler.py
@@ -15,6 +15,7 @@ from tornado import httputil
 from tornado.web import Application, HTTPError
 
 from ads.aqua import logger
+from ads.aqua.common.utils import is_pydantic_model
 from ads.config import AQUA_TELEMETRY_BUCKET, AQUA_TELEMETRY_BUCKET_NS
 from ads.telemetry.client import TelemetryClient
 
@@ -40,7 +41,7 @@ class AquaAPIhandler(APIHandler):
     def prepare(self, *args, **kwargs):
         """The base class prepare is not required for Aqua"""
         pass
-        
+
     @staticmethod
     def serialize(obj: Any):
         """Serialize the object.
@@ -51,6 +52,9 @@ class AquaAPIhandler(APIHandler):
 
         if is_dataclass(obj):
             return asdict(obj)
+
+        if is_pydantic_model(obj):
+            return obj.model_dump()
 
         return str(obj)
 

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -266,11 +266,11 @@ class AquaModelApp(AquaApp):
             display_name = source_model.display_name
             model.model_name = model.model_name or display_name
 
-            if not source_model.freeform_tags.get(Tags.AQUA_SERVICE_MODEL_TAG, UNKNOWN):
-                raise AquaValueError(
-                    f"Invalid selected model {display_name}. "
-                    "Currently only service models are supported for multi model deployment."
-                )
+            # if not source_model.freeform_tags.get(Tags.AQUA_SERVICE_MODEL_TAG, UNKNOWN):
+            #     raise AquaValueError(
+            #         f"Invalid selected model {display_name}. "
+            #         "Currently only service models are supported for multi model deployment."
+            #     )
 
             if (
                 source_model.freeform_tags.get(Tags.TASK, UNKNOWN)

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -249,15 +249,19 @@ class AquaModelApp(AquaApp):
         """
 
         if not models:
-            raise AquaValueError("Model list cannot be empty.")
+            raise AquaValueError(
+                "Model list cannot be empty. Please provide at least one model for deployment."
+            )
 
         artifact_list = []
         display_name_list = []
         model_custom_metadata = ModelCustomMetadata()
+
         # TODO: update it when more deployment containers are supported
-        default_deployment_container = (
+        supported_container_families = (
             InferenceContainerTypeFamily.AQUA_VLLM_CONTAINER_FAMILY
         )
+        deployment_container = InferenceContainerTypeFamily.AQUA_VLLM_CONTAINER_FAMILY
 
         # Process each model
         for idx, model in enumerate(models):
@@ -265,6 +269,7 @@ class AquaModelApp(AquaApp):
             display_name = source_model.display_name
             model.model_name = model.model_name or display_name
 
+            # We cannot rely on this tag, service and cached models doesn't have it.
             # if not source_model.freeform_tags.get(Tags.AQUA_SERVICE_MODEL_TAG, UNKNOWN):
             #     raise AquaValueError(
             #         f"Invalid selected model {display_name}. "
@@ -297,10 +302,10 @@ class AquaModelApp(AquaApp):
                 ),
             ).value
 
-            if default_deployment_container != deployment_container:
+            if deployment_container not in supported_container_families:
                 raise AquaValueError(
                     f"Unsupported deployment container '{deployment_container}' for model '{source_model.id}'. "
-                    f"Only '{InferenceContainerTypeFamily.AQUA_VLLM_CONTAINER_FAMILY}' is supported for multi-model deployments."
+                    f"Only '{supported_container_families}' are supported for multi-model deployments."
                 )
 
             # Add model-specific metadata
@@ -353,7 +358,7 @@ class AquaModelApp(AquaApp):
         # Add global metadata
         model_custom_metadata.add(
             key=ModelCustomMetadataFields.DEPLOYMENT_CONTAINER,
-            value=default_deployment_container,
+            value=deployment_container,
             description=f"Inference container mapping for {model_group_display_name}",
             category="Other",
         )

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -65,7 +65,6 @@ from ads.aqua.model.constants import (
     FineTuningCustomMetadata,
     FineTuningMetricCategories,
     ModelCustomMetadataFields,
-    ModelTask,
     ModelType,
 )
 from ads.aqua.model.entities import (
@@ -272,13 +271,10 @@ class AquaModelApp(AquaApp):
             #         "Currently only service models are supported for multi model deployment."
             #     )
 
-            if (
-                source_model.freeform_tags.get(Tags.TASK, UNKNOWN)
-                != ModelTask.TEXT_GENERATION
-            ):
+            if source_model.freeform_tags.get(Tags.TASK, UNKNOWN) != "text_generation":
                 raise AquaValueError(
                     f"Invalid or missing {Tags.TASK} tag for selected model {display_name}. "
-                    f"Currently only {ModelTask.TEXT_GENERATION} models are support for multi model deployment."
+                    f"Currently only `text_generation` models are support for multi model deployment."
                 )
 
             display_name_list.append(display_name)

--- a/ads/aqua/modeldeployment/entities.py
+++ b/ads/aqua/modeldeployment/entities.py
@@ -8,13 +8,35 @@ from oci.data_science.models import ModelDeployment, ModelDeploymentSummary
 from pydantic import BaseModel, Field, model_validator
 
 from ads.aqua import logger
-from ads.aqua.common.entities import AquaMultiModelRef, ShapeInfo
+from ads.aqua.common.entities import AquaMultiModelRef
 from ads.aqua.common.enums import Tags
 from ads.aqua.config.utils.serializer import Serializable
 from ads.aqua.constants import UNKNOWN, UNKNOWN_DICT
 from ads.aqua.data import AquaResourceIdentifier
 from ads.common.serializer import DataClassSerializable
 from ads.common.utils import get_console_link
+
+
+class ShapeInfo(Serializable):
+    """
+    Represents the configuration details for a compute instance shape.
+    """
+
+    instance_shape: Optional[str] = Field(
+        default=None,
+        description="The identifier of the compute instance shape (e.g., VM.Standard2.1)",
+    )
+    instance_count: Optional[int] = Field(
+        default=None, description="The number of instances for the given shape."
+    )
+    ocpus: Optional[float] = Field(
+        default=None,
+        description="The number of Oracle CPUs allocated for the instance.",
+    )
+    memory_in_gbs: Optional[float] = Field(
+        default=None,
+        description="The total memory allocated for the instance, in gigabytes.",
+    )
 
 
 class ModelParams(Serializable):

--- a/ads/aqua/modeldeployment/entities.py
+++ b/ads/aqua/modeldeployment/entities.py
@@ -510,7 +510,8 @@ class CreateModelDeploymentDetails(BaseModel):
         if not self.models:
             logger.error("User defined model group (List[AquaMultiModelRef]) is None.")
             raise ConfigValidationError(
-                "Multi-model deployment requires at least one model, but none were provided. Please add one or more models to the model group to proceed."
+                "Multi-model deployment requires at least one model, but none were provided. "
+                "Please add one or more models to the model group to proceed."
             )
 
         selected_shape = self.instance_shape
@@ -520,7 +521,8 @@ class CreateModelDeploymentDetails(BaseModel):
                 f"The model group is not compatible with the selected instance shape {selected_shape}"
             )
             raise ConfigValidationError(
-                f"The model group is not compatible with the selected instance shape '{selected_shape}'. Select a different instance shape."
+                f"The model group is not compatible with the selected instance shape "
+                f"'{selected_shape}'. Select a different instance shape."
             )
 
         total_available_gpus = models_config_summary.gpu_allocation[
@@ -534,10 +536,12 @@ class CreateModelDeploymentDetails(BaseModel):
 
         if len(missing_model_keys) > 0:
             logger.error(
-                f"Missing the following model entry with key {missing_model_keys} in ModelDeploymentConfigSummary"
+                f"Missing the following model entry with key {missing_model_keys} "
+                "in ModelDeploymentConfigSummary"
             )
             raise ConfigValidationError(
-                "One or more selected models are missing from the configuration, preventing validation for deployment on the given shape."
+                "One or more selected models are missing from the configuration, preventing "
+                "validation for deployment on the given shape."
             )
 
         sum_model_gpus = 0
@@ -549,15 +553,17 @@ class CreateModelDeploymentDetails(BaseModel):
             # We cannot rely on .shape because some models, like Falcon-7B, can only be deployed on a single GPU card (A10.1).
             # However, Falcon can also be deployed on a single card in other A10 shapes, such as A10.2.
             # Our current configuration does not support this flexibility.
-            # multi_deployment_shape = aqua_deployment_config.shape
-            multi_deployment_shape = list(aqua_deployment_config.configuration.keys())
 
-            if selected_shape not in multi_deployment_shape:
+            # multi_deployment_shape = aqua_deployment_config.shape
+
+            if selected_shape not in aqua_deployment_config.configuration:
                 logger.error(
-                    f"Model with OCID {model.model_id} in the model group is not compatible with the selected instance shape: {selected_shape}"
+                    f"Model with OCID {model.model_id} in the model group is not compatible "
+                    f"with the selected instance shape: {selected_shape}"
                 )
                 raise ConfigValidationError(
-                    "Select a different instance shape. One or more models in the group are incompatible with the selected instance shape."
+                    "Select a different instance shape. One or more models in the "
+                    "group are incompatible with the selected instance shape."
                 )
 
             multi_model_configs = aqua_deployment_config.configuration.get(
@@ -570,18 +576,22 @@ class CreateModelDeploymentDetails(BaseModel):
             if model.gpu_count not in valid_gpu_configurations:
                 valid_gpu_str = ", ".join(map(str, valid_gpu_configurations))
                 logger.error(
-                    f"Model {model.model_id} allocated {model.gpu_count} GPUs by user, but its deployment configuration requires either {valid_gpu_str} GPUs."
+                    f"Model {model.model_id} allocated {model.gpu_count} GPUs by user, "
+                    f"but its deployment configuration requires either {valid_gpu_str} GPUs."
                 )
                 raise ConfigValidationError(
-                    "Change the GPU count for one or more models in the model group. Adjust GPU allocations per model or choose a larger instance shape."
+                    "Change the GPU count for one or more models in the model group. "
+                    "Adjust GPU allocations per model or choose a larger instance shape."
                 )
 
         if sum_model_gpus > total_available_gpus:
             logger.error(
-                f"Selected shape {selected_shape} has {total_available_gpus} GPUs while model group has {sum_model_gpus} GPUs."
+                f"Selected shape {selected_shape} has {total_available_gpus} "
+                f"GPUs while model group has {sum_model_gpus} GPUs."
             )
             raise ConfigValidationError(
-                "Total requested GPU count exceeds the available GPU capacity for the selected instance shape. Adjust GPU allocations per model or choose a larger instance shape."
+                "Total requested GPU count exceeds the available GPU capacity for the selected "
+                "instance shape. Adjust GPU allocations per model or choose a larger instance shape."
             )
 
     class Config:

--- a/tests/unitary/with_extras/aqua/test_common_entities.py
+++ b/tests/unitary/with_extras/aqua/test_common_entities.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*--
+
+# Copyright (c) 2025 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+import pytest
+
+from ads.aqua.common.entities import ComputeShapeSummary
+
+
+class TestComputeShapeSummary:
+    @pytest.mark.parametrize(
+        "input_data, expected_gpu_specs",
+        [
+            # Case 1: Shape is present in GPU_SPECS.
+            (
+                {
+                    "core_count": 32,
+                    "memory_in_gbs": 512,
+                    "name": "VM.GPU2.1",
+                    "shape_series": "GPU",
+                },
+                {"gpu_type": "P100", "gpu_count": 1, "gpu_memory_in_gbs": 16},
+            ),
+            # Case 2: Not in GPU_SPECS; fallback extraction should yield gpu_count.
+            (
+                {
+                    "core_count": 16,
+                    "memory_in_gbs": 256,
+                    "name": "VM.GPU.UNKNOWN.4",
+                    "shape_series": "GPU",
+                },
+                {"gpu_type": None, "gpu_count": 4, "gpu_memory_in_gbs": None},
+            ),
+            # Case 3: Non-GPU shape should not populate GPU specs.
+            (
+                {
+                    "core_count": 8,
+                    "memory_in_gbs": 64,
+                    "name": "VM.Standard2.1",
+                    "shape_series": "STANDARD",
+                },
+                None,
+            ),
+        ],
+    )
+    def test_set_gpu_specs(self, input_data, expected_gpu_specs):
+        shape = ComputeShapeSummary(**input_data)
+        if expected_gpu_specs is None:
+            assert shape.gpu_specs is None
+        else:
+            assert shape.gpu_specs is not None
+            # Verify GPU type, count, and memory.
+            assert shape.gpu_specs.gpu_type == expected_gpu_specs.get("gpu_type")
+            assert shape.gpu_specs.gpu_count == expected_gpu_specs.get("gpu_count")
+            assert shape.gpu_specs.gpu_memory_in_gbs == expected_gpu_specs.get(
+                "gpu_memory_in_gbs"
+            )

--- a/tests/unitary/with_extras/aqua/test_data/deployment/aqua_deployment_shapes.json
+++ b/tests/unitary/with_extras/aqua/test_data/deployment/aqua_deployment_shapes.json
@@ -1,0 +1,288 @@
+{
+  "shapes": [
+    {
+      "core_count": 1,
+      "gpu_specs": null,
+      "memory_in_gbs": 15,
+      "name": "VM.Standard2.1",
+      "shape_series": "INTEL_SKYLAKE"
+    },
+    {
+      "core_count": 2,
+      "gpu_specs": null,
+      "memory_in_gbs": 30,
+      "name": "VM.Standard2.2",
+      "shape_series": "INTEL_SKYLAKE"
+    },
+    {
+      "core_count": 4,
+      "gpu_specs": null,
+      "memory_in_gbs": 30,
+      "name": "VM.Standard2.4",
+      "shape_series": "INTEL_SKYLAKE"
+    },
+    {
+      "core_count": 8,
+      "gpu_specs": null,
+      "memory_in_gbs": 120,
+      "name": "VM.Standard2.8",
+      "shape_series": "INTEL_SKYLAKE"
+    },
+    {
+      "core_count": 16,
+      "gpu_specs": null,
+      "memory_in_gbs": 240,
+      "name": "VM.Standard2.16",
+      "shape_series": "INTEL_SKYLAKE"
+    },
+    {
+      "core_count": 24,
+      "gpu_specs": null,
+      "memory_in_gbs": 320,
+      "name": "VM.Standard2.24",
+      "shape_series": "INTEL_SKYLAKE"
+    },
+    {
+      "core_count": 64,
+      "gpu_specs": null,
+      "memory_in_gbs": 1024,
+      "name": "VM.Standard.E3.Flex",
+      "shape_series": "AMD_ROME"
+    },
+    {
+      "core_count": 64,
+      "gpu_specs": null,
+      "memory_in_gbs": 1024,
+      "name": "VM.Standard.E4.Flex",
+      "shape_series": "AMD_ROME"
+    },
+    {
+      "core_count": 94,
+      "gpu_specs": null,
+      "memory_in_gbs": 1049,
+      "name": "VM.Standard.E5.Flex",
+      "shape_series": "AMD_ROME"
+    },
+    {
+      "core_count": 32,
+      "gpu_specs": null,
+      "memory_in_gbs": 512,
+      "name": "VM.Standard3.Flex",
+      "shape_series": "INTEL_SKYLAKE"
+    },
+    {
+      "core_count": 18,
+      "gpu_specs": null,
+      "memory_in_gbs": 256,
+      "name": "VM.Optimized3.Flex",
+      "shape_series": "INTEL_SKYLAKE"
+    },
+    {
+      "core_count": 80,
+      "gpu_specs": null,
+      "memory_in_gbs": 512,
+      "name": "VM.Standard.A1.Flex",
+      "shape_series": "ARM"
+    },
+    {
+      "core_count": 78,
+      "gpu_specs": null,
+      "memory_in_gbs": 946,
+      "name": "VM.Standard.A2.Flex",
+      "shape_series": "ARM"
+    },
+    {
+      "core_count": 12,
+      "gpu_specs": {
+        "gpu_count": 1,
+        "gpu_memory_in_gbs": 16,
+        "gpu_type": "P100"
+      },
+      "memory_in_gbs": 72,
+      "name": "VM.GPU2.1",
+      "shape_series": "NVIDIA_GPU"
+    },
+    {
+      "core_count": 6,
+      "gpu_specs": {
+        "gpu_count": 1,
+        "gpu_memory_in_gbs": 16,
+        "gpu_type": "V100"
+      },
+      "memory_in_gbs": 90,
+      "name": "VM.GPU3.1",
+      "shape_series": "NVIDIA_GPU"
+    },
+    {
+      "core_count": 12,
+      "gpu_specs": {
+        "gpu_count": 2,
+        "gpu_memory_in_gbs": 32,
+        "gpu_type": "V100"
+      },
+      "memory_in_gbs": 180,
+      "name": "VM.GPU3.2",
+      "shape_series": "NVIDIA_GPU"
+    },
+    {
+      "core_count": 24,
+      "gpu_specs": {
+        "gpu_count": 4,
+        "gpu_memory_in_gbs": 64,
+        "gpu_type": "V100"
+      },
+      "memory_in_gbs": 360,
+      "name": "VM.GPU3.4",
+      "shape_series": "NVIDIA_GPU"
+    },
+    {
+      "core_count": 28,
+      "gpu_specs": {
+        "gpu_count": 2,
+        "gpu_memory_in_gbs": 32,
+        "gpu_type": "P100"
+      },
+      "memory_in_gbs": 192,
+      "name": "BM.GPU2.2",
+      "shape_series": "NVIDIA_GPU"
+    },
+    {
+      "core_count": 52,
+      "gpu_specs": {
+        "gpu_count": 8,
+        "gpu_memory_in_gbs": 128,
+        "gpu_type": "V100"
+      },
+      "memory_in_gbs": 768,
+      "name": "BM.GPU3.8",
+      "shape_series": "NVIDIA_GPU"
+    },
+    {
+      "core_count": 64,
+      "gpu_specs": {
+        "gpu_count": 8,
+        "gpu_memory_in_gbs": 320,
+        "gpu_type": "A100"
+      },
+      "memory_in_gbs": 2048,
+      "name": "BM.GPU4.8",
+      "shape_series": "NVIDIA_GPU"
+    },
+    {
+      "core_count": 64,
+      "gpu_specs": {
+        "gpu_count": 8,
+        "gpu_memory_in_gbs": 320,
+        "gpu_type": "A100"
+      },
+      "memory_in_gbs": 2048,
+      "name": "BM.GPU.A100-v2.8",
+      "shape_series": "NVIDIA_GPU"
+    },
+    {
+      "core_count": 112,
+      "gpu_specs": {
+        "gpu_count": 8,
+        "gpu_memory_in_gbs": 1128,
+        "gpu_type": "H200"
+      },
+      "memory_in_gbs": 2048,
+      "name": "BM.GPU.H100.8",
+      "shape_series": "NVIDIA_GPU"
+    },
+    {
+      "core_count": 32,
+      "gpu_specs": {
+        "gpu_count": 2,
+        "gpu_memory_in_gbs": null,
+        "gpu_type": null
+      },
+      "memory_in_gbs": 1024,
+      "name": "BM.GPU.T1.2",
+      "shape_series": "NVIDIA_GPU"
+    },
+    {
+      "core_count": 64,
+      "gpu_specs": {
+        "gpu_count": 4,
+        "gpu_memory_in_gbs": 96,
+        "gpu_type": "A10"
+      },
+      "memory_in_gbs": 1024,
+      "name": "BM.GPU.A10.4",
+      "shape_series": "NVIDIA_GPU"
+    },
+    {
+      "core_count": 64,
+      "gpu_specs": {
+        "gpu_count": 4,
+        "gpu_memory_in_gbs": 96,
+        "gpu_type": "A10"
+      },
+      "memory_in_gbs": 1024,
+      "name": "VM.GPU.A10.4",
+      "shape_series": "NVIDIA_GPU"
+    },
+    {
+      "core_count": 112,
+      "gpu_specs": {
+        "gpu_count": 4,
+        "gpu_memory_in_gbs": 192,
+        "gpu_type": "L40S"
+      },
+      "memory_in_gbs": 1024,
+      "name": "BM.GPU.L40S-NC.4",
+      "shape_series": "NVIDIA_GPU"
+    },
+    {
+      "core_count": 15,
+      "gpu_specs": {
+        "gpu_count": 1,
+        "gpu_memory_in_gbs": 24,
+        "gpu_type": "A10"
+      },
+      "memory_in_gbs": 240,
+      "name": "VM.GPU.A10.1",
+      "shape_series": "NVIDIA_GPU"
+    },
+    {
+      "core_count": 30,
+      "gpu_specs": {
+        "gpu_count": 2,
+        "gpu_memory_in_gbs": 48,
+        "gpu_type": "A10"
+      },
+      "memory_in_gbs": 480,
+      "name": "VM.GPU.A10.2",
+      "shape_series": "NVIDIA_GPU"
+    },
+    {
+      "core_count": 64,
+      "gpu_specs": null,
+      "memory_in_gbs": 1024,
+      "name": "VM.Standard.AMD.Generic",
+      "shape_series": "GENERIC"
+    },
+    {
+      "core_count": 32,
+      "gpu_specs": null,
+      "memory_in_gbs": 512,
+      "name": "VM.Standard.Intel.Generic",
+      "shape_series": "GENERIC"
+    },
+    {
+      "core_count": 80,
+      "gpu_specs": null,
+      "memory_in_gbs": 512,
+      "name": "VM.Standard.Ampere.Generic",
+      "shape_series": "GENERIC"
+    },
+    {
+      "core_count": 32,
+      "gpu_specs": null,
+      "memory_in_gbs": 512,
+      "name": "VM.Standard.x86.Generic",
+      "shape_series": "GENERIC"
+    }
+  ]
+}

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -884,18 +884,16 @@ class TestAquaDeployment(unittest.TestCase):
         )
 
         assert result[0] == True
-        assert result[1] == 8
-        assert len(result[2]) == 3
+        assert len(result[1]) == 3
 
         result = MultiModelDeploymentConfigLoader(self.app)._verify_compatibility(
             8, model_gpu_dict=TestDataset.model_gpu_dict, primary_model_id="model_b"
         )
 
         assert result[0] == True
-        assert result[1] == 8
-        assert len(result[2]) == 3
+        assert len(result[1]) == 3
 
-        for item in result[2]:
+        for item in result[1]:
             if item.ocid == "model_b":
                 # model_b gets the maximum gpu count
                 assert item.gpu_count == 4
@@ -905,8 +903,7 @@ class TestAquaDeployment(unittest.TestCase):
         )
 
         assert result[0] == False
-        assert result[1] == 0
-        assert result[2] == []
+        assert result[1] == []
 
     @patch("ads.aqua.modeldeployment.deployment.get_container_config")
     @patch("ads.aqua.model.AquaModelApp.create")

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -15,7 +15,7 @@ import oci
 import pytest
 from parameterized import parameterized
 
-from ads.aqua.common.entities import AquaMultiModelRef
+from ads.aqua.common.entities import AquaMultiModelRef, ComputeShapeSummary
 import ads.aqua.modeldeployment.deployment
 import ads.config
 from ads.aqua.common.entities import AquaMultiModelRef
@@ -793,8 +793,9 @@ class TestAquaDeployment(unittest.TestCase):
     @patch(
         "ads.aqua.modeldeployment.utils.MultiModelDeploymentConfigLoader._fetch_deployment_configs_concurrently"
     )
+    @patch("ads.aqua.modeldeployment.AquaDeploymentApp.list_shapes")
     def test_get_multimodel_deployment_config(
-        self, mock_fetch_deployment_configs_concurrently
+        self, mock_list_shapes, mock_fetch_deployment_configs_concurrently
     ):
         config_json = os.path.join(
             self.curr_dir,
@@ -802,6 +803,20 @@ class TestAquaDeployment(unittest.TestCase):
         )
         with open(config_json, "r") as _file:
             config = json.load(_file)
+
+        shapes = []
+
+        with open(
+            os.path.join(
+                self.curr_dir,
+                "test_data/deployment/aqua_deployment_shapes.json",
+            ),
+            "r",
+        ) as _file:
+            shapes = [
+                ComputeShapeSummary(**item) for item in json.load(_file)["shapes"]
+            ]
+        mock_list_shapes.return_value = shapes
 
         mock_fetch_deployment_configs_concurrently.return_value = {
             "model_a": AquaDeploymentConfig(**config)
@@ -824,8 +839,13 @@ class TestAquaDeployment(unittest.TestCase):
     @patch(
         "ads.aqua.modeldeployment.utils.MultiModelDeploymentConfigLoader._fetch_deployment_configs_concurrently"
     )
+    @patch("ads.aqua.modeldeployment.AquaDeploymentApp.list_shapes")
     def test_get_multimodel_compatible_shapes_invalid_config(
-        self, missing_key, error, mock_fetch_deployment_configs_concurrently
+        self,
+        missing_key,
+        error,
+        mock_list_shapes,
+        mock_fetch_deployment_configs_concurrently,
     ):
         config_json = os.path.join(
             self.curr_dir,
@@ -835,6 +855,20 @@ class TestAquaDeployment(unittest.TestCase):
             config = json.load(_file)
 
         config.pop(missing_key)
+
+        shapes = []
+
+        with open(
+            os.path.join(
+                self.curr_dir,
+                "test_data/deployment/aqua_deployment_shapes.json",
+            ),
+            "r",
+        ) as _file:
+            shapes = [
+                ComputeShapeSummary(**item) for item in json.load(_file)["shapes"]
+            ]
+        mock_list_shapes.return_value = shapes
 
         mock_fetch_deployment_configs_concurrently.return_value = {
             "model_a": AquaDeploymentConfig(**config)
@@ -846,7 +880,7 @@ class TestAquaDeployment(unittest.TestCase):
 
     def test_verify_compatibility(self):
         result = MultiModelDeploymentConfigLoader(self.app)._verify_compatibility(
-            TestDataset.model_gpu_dict
+            8, TestDataset.model_gpu_dict
         )
 
         assert result[0] == True
@@ -854,7 +888,7 @@ class TestAquaDeployment(unittest.TestCase):
         assert len(result[2]) == 3
 
         result = MultiModelDeploymentConfigLoader(self.app)._verify_compatibility(
-            model_gpu_dict=TestDataset.model_gpu_dict, primary_model_id="model_b"
+            8, model_gpu_dict=TestDataset.model_gpu_dict, primary_model_id="model_b"
         )
 
         assert result[0] == True
@@ -867,7 +901,7 @@ class TestAquaDeployment(unittest.TestCase):
                 assert item.gpu_count == 4
 
         result = MultiModelDeploymentConfigLoader(self.app)._verify_compatibility(
-            TestDataset.incompatible_model_gpu_dict
+            0, TestDataset.incompatible_model_gpu_dict
         )
 
         assert result[0] == False


### PR DESCRIPTION
## Description

This PR updates the multi-model deployment logic to fetch the total available GPU count directly from the `list_model_deployment_shapes` API, instead of relying on static multi-model configurations. This change ensures that GPU allocation aligns with the latest shape specifications provided by the Model Deployment service.

### Key Changes:
- Integrated `list_model_deployment_shapes` API to dynamically retrieve available GPU count per shape.
- Updated multi-model deployment logic to use real-time API data instead of relying on predefined configurations.
- Modified shape-related calculations to ensure accurate GPU allocation.
- Added unit tests to validate GPU count retrieval from the API.
- Added a dedicated **handler** for **Model Deployment** to retrieve the list of **available shapes**.
- Temporary added a constant `GPU_SPECS` containing GPU details for the given list of shapes.

## Tests

### Handler
**Request**
```http://localhost:8888/aqua/deployments/shapes```

**Response**
```
{
    "data": [
        {
            "core_count": 64,
            "memory_in_gbs": 1024,
            "name": "BM.GPU.A10.4",
            "shape_series": "NVIDIA_GPU",
            "gpu_specs": {"gpu_memory_in_gbs": 96, "gpu_count": 4, "gpu_type": "A10"},
        },
        {
            "core_count": 112,
            "memory_in_gbs": 1024,
            "name": "BM.GPU.L40S-NC.4",
            "shape_series": "NVIDIA_GPU",
            "gpu_specs": {"gpu_memory_in_gbs": 192, "gpu_count": 4, "gpu_type": "L40S"},
        },
    ]
}
```

### CLI

```
ads aqua deployment list_shapes 
```

**Result**
```
{
    "core_count": 64,
    "memory_in_gbs": 1024,
    "name": "BM.GPU.A10.4",
    "shape_series": "NVIDIA_GPU",
    "gpu_specs": {
        "gpu_memory_in_gbs": 96,
        "gpu_count": 4,
        "gpu_type": "A10"
    }
}
{
    "core_count": 112,
    "memory_in_gbs": 1024,
    "name": "BM.GPU.L40S-NC.4",
    "shape_series": "NVIDIA_GPU",
    "gpu_specs": {
        "gpu_memory_in_gbs": 192,
        "gpu_count": 4,
        "gpu_type": "L40S"
    }
}
```