### PR TITLE
Disable new taxonomy metadata tags in  model_metadata.py

### DIFF
--- a/ads/model/model_metadata.py
+++ b/ads/model/model_metadata.py
@@ -103,10 +103,10 @@ class MetadataTaxonomyKeys(ExtendedEnum):
     ALGORITHM = "Algorithm"
     HYPERPARAMETERS = "Hyperparameters"
     ARTIFACT_TEST_RESULT = "ArtifactTestResults"
-    README = "Readme"
-    LICENSE = "License"
-    DEPLOYMENT_CONFIGURATION = "DeploymentConfiguration"
-    FINETUNE_CONFIGURATION = "FineTuneConfiguration"
+    # README = "Readme"
+    # LICENSE = "License"
+    # DEPLOYMENT_CONFIGURATION = "DeploymentConfiguration"
+    # FINETUNE_CONFIGURATION = "FineTuneConfiguration"
 
 
 class MetadataCustomKeys(ExtendedEnum):


### PR DESCRIPTION
## Description
Disable new taxonomy metadata tags in  `model_metadata.py`  to make them optional.