### PR TITLE
Changed multi model metadata storage.

### DIFF
--- a/ads/aqua/common/entities.py
+++ b/ads/aqua/common/entities.py
@@ -153,6 +153,8 @@ class AquaMultiModelRef(Serializable):
         Number of GPUs required for deployment.
     env_var : Optional[Dict[str, Any]]
         Optional environment variables to override during deployment.
+    artifact_location : Optional[str]
+        Artifact path of model in the multimodel group.
     """
 
     model_id: str = Field(..., description="The model OCID to deploy.")
@@ -162,6 +164,9 @@ class AquaMultiModelRef(Serializable):
     )
     env_var: Optional[dict] = Field(
         default_factory=dict, description="The environment variables of the model."
+    )
+    artifact_location: Optional[str] = Field(
+        None, description="Artifact path of model in the multimodel group."
     )
 
     class Config:

--- a/ads/aqua/constants.py
+++ b/ads/aqua/constants.py
@@ -3,7 +3,6 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 """This module defines constants used in ads.aqua module."""
 
-UNKNOWN = ""
 UNKNOWN_VALUE = ""
 READY_TO_IMPORT_STATUS = "TRUE"
 UNKNOWN_DICT = {}

--- a/ads/aqua/constants.py
+++ b/ads/aqua/constants.py
@@ -3,6 +3,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 """This module defines constants used in ads.aqua module."""
 
+UNKNOWN = ""
 UNKNOWN_VALUE = ""
 READY_TO_IMPORT_STATUS = "TRUE"
 UNKNOWN_DICT = {}

--- a/ads/aqua/model/constants.py
+++ b/ads/aqua/model/constants.py
@@ -19,6 +19,7 @@ class ModelCustomMetadataFields(ExtendedEnum):
     FINETUNE_CONTAINER = "finetune-container"
     DEPLOYMENT_CONTAINER_URI = "deployment-container-uri"
     MULTIMODEL_GROUP_COUNT = "model_group_count"
+    MULTIMODEL_METADATA = "multi_model_metadata"
 
 
 class ModelTask(ExtendedEnum):

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -391,6 +391,10 @@ class AquaModelApp(AquaApp):
         # Finalize creation
         custom_model.create(model_by_reference=True)
 
+        logger.info(
+            f"Aqua Model '{custom_model.id}' created with models: {', '.join(display_name_list)}."
+        )
+
         # Create custom metadata for multi model metadata
         custom_model.create_custom_metadata_artifact(
             metadata_key_name=ModelCustomMetadataFields.MULTIMODEL_METADATA,
@@ -400,8 +404,8 @@ class AquaModelApp(AquaApp):
             path_type=MetadataArtifactPathType.CONTENT,
         )
 
-        logger.info(
-            f"Aqua Model '{custom_model.id}' created with models: {', '.join(display_name_list)}."
+        logger.debug(
+            f"Multi model metadata uploaded for Aqua model: {custom_model.id}."
         )
 
         # Track telemetry event

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -62,7 +62,7 @@ from ads.aqua.modeldeployment.entities import (
 )
 from ads.aqua.modeldeployment.utils import MultiModelDeploymentConfigLoader
 from ads.common.object_storage_details import ObjectStorageDetails
-from ads.common.utils import get_log_links
+from ads.common.utils import UNKNOWN, get_log_links
 from ads.config import (
     AQUA_DEPLOYMENT_CONTAINER_CMD_VAR_METADATA_NAME,
     AQUA_DEPLOYMENT_CONTAINER_METADATA_NAME,

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -958,8 +958,8 @@ class AquaDeploymentApp(AquaApp):
             ).value
             if not multi_model_metadata_value:
                 raise AquaRuntimeError(
-                    f"Invalid multi model deployment {model_deployment_id}."
-                    f"Make sure the custom metadata {ModelCustomMetadataFields.MULTIMODEL_METADATA} is added to the aqua multi model {aqua_model.display_name}."
+                    f"Invalid multi-model deployment: {model_deployment_id}. "
+                    f"Ensure that the required custom metadata `{ModelCustomMetadataFields.MULTIMODEL_METADATA}` is added to the AQUA multi-model `{aqua_model.display_name}` ({aqua_model.id})."
                 )
             multi_model_metadata = json.loads(
                 aqua_model.dsc_model.get_custom_metadata_artifact(

--- a/tests/unitary/with_extras/aqua/test_data/deployment/aqua_multi_model.yaml
+++ b/tests/unitary/with_extras/aqua/test_data/deployment/aqua_multi_model.yaml
@@ -4,66 +4,10 @@ spec:
   compartmentId: ocid1.compartment.oc1..<OCID>
   customMetadataList:
     data:
-    - category: Other
-      description: ID of model_one in the multimodel group.
-      key: model-id-0
-      value: ocid1.compartment.oc1..<OCID>
-    - category: Other
-      description: Name of model_one in the multimodel group.
-      key: model-name-0
-      value: model_one
-    - category: Other
-      description: GPU count of model_one in the multimodel group.
-      key: model-gpu-count-0
-      value: 1
-    - category: Other
-      description: User params of model_one in the multimodel group.
-      key: model-user-params-0
-      value: --test_key_one test_value_one
-    - category: Other
-      description: Artifact path for model_one in the multimodel group.
-      key: artifact_location-0
-      value: model_one_path
-    - category: Other
-      description: ID of model_two in the multimodel group.
-      key: model-id-1
-      value: ocid1.compartment.oc1..<OCID>
-    - category: Other
-      description: Name of model_two in the multimodel group.
-      key: model-name-1
-      value: model_two
-    - category: Other
-      description: GPU count of model_two in the multimodel group.
-      key: model-gpu-count-1
-      value: 1
-    - category: Other
-      description: User params of model_two in the multimodel group.
-      key: model-user-params-1
-      value: --test_key_two test_value_two
-    - category: Other
-      description: Artifact path for model_two in the multimodel group.
-      key: artifact_location-1
-      value: model_two_path
-    - category: Other
-      description: ID of model_three in the multimodel group.
-      key: model-id-2
-      value: ocid1.compartment.oc1..<OCID>
-    - category: Other
-      description: Name of model_three in the multimodel group.
-      key: model-name-2
-      value: model_three
-    - category: Other
-      description: GPU count of model_three in the multimodel group.
-      key: model-gpu-count-2
-      value: 1
-    - category: Other
-      description: User params of model_three in the multimodel group.
-      key: model-user-params-2
-      value: --test_key_three test_value_three
-    - category: Other
-      description: Artifact path for model_three in the multimodel group.
-      key: artifact_location-2
-      value: model_three_path
+    - category: null
+      description: null
+      key: multi_model_metadata
+      value: Uploaded
     - category: Other
       description: Inference container mapping for multi_model
       key: deployment-container

--- a/tests/unitary/with_extras/aqua/test_evaluation.py
+++ b/tests/unitary/with_extras/aqua/test_evaluation.py
@@ -359,6 +359,30 @@ class TestDataset:
     INVALID_EVAL_ID = "ocid1.datasciencemodel.oc1.phx.<OCID>"
     MODEL_DEPLOYMENT_ID = "ocid1.datasciencemodeldeployment.oc1.<region>.<MD_OCID>"
 
+    multi_model_deployment_model_attributes = [
+        {
+            "env_var": {"--test_key_one": "test_value_one"},
+            "gpu_count": 1,
+            "model_id": "ocid1.compartment.oc1..<OCID>",
+            "model_name": "model_one",
+            "artifact_location": "artifact_location_one",
+        },
+        {
+            "env_var": {"--test_key_two": "test_value_two"},
+            "gpu_count": 1,
+            "model_id": "ocid1.compartment.oc1..<OCID>",
+            "model_name": "model_two",
+            "artifact_location": "artifact_location_two",
+        },
+        {
+            "env_var": {"--test_key_three": "test_value_three"},
+            "gpu_count": 1,
+            "model_id": "ocid1.compartment.oc1..<OCID>",
+            "model_name": "model_three",
+            "artifact_location": "artifact_location_three",
+        },
+    ]
+
 
 class TestAquaEvaluation(unittest.TestCase):
     """Contains unittests for TestAquaEvaluationApp."""
@@ -551,8 +575,15 @@ class TestAquaEvaluation(unittest.TestCase):
         ]
     )
     @patch("ads.aqua.evaluation.evaluation.AquaEvaluationApp.create")
+    @patch(
+        "ads.model.datascience_model.OCIDataScienceModel.get_custom_metadata_artifact"
+    )
     def test_validate_model_name(
-        self, mock_model_parameters, expected_message, mock_model
+        self,
+        mock_model_parameters,
+        expected_message,
+        mock_get_custom_metadata_artifact,
+        mock_model,
     ):
         curr_dir = os.path.dirname(__file__)
 
@@ -582,6 +613,13 @@ class TestAquaEvaluation(unittest.TestCase):
         )
 
         mock_model = DataScienceModel.from_yaml(uri=aqua_multi_model)
+
+        multi_model_deployment_model_attributes_str = json.dumps(
+            TestDataset.multi_model_deployment_model_attributes
+        ).encode("utf-8")
+        mock_get_custom_metadata_artifact.return_value = (
+            multi_model_deployment_model_attributes_str
+        )
 
         mock_create_aqua_evaluation_details = MagicMock(
             **create_aqua_evaluation_details, spec=CreateAquaEvaluationDetails

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -370,6 +370,7 @@ class TestAquaModel:
     def test_create_multimodel(
         self,
         mock_from_id,
+        mock_get_container_config,
         mock_validate,
         mock_create,
         mock_create_custom_metadata_artifact,

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -362,6 +362,7 @@ class TestAquaModel:
         assert model.provenance_metadata.training_id == "test_training_id"
 
     @patch.object(DataScienceModel, "add_artifact")
+    @patch.object(DataScienceModel, "create_custom_metadata_artifact")
     @patch.object(DataScienceModel, "create")
     @patch("ads.model.datascience_model.validate")
     @patch("ads.aqua.model.model.get_container_config")
@@ -369,9 +370,9 @@ class TestAquaModel:
     def test_create_multimodel(
         self,
         mock_from_id,
-        mock_get_container_config,
         mock_validate,
         mock_create,
+        mock_create_custom_metadata_artifact,
         mock_add_artifact,
     ):
         mock_get_container_config.return_value = get_container_config()


### PR DESCRIPTION
### Improved multi model metadata storage

- Applied `create_custom_metadata_artifact` to store multi model metadata in model catalog while creating the aqua model.
- Applied `get_custom_metadata_artifact` to get multi model metadata in model catalog while fetching the aqua deployment.

### Notebook
<img width="1040" alt="Screenshot 2025-03-12 at 3 44 46 PM" src="https://github.com/user-attachments/assets/216878a2-9218-4bd4-8ef8-77d57ac8fae7" />
<img width="1254" alt="Screenshot 2025-03-12 at 3 43 20 PM" src="https://github.com/user-attachments/assets/b9ce0a5f-a13c-4367-bca6-c7ad58fe453c" />
