### PR TITLE
Added Error Message for Unavailable Shape in Region

### DIFF
--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -172,11 +172,21 @@ class AquaDeploymentApp(AquaApp):
                 "Invalid parameters for creating a model deployment. Either `model_id` or `models` must be provided."
             )
 
+
         # Set defaults for compartment and project if not provided.
         compartment_id = create_deployment_details.compartment_id or COMPARTMENT_OCID
         project_id = create_deployment_details.project_id or PROJECT_OCID
         freeform_tags = create_deployment_details.freeform_tags
         defined_tags = create_deployment_details.defined_tags
+
+        # validate instance shape availability in compartment
+        available_shapes = self.list_shapes(compartment_id=create_deployment_details.compartment_id)
+
+        if create_deployment_details.instance_shape not in available_shapes:
+            raise AquaValueError(
+                f"Invalid Instance Shape. The selected shape '{create_deployment_details.instance_shape}' is not available in the {self.region} region. "
+                "Please choose another shape to deploy the model."
+            )
 
         # Get container config
         container_config = get_container_config()


### PR DESCRIPTION
Added error to fix bug encountered on-call. 

BUG:
if a user is in a region (ie. Singapore West) where the following shapes (VM.GPU.A10.1, VM.GPU.A10.2, etc) are not available, the error thrown is non-descriptive and shows as an auth error.
<img width="1201" alt="Screenshot 2025-03-19 at 1 47 03 PM" src="https://github.com/user-attachments/assets/7013b245-4cad-4c84-ac9c-3d5deb066227" />

We now throw an Invalid Instance Name error complete with details about the unavailable shape. 
<img width="878" alt="Screenshot 2025-03-19 at 1 48 09 PM" src="https://github.com/user-attachments/assets/5a3dd024-b947-4883-b5b9-5f5b9e0ddb45" />


Ideally, the shape should not even be listed in the AQUA UI if not available in the region.
<img width="911" alt="Screenshot 2025-03-19 at 1 46 21 PM" src="https://github.com/user-attachments/assets/b2f9e4a7-4d5b-4e84-8b7d-bbbbd544efdb" />