### PR TITLE
Additional CLI Support for AQUA with Pydantic Objects

### DIFF
--- a/ads/aqua/evaluation/evaluation.py
+++ b/ads/aqua/evaluation/evaluation.py
@@ -141,13 +141,62 @@ class AquaEvaluationApp(AquaApp):
         create_aqua_evaluation_details: CreateAquaEvaluationDetails = None,
         **kwargs,
     ) -> "AquaEvaluationSummary":
-        """Creates Aqua evaluation for resource.
+        """Creates Aqua evaluation for resource.\n
+        For detailed information about CLI flags see: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/f271ca63d12e3c256718f23a14d93da4b4fc086b/ai-quick-actions/cli-tips.md#create-model-evaluation
 
         Parameters
         ----------
         create_aqua_evaluation_details: CreateAquaEvaluationDetails
             The CreateAquaEvaluationDetails data class which contains all
             required and optional fields to create the aqua evaluation.
+            kwargs:
+                evaluation_source_id: str
+                    The evaluation source id. Must be either model or model deployment ocid.
+                evaluation_name: str
+                    The name for evaluation.
+                dataset_path: str
+                    The dataset path for the evaluation. Could be either a local path from notebook session
+                    or an object storage path.
+                report_path: str
+                    The report path for the evaluation. Must be an object storage path.
+                model_parameters: dict
+                    The parameters for the evaluation.
+                shape_name: str
+                    The shape name for the evaluation job infrastructure.
+                memory_in_gbs: float
+                    The memory in gbs for the shape selected.
+                ocpus: float
+                    The ocpu count for the shape selected.
+                block_storage_size: int
+                    The storage for the evaluation job infrastructure.
+                compartment_id: (str, optional). Defaults to `None`.
+                    The compartment id for the evaluation.
+                project_id: (str, optional). Defaults to `None`.
+                    The project id for the evaluation.
+                evaluation_description: (str, optional). Defaults to `None`.
+                    The description for evaluation
+                experiment_id: (str, optional). Defaults to `None`.
+                    The evaluation model version set id. If provided,
+                    evaluation model will be associated with it.
+                experiment_name: (str, optional). Defaults to `None`.
+                    The evaluation model version set name. If provided,
+                    the model version set with the same name will be used if exists,
+                    otherwise a new model version set will be created with the name.
+                experiment_description: (str, optional). Defaults to `None`.
+                    The description for the evaluation model version set.
+                log_group_id: (str, optional). Defaults to `None`.
+                    The log group id for the evaluation job infrastructure.
+                log_id: (str, optional). Defaults to `None`.
+                    The log id for the evaluation job infrastructure.
+                metrics: (list, optional). Defaults to `None`.
+                    The metrics for the evaluation.
+                force_overwrite: (bool, optional). Defaults to `False`.
+                    Whether to force overwrite the existing file in object storage.
+                freeform_tags: (dict, optional)
+                    Freeform tags for the evaluation model
+                defined_tags: (dict, optional)
+                    Defined tags for the evaluation model
+
         kwargs:
             The kwargs for creating CreateAquaEvaluationDetails instance if
             no create_aqua_evaluation_details provided.

--- a/ads/aqua/finetuning/finetuning.py
+++ b/ads/aqua/finetuning/finetuning.py
@@ -87,13 +87,62 @@ class AquaFineTuningApp(AquaApp):
     def create(
         self, create_fine_tuning_details: CreateFineTuningDetails = None, **kwargs
     ) -> "AquaFineTuningSummary":
-        """Creates Aqua fine tuning for model.
+        """Creates Aqua fine tuning for model.\n
+        For detailed information about CLI flags see: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/f271ca63d12e3c256718f23a14d93da4b4fc086b/ai-quick-actions/cli-tips.md#create-fine-tuned-model
 
         Parameters
         ----------
         create_fine_tuning_details: CreateFineTuningDetails
             The CreateFineTuningDetails data class which contains all
             required and optional fields to create the aqua fine tuning.
+            kwargs:
+                ft_source_id: str The fine tuning source id. Must be model OCID.
+                ft_name: str
+                    The name for fine tuning.
+                dataset_path: str
+                    The dataset path for fine tuning. Could be either a local path from notebook session
+                    or an object storage path.
+                report_path: str
+                    The report path for fine tuning. Must be an object storage path.
+                ft_parameters: dict
+                    The parameters for fine tuning.
+                shape_name: str
+                    The shape name for fine tuning job infrastructure.
+                replica: int
+                    The replica for fine tuning job runtime.
+                validation_set_size: float
+                    The validation set size for fine tuning job. Must be a float in between [0,1).
+                ft_description: (str, optional). Defaults to `None`.
+                    The description for fine tuning.
+                compartment_id: (str, optional). Defaults to `None`.
+                    The compartment id for fine tuning.
+                project_id: (str, optional). Defaults to `None`.
+                    The project id for fine tuning.
+                experiment_id: (str, optional). Defaults to `None`.
+                    The fine tuning model version set id. If provided,
+                    fine tuning model will be associated with it.
+                experiment_name: (str, optional). Defaults to `None`.
+                    The fine tuning model version set name. If provided,
+                    the fine tuning version set with the same name will be used if exists,
+                    otherwise a new model version set will be created with the name.
+                experiment_description: (str, optional). Defaults to `None`.
+                    The description for fine tuning model version set.
+                block_storage_size: (int, optional). Defaults to 256.
+                    The storage for fine tuning job infrastructure.
+                subnet_id: (str, optional). Defaults to `None`.
+                    The custom egress for fine tuning job.
+                log_group_id: (str, optional). Defaults to `None`.
+                    The log group id for fine tuning job infrastructure.
+                log_id: (str, optional). Defaults to `None`.
+                    The log id for fine tuning job infrastructure.
+                watch_logs: (bool, optional). Defaults to `False`.
+                    The flag to watch the job run logs when a fine-tuning job is created.
+                force_overwrite: (bool, optional). Defaults to `False`.
+                    Whether to force overwrite the existing file in object storage.
+                freeform_tags: (dict, optional)
+                    Freeform tags for the fine-tuning model
+                defined_tags: (dict, optional)
+                    Defined tags for the fine-tuning model
         kwargs:
             The kwargs for creating CreateFineTuningDetails instance if
             no create_fine_tuning_details provided.

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -1654,8 +1654,9 @@ class AquaModelApp(AquaApp):
         self, import_model_details: ImportModelDetails = None, **kwargs
     ) -> AquaModel:
         """Loads the model from object storage and registers as Model in Data Science Model catalog
-        The inference container and finetuning container could be of type Service Manged Container(SMC) or custom.
-        If it is custom, full container URI is expected. If it of type SMC, only the container family name is expected.
+        The inference container and finetuning container could be of type Service Managed Container(SMC) or custom.
+        If it is custom, full container URI is expected. If it of type SMC, only the container family name is expected.\n
+        For detailed information about CLI flags see: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/cli-tips.md#register-model
 
         Args:
             import_model_details (ImportModelDetails): Model details for importing the model.

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -121,11 +121,10 @@ class AquaDeploymentApp(AquaApp):
         Creates a new Aqua model deployment.\n
         For detailed information about CLI flags see: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/cli-tips.md#create-model-deployment
 
-        Parameters
-        ----------
-        create_deployment_details : CreateModelDeploymentDetails, optional
-            An instance of CreateModelDeploymentDetails containing all required and optional
-            fields for creating a model deployment via Aqua.
+        Args:
+            create_deployment_details : CreateModelDeploymentDetails, optional
+                An instance of CreateModelDeploymentDetails containing all required and optional
+                fields for creating a model deployment via Aqua.
             kwargs:
                 instance_shape (str): The instance shape used for deployment.
                 display_name (str): The name of the model deployment.
@@ -152,10 +151,6 @@ class AquaDeploymentApp(AquaApp):
                 cmd_var (Optional[List[str]]): Command variables for the container runtime.
                 freeform_tags (Optional[Dict]): Freeform tags for model deployment.
                 defined_tags (Optional[Dict]): Defined tags for model deployment.
-
-        **kwargs:
-            Keyword arguments used to construct a CreateModelDeploymentDetails instance if one
-            is not provided.
 
         Returns
         -------

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -118,13 +118,41 @@ class AquaDeploymentApp(AquaApp):
         **kwargs,
     ) -> "AquaDeployment":
         """
-        Creates a new Aqua model deployment.
+        Creates a new Aqua model deployment.\n
+        For detailed information about CLI flags see: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/cli-tips.md#create-model-deployment
 
         Parameters
         ----------
         create_deployment_details : CreateModelDeploymentDetails, optional
             An instance of CreateModelDeploymentDetails containing all required and optional
             fields for creating a model deployment via Aqua.
+            kwargs:
+                instance_shape (str): The instance shape used for deployment.
+                display_name (str): The name of the model deployment.
+                compartment_id (Optional[str]): The compartment OCID.
+                project_id (Optional[str]): The project OCID.
+                description (Optional[str]): The description of the deployment.
+                model_id (Optional[str]): The model OCID to deploy.
+                models (Optional[List[AquaMultiModelRef]]): List of models for multimodel deployment.
+                instance_count (int): Number of instances used for deployment.
+                log_group_id (Optional[str]): OCI logging group ID for logs.
+                access_log_id (Optional[str]): OCID for access logs.
+                predict_log_id (Optional[str]): OCID for prediction logs.
+                bandwidth_mbps (Optional[int]): Bandwidth limit on the load balancer in Mbps.
+                web_concurrency (Optional[int]): Number of worker processes/threads for handling requests.
+                server_port (Optional[int]): Server port for the Docker container image.
+                health_check_port (Optional[int]): Health check port for the Docker container image.
+                env_var (Optional[Dict[str, str]]): Environment variables for deployment.
+                container_family (Optional[str]): Image family of the model deployment container runtime.
+                memory_in_gbs (Optional[float]): Memory (in GB) for the selected shape.
+                ocpus (Optional[float]): OCPU count for the selected shape.
+                model_file (Optional[str]): File used for model deployment.
+                private_endpoint_id (Optional[str]): Private endpoint ID for model deployment.
+                container_image_uri (Optional[str]): Image URI for model deployment container runtime.
+                cmd_var (Optional[List[str]]): Command variables for the container runtime.
+                freeform_tags (Optional[Dict]): Freeform tags for model deployment.
+                defined_tags (Optional[Dict]): Defined tags for model deployment.
+
         **kwargs:
             Keyword arguments used to construct a CreateModelDeploymentDetails instance if one
             is not provided.


### PR DESCRIPTION
Since we migrated AQUA to use Pydantic objects, the fire package used for automatically parsing the method docstring now does not disclose the parameters for Pydantic objects used in several AQUA methods. The CLI --help command needed to be updated to give the user more insight on the parameters of these Pydantic objects.

For the following CLI AQUA commands, added Github Links to relevant documentation about flags. 'kwargs' were also added to the method docstring as well.

`ads aqua model register --help`
![Screenshot 2025-03-18 at 1 40 10 PM](https://github.com/user-attachments/assets/84adec6d-ed37-4da5-96a4-9c92a3d59429)

`ads aqua deployment create --help`
Comment- I know this one looks crazy- Any suggestions? I followed the example [here ](https://github.com/oracle/accelerated-data-science/blob/feature/multi_model_deployment/ads/aqua/model/model.py#L1653)for formatting, but fire package is rendering the output like this:

![Screenshot 2025-03-18 at 1 49 57 PM](https://github.com/user-attachments/assets/d7e02cb2-6c51-4b02-84ed-8116871bb9bf)

`ads aqua evaluation create --help`
![Screenshot 2025-03-18 at 1 47 37 PM](https://github.com/user-attachments/assets/6dcde823-0856-441c-9526-8e3f2f446386)

`ads aqua fine_tuning create --help`
![Screenshot 2025-03-18 at 1 48 28 PM](https://github.com/user-attachments/assets/7303726d-54db-4a18-900a-df709b60b277)