### PR TITLE
Fixing conflict in OCIDatascienceModel Due to is_model_by_reference with latest preview sdk

### DIFF
--- a/ads/model/artifact_downloader.py
+++ b/ads/model/artifact_downloader.py
@@ -170,7 +170,10 @@ class LargeArtifactDownloader(ArtifactDownloader):
         """Downloads model artifacts."""
         self.progress.update("Importing model artifacts from catalog")
 
-        if self.dsc_model._is_model_by_reference() and self.model_file_description:
+        if (
+            self.dsc_model.is_model_created_by_reference()
+            and self.model_file_description
+        ):
             self.download_from_model_file_description()
             self.progress.update()
             return

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -1779,7 +1779,7 @@ class DataScienceModel(Builder):
                 artifact_info["Content-Disposition"]
             )
 
-            if self.dsc_model._is_model_by_reference():
+            if self.dsc_model.is_model_created_by_reference():
                 _, file_extension = os.path.splitext(file_name_info["filename"])
                 if file_extension.lower() == ".json":
                     bucket_uri, _ = self._download_file_description_artifact()

--- a/ads/model/service/oci_datascience_model.py
+++ b/ads/model/service/oci_datascience_model.py
@@ -579,7 +579,7 @@ class OCIDataScienceModel(
             raise ValueError("Model OCID not provided.")
         return super().from_ocid(ocid)
 
-    def _is_model_by_reference(self):
+    def is_model_created_by_reference(self):
         """Checks if model is created by reference
         Returns
         -------

--- a/tests/unitary/default_setup/model/test_artifact_downloader.py
+++ b/tests/unitary/default_setup/model/test_artifact_downloader.py
@@ -189,7 +189,7 @@ class TestArtifactDownloader:
         """Tests whether model_file_description is loaded within downloader and is parsed, and also if
         #  download_from_model_file_description is appropriately called."""
 
-        self.mock_dsc_model._is_model_by_reference.return_value = True
+        self.mock_dsc_model.is_model_created_by_reference.return_value = True
         self.mock_artifact_file_path = os.path.join(
             self.curr_dir, "test_files/model_description.json"
         )

--- a/tests/unitary/default_setup/model/test_datascience_model.py
+++ b/tests/unitary/default_setup/model/test_datascience_model.py
@@ -613,7 +613,7 @@ class TestDataScienceModel:
             True,
         ],
     )
-    @patch.object(OCIDataScienceModel, "_is_model_by_reference")
+    @patch.object(OCIDataScienceModel, "is_model_created_by_reference")
     @patch.object(OCIDataScienceModel, "get_artifact_info")
     @patch.object(OCIDataScienceModel, "get_model_provenance")
     @patch.object(DataScienceModel, "_download_file_description_artifact")

--- a/tests/unitary/default_setup/model/test_oci_datascience_model.py
+++ b/tests/unitary/default_setup/model/test_oci_datascience_model.py
@@ -473,7 +473,7 @@ class TestOCIDataScienceModel:
             category="Other",
         )
         self.mock_model.custom_metadata_list = [metadata_item]
-        assert not self.mock_model._is_model_by_reference()
+        assert not self.mock_model.is_model_created_by_reference()
 
         metadata_item = ModelCustomMetadataItem(
             key="modelDescription",
@@ -483,4 +483,4 @@ class TestOCIDataScienceModel:
         )
         self.mock_model.custom_metadata_list = [metadata_item]
 
-        assert self.mock_model._is_model_by_reference()
+        assert self.mock_model.is_model_created_by_reference()


### PR DESCRIPTION
# Description
This PR intends to solve the conflict issue with OCIDatascienceModel class due to a conflicting field name 
`_ is_model_by_reference` with latest preview sdk

# Related PR
https://github.com/oracle/accelerated-data-science/pull/1073

# Issue

The test case `test_is_model_by_reference` was failing with latest preview sdk

<img width="1512" alt="Screenshot 2025-03-05 at 12 55 07 AM" src="https://github.com/user-attachments/assets/92b4561e-0b30-4467-b2b9-1e90d1218042" />


# Resolution
In the OCI SDK, attributes are always defined with both attr and _attr. Both is_model_by_reference and _ is_model_by_reference are defined in the new SDK.  Hence , to avoid conflict , renaming `_is_model_by_reference` to `is_model_created_by_reference` in ADS.

The screenshot of the conflicting attribute in latest oci sdk: 

<img width="979" alt="Screenshot 2025-03-05 at 2 04 25 AM" src="https://github.com/user-attachments/assets/16f7250b-f8ae-419a-843a-25ae00b1f783" />
