### PR TITLE
Switch Multi-Model deployment container validation to usage-based tagging

### DIFF
--- a/ads/aqua/config/container_config.py
+++ b/ads/aqua/config/container_config.py
@@ -4,10 +4,17 @@
 
 from typing import Dict, List, Optional
 
+from common.extended_enum import ExtendedEnum
 from pydantic import Field
 
 from ads.aqua.common.entities import ContainerSpec
 from ads.aqua.config.utils.serializer import Serializable
+
+
+class Usage(ExtendedEnum):
+    INFERENCE = "inference"
+    BATCH_INFERENCE = "batch_inference"
+    MULTI_MODEL = "multi_model"
 
 
 class AquaContainerConfigSpec(Serializable):


### PR DESCRIPTION

# Description
This update modifies the **multi-model deployment validation** by replacing the **static container family check** with a **usage-based approach**. Instead of relying on a hardcoded container family, the validation now leverages the **`usages`** attribute, which includes a **`multi_model`** tag for containers that support multi-model deployment.  

