### PR TITLE
[DRCC] Create and Update Metadata artifact content changes

### DIFF
--- a/ads/common/utils.py
+++ b/ads/common/utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 
@@ -150,22 +150,6 @@ def oci_key_location():
     return os.environ.get(
         "OCI_CONFIG_DIR", os.path.join(os.path.expanduser("~"), ".oci")
     )
-
-
-def text_sanitizer(content):
-    if isinstance(content, str):
-        return (
-            content.replace("“", '"')
-            .replace("”", '"')
-            .replace("’", "'")
-            .replace("‘", "'")
-            .replace("—", "-")
-            .encode("utf-8", "ignore")
-            .decode("utf-8", "ignore")
-        )
-    if isinstance(content, dict):
-        return json.dumps(content)
-    return str(content)
 
 
 @deprecated(

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -89,6 +89,11 @@ class InvalidArtifactType(Exception):  # pragma: no cover
     pass
 
 
+class InvalidArtifactPathTypeOrContentError(Exception):  # pragma: no cover
+    def __init__(self, msg="Invalid type of Metdata artifact content"):
+        super().__init__(msg)
+
+
 class CustomerNotificationType(ExtendedEnum):
     NONE = "NONE"
     ALL = "ALL"
@@ -2238,7 +2243,7 @@ class DataScienceModel(Builder):
     def create_custom_metadata_artifact(
         self,
         metadata_key_name: str,
-        artifact_path_or_content: str,
+        artifact_path_or_content: Union[str, bytes],
         path_type: MetadataArtifactPathType = MetadataArtifactPathType.LOCAL,
     ) -> ModelMetadataArtifactDetails:
         """Creates model custom metadata artifact for specified model.
@@ -2248,8 +2253,10 @@ class DataScienceModel(Builder):
         metadata_key_name: str
             The name of the model custom metadata key
 
-        artifact_path_or_content: str
-            The model custom metadata artifact path to be upload. It can also be the actual content of the custom metadata
+        artifact_path_or_content: Union[str,bytes]
+            The model custom metadata artifact path to be upload. It can also be the actual content of the defined metadata
+            The type is string when it represents local path or oss path.
+            The type is bytes when it represents content itself
 
         path_type: MetadataArtifactPathType
             Can be either of MetadataArtifactPathType.LOCAL , MetadataArtifactPathType.OSS , MetadataArtifactPathType.CONTENT
@@ -2273,16 +2280,23 @@ class DataScienceModel(Builder):
             }
 
         """
+        if path_type == MetadataArtifactPathType.CONTENT and not isinstance(
+            artifact_path_or_content, bytes
+        ):
+            raise InvalidArtifactPathTypeOrContentError(
+                f"Invalid type of artifact content: {type(artifact_path_or_content)}. It should be bytes."
+            )
+
         return self.dsc_model.create_custom_metadata_artifact(
             metadata_key_name=metadata_key_name,
-            artifact_path=artifact_path_or_content,
+            artifact_path_or_content=artifact_path_or_content,
             path_type=path_type,
         )
 
     def create_defined_metadata_artifact(
         self,
         metadata_key_name: str,
-        artifact_path_or_content: str,
+        artifact_path_or_content: Union[str, bytes],
         path_type: MetadataArtifactPathType = MetadataArtifactPathType.LOCAL,
     ) -> ModelMetadataArtifactDetails:
         """Creates model defined metadata artifact for specified model.
@@ -2292,8 +2306,10 @@ class DataScienceModel(Builder):
         metadata_key_name: str
             The name of the model defined metadata key
 
-        artifact_path_or_content: str
+        artifact_path_or_content: Union[str,bytes]
             The model defined metadata artifact path to be upload. It can also be the actual content of the defined metadata
+            The type is string when it represents local path or oss path.
+            The type is bytes when it represents content itself
 
         path_type: MetadataArtifactPathType
             Can be either of MetadataArtifactPathType.LOCAL , MetadataArtifactPathType.OSS , MetadataArtifactPathType.CONTENT
@@ -2317,16 +2333,23 @@ class DataScienceModel(Builder):
             }
 
         """
+        if path_type == MetadataArtifactPathType.CONTENT and not isinstance(
+            artifact_path_or_content, bytes
+        ):
+            raise InvalidArtifactPathTypeOrContentError(
+                f"Invalid type of artifact content: {type(artifact_path_or_content)}. It should be bytes."
+            )
+
         return self.dsc_model.create_defined_metadata_artifact(
             metadata_key_name=metadata_key_name,
-            artifact_path=artifact_path_or_content,
+            artifact_path_or_content=artifact_path_or_content,
             path_type=path_type,
         )
 
     def update_custom_metadata_artifact(
         self,
         metadata_key_name: str,
-        artifact_path_or_content: str,
+        artifact_path_or_content: Union[str, bytes],
         path_type: MetadataArtifactPathType = MetadataArtifactPathType.LOCAL,
     ) -> ModelMetadataArtifactDetails:
         """Update model custom metadata artifact for specified model.
@@ -2336,8 +2359,10 @@ class DataScienceModel(Builder):
         metadata_key_name: str
             The name of the model custom metadata key
 
-        artifact_path_or_content: str
-            The model custom metadata artifact path. It can also be the actual content of the custom metadata
+        artifact_path_or_content: Union[str,bytes]
+            The model custom metadata artifact path to be upload. It can also be the actual content of the defined metadata
+            The type is string when it represents local path or oss path.
+            The type is bytes when it represents content itself
 
         path_type: MetadataArtifactPathType
             Can be either of MetadataArtifactPathType.LOCAL , MetadataArtifactPathType.OSS , MetadataArtifactPathType.CONTENT
@@ -2361,16 +2386,23 @@ class DataScienceModel(Builder):
             }
 
         """
+        if path_type == MetadataArtifactPathType.CONTENT and not isinstance(
+            artifact_path_or_content, bytes
+        ):
+            raise InvalidArtifactPathTypeOrContentError(
+                f"Invalid type of artifact content: {type(artifact_path_or_content)}. It should be bytes."
+            )
+
         return self.dsc_model.update_custom_metadata_artifact(
             metadata_key_name=metadata_key_name,
-            artifact_path=artifact_path_or_content,
+            artifact_path_or_content=artifact_path_or_content,
             path_type=path_type,
         )
 
     def update_defined_metadata_artifact(
         self,
         metadata_key_name: str,
-        artifact_path_or_content: str,
+        artifact_path_or_content: Union[str, bytes],
         path_type: MetadataArtifactPathType = MetadataArtifactPathType.LOCAL,
     ) -> ModelMetadataArtifactDetails:
         """Update model defined metadata artifact for specified model.
@@ -2380,8 +2412,10 @@ class DataScienceModel(Builder):
         metadata_key_name: str
             The name of the model defined metadata key
 
-        artifact_path_or_content: str
-            The model defined metadata artifact path. It can also be the actual content of the defined metadata
+        artifact_path_or_content: Union[str,bytes]
+            The model defined metadata artifact path to be upload. It can also be the actual content of the defined metadata
+            The type is string when it represents local path or oss path.
+            The type is bytes when it represents content itself
 
         path_type: MetadataArtifactPathType
             Can be either of MetadataArtifactPathType.LOCAL , MetadataArtifactPathType.OSS , MetadataArtifactPathType.CONTENT
@@ -2405,9 +2439,16 @@ class DataScienceModel(Builder):
             }
 
         """
+        if path_type == MetadataArtifactPathType.CONTENT and not isinstance(
+            artifact_path_or_content, bytes
+        ):
+            raise InvalidArtifactPathTypeOrContentError(
+                f"Invalid type of artifact content: {type(artifact_path_or_content)}. It should be bytes."
+            )
+
         return self.dsc_model.update_defined_metadata_artifact(
             metadata_key_name=metadata_key_name,
-            artifact_path=artifact_path_or_content,
+            artifact_path_or_content=artifact_path_or_content,
             path_type=path_type,
         )
 
@@ -2442,7 +2483,7 @@ class DataScienceModel(Builder):
         )
         artifact_file_path = os.path.join(target_dir, f"{metadata_key_name}")
 
-        if not override and os.path.exists(artifact_file_path):
+        if not override and is_path_exists(artifact_file_path):
             raise FileExistsError(f"File already exists: {artifact_file_path}")
 
         with open(artifact_file_path, "wb") as _file:
@@ -2481,7 +2522,7 @@ class DataScienceModel(Builder):
         )
         artifact_file_path = os.path.join(target_dir, f"{metadata_key_name}")
 
-        if not override and os.path.exists(artifact_file_path):
+        if not override and is_path_exists(artifact_file_path):
             raise FileExistsError(f"File already exists: {artifact_file_path}")
 
         with open(artifact_file_path, "wb") as _file:

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -2254,14 +2254,21 @@ class DataScienceModel(Builder):
             The name of the model custom metadata key
 
         artifact_path_or_content: Union[str,bytes]
-            The model custom metadata artifact path to be upload. It can also be the actual content of the defined metadata
+            The model custom metadata artifact path to be uploaded. It can also be the actual content of the custom metadata artifact
             The type is string when it represents local path or oss path.
             The type is bytes when it represents content itself
 
         path_type: MetadataArtifactPathType
             Can be either of MetadataArtifactPathType.LOCAL , MetadataArtifactPathType.OSS , MetadataArtifactPathType.CONTENT
             Specifies what type of path is to be provided for metadata artifact.
-            Can be either local , oss or the actual content itself
+
+        Example:
+        >>>       ds_model=DataScienceModel.from_id("ocid1.datasciencemodel.iad.xxyxz...")
+        >>>       ds_model.create_custom_metadata_artifact(
+        ...         "README",
+        ...         artifact_path_or_content="/Users/<username>/Downloads/README.md",
+        ...         path_type=MetadataArtifactPathType.LOCAL
+        ...       )
 
         Returns
         -------
@@ -2307,7 +2314,7 @@ class DataScienceModel(Builder):
             The name of the model defined metadata key
 
         artifact_path_or_content: Union[str,bytes]
-            The model defined metadata artifact path to be upload. It can also be the actual content of the defined metadata
+            The model defined metadata artifact path to be uploaded. It can also be the actual content of the defined metadata
             The type is string when it represents local path or oss path.
             The type is bytes when it represents content itself
 
@@ -2315,6 +2322,14 @@ class DataScienceModel(Builder):
             Can be either of MetadataArtifactPathType.LOCAL , MetadataArtifactPathType.OSS , MetadataArtifactPathType.CONTENT
             Specifies what type of path is to be provided for metadata artifact.
             Can be either local , oss or the actual content itself
+
+        Example:
+        >>>       ds_model=DataScienceModel.from_id("ocid1.datasciencemodel.iad.xxyxz...")
+        >>>       ds_model.create_defined_metadata_artifact(
+        ...         "README",
+        ...         artifact_path_or_content="oci://path/to/bucket/README.md",
+        ...         path_type=MetadataArtifactPathType.OSS
+        ...       )
 
         Returns
         -------
@@ -2360,7 +2375,7 @@ class DataScienceModel(Builder):
             The name of the model custom metadata key
 
         artifact_path_or_content: Union[str,bytes]
-            The model custom metadata artifact path to be upload. It can also be the actual content of the defined metadata
+            The model custom metadata artifact path to be uploaded. It can also be the actual content of the custom metadata
             The type is string when it represents local path or oss path.
             The type is bytes when it represents content itself
 
@@ -2413,7 +2428,7 @@ class DataScienceModel(Builder):
             The name of the model defined metadata key
 
         artifact_path_or_content: Union[str,bytes]
-            The model defined metadata artifact path to be upload. It can also be the actual content of the defined metadata
+            The model defined metadata artifact path to be uploaded. It can also be the actual content of the defined metadata
             The type is string when it represents local path or oss path.
             The type is bytes when it represents content itself
 

--- a/ads/model/datascience_model.py
+++ b/ads/model/datascience_model.py
@@ -2499,7 +2499,9 @@ class DataScienceModel(Builder):
         artifact_file_path = os.path.join(target_dir, f"{metadata_key_name}")
 
         if not override and is_path_exists(artifact_file_path):
-            raise FileExistsError(f"File already exists: {artifact_file_path}")
+            raise FileExistsError(
+                f"File already exists: {artifact_file_path}. Please use boolean override parameter to override the file content."
+            )
 
         with open(artifact_file_path, "wb") as _file:
             _file.write(file_content)
@@ -2538,7 +2540,9 @@ class DataScienceModel(Builder):
         artifact_file_path = os.path.join(target_dir, f"{metadata_key_name}")
 
         if not override and is_path_exists(artifact_file_path):
-            raise FileExistsError(f"File already exists: {artifact_file_path}")
+            raise FileExistsError(
+                f"File already exists: {artifact_file_path}. Please use boolean override parameter to override the file content."
+            )
 
         with open(artifact_file_path, "wb") as _file:
             _file.write(file_content)

--- a/ads/model/service/oci_datascience_model.py
+++ b/ads/model/service/oci_datascience_model.py
@@ -645,23 +645,17 @@ class OCIDataScienceModel(
         if path_type == MetadataArtifactPathType.CONTENT:
             return artifact_path_or_content
 
-        elif path_type == MetadataArtifactPathType.LOCAL:
-            if not utils.is_path_exists(artifact_path_or_content):
-                raise FileNotFoundError(
-                    f"File not found:  {artifact_path_or_content} . "
-                )
-
-            with open(artifact_path_or_content, "rb") as f:
-                contents = f.read()
-                logger.info(f"The metadata artifact content - {contents}")
-
-            return contents
-
-        elif path_type == MetadataArtifactPathType.OSS:
+        elif (
+            path_type == MetadataArtifactPathType.LOCAL
+            or path_type == MetadataArtifactPathType.OSS
+        ):
             if not utils.is_path_exists(artifact_path_or_content):
                 raise FileNotFoundError(f"File not found: {artifact_path_or_content}")
+            signer = (
+                default_signer() if path_type == MetadataArtifactPathType.OSS else {}
+            )
             contents = read_file(
-                file_path=artifact_path_or_content, auth=default_signer()
+                file_path=artifact_path_or_content, auth=signer
             ).encode()
             logger.debug(f"The metadata artifact content - {contents}")
 

--- a/ads/model/service/oci_datascience_model.py
+++ b/ads/model/service/oci_datascience_model.py
@@ -624,7 +624,7 @@ class OCIDataScienceModel(
         self,
         artifact_path_or_content: Union[str, bytes],
         path_type: MetadataArtifactPathType,
-    ):
+    ) -> bytes:
         """
         returns the content of the metadata artifact
 
@@ -639,7 +639,8 @@ class OCIDataScienceModel(
 
         Returns
         -------
-        metadata artifact content
+        bytes
+            metadata artifact content in bytes
         """
 
         if path_type == MetadataArtifactPathType.CONTENT:

--- a/ads/model/service/oci_datascience_model.py
+++ b/ads/model/service/oci_datascience_model.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2022, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2022, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import logging
@@ -28,7 +28,7 @@ from ads.common.oci_datascience import OCIDataScienceMixin
 from ads.common.oci_mixin import OCIWorkRequestMixin
 from ads.common.oci_resource import SEARCH_TYPE, OCIResource
 from ads.common.serializer import DataClassSerializable
-from ads.common.utils import extract_region, read_file, text_sanitizer
+from ads.common.utils import extract_region, read_file
 from ads.common.work_request import DataScienceWorkRequest
 from ads.model.common.utils import MetadataArtifactPathType
 from ads.model.deployment import ModelDeployment
@@ -621,15 +621,19 @@ class OCIDataScienceModel(
         return False
 
     def get_metadata_content(
-        self, artifact_path_or_content: str, path_type: MetadataArtifactPathType
+        self,
+        artifact_path_or_content: Union[str, bytes],
+        path_type: MetadataArtifactPathType,
     ):
         """
         returns the content of the metadata artifact
 
         Parameters
         ----------
-        artifact_path_or_content: str
+        artifact_path_or_content: Union[str,bytes]
             The path of the file (local or oss) containing metadata artifact or content.
+            The type is string when it represents local path or oss path.
+            The type is bytes when it represents content itself
         path_type: str
             can be one of local , oss or actual content itself
 
@@ -656,10 +660,9 @@ class OCIDataScienceModel(
         elif path_type == MetadataArtifactPathType.OSS:
             if not utils.is_path_exists(artifact_path_or_content):
                 raise FileNotFoundError(f"File not found: {artifact_path_or_content}")
-
-            contents = str(
-                read_file(file_path=artifact_path_or_content, auth=default_signer())
-            )
+            contents = read_file(
+                file_path=artifact_path_or_content, auth=default_signer()
+            ).encode()
             logger.debug(f"The metadata artifact content - {contents}")
 
             return contents
@@ -670,7 +673,7 @@ class OCIDataScienceModel(
     def create_custom_metadata_artifact(
         self,
         metadata_key_name: str,
-        artifact_path: str,
+        artifact_path_or_content: Union[str, bytes],
         path_type: MetadataArtifactPathType,
     ) -> ModelMetadataArtifactDetails:
         """Creates model custom metadata artifact for specified model.
@@ -680,8 +683,10 @@ class OCIDataScienceModel(
         metadata_key_name: str
             The name of the model metadatum in the metadata.
 
-        artifact_path: str
-            The model custom metadata artifact path to be upload.
+        artifact_path_or_content: Union[str,bytes]
+            The path of the file (local or oss) containing metadata artifact or content.
+            The type is string when it represents local path or oss path.
+            The type is bytes when it represents content itself
 
         path_type: MetadataArtifactPathType
             can be one of local , oss or actual content itself
@@ -704,12 +709,13 @@ class OCIDataScienceModel(
 
         """
         contents = self.get_metadata_content(
-            artifact_path_or_content=artifact_path, path_type=path_type
+            artifact_path_or_content=artifact_path_or_content, path_type=path_type
         )
+
         response = self.client.create_model_custom_metadatum_artifact(
             self.id,
             metadata_key_name,
-            text_sanitizer(contents),
+            contents,
             content_disposition="form" '-data; name="file"; filename="readme.*"',
         )
         response_data = convert_model_metadata_response(
@@ -723,7 +729,7 @@ class OCIDataScienceModel(
     def create_defined_metadata_artifact(
         self,
         metadata_key_name: str,
-        artifact_path: str,
+        artifact_path_or_content: Union[str, bytes],
         path_type: MetadataArtifactPathType,
     ) -> ModelMetadataArtifactDetails:
         """Creates model defined metadata artifact for specified model.
@@ -733,8 +739,10 @@ class OCIDataScienceModel(
         metadata_key_name: str
             The name of the model metadatum in the metadata.
 
-        artifact_path: str
-            The model custom metadata artifact path to be upload.
+        artifact_path_or_content: Union[str,bytes]
+            The path of the file (local or oss) containing metadata artifact or content.
+            The type is string when it represents local path or oss path.
+            The type is bytes when it represents content itself
 
         path_type: MetadataArtifactPathType
             can be one of local , oss or actual content itself.
@@ -757,12 +765,13 @@ class OCIDataScienceModel(
 
         """
         contents = self.get_metadata_content(
-            artifact_path_or_content=artifact_path, path_type=path_type
+            artifact_path_or_content=artifact_path_or_content, path_type=path_type
         )
+
         response = self.client.create_model_defined_metadatum_artifact(
             self.id,
             metadata_key_name,
-            text_sanitizer(contents),
+            contents,
             content_disposition='form-data; name="file"; filename="readme.*"',
         )
         response_data = convert_model_metadata_response(
@@ -776,7 +785,7 @@ class OCIDataScienceModel(
     def update_defined_metadata_artifact(
         self,
         metadata_key_name: str,
-        artifact_path: str,
+        artifact_path_or_content: Union[str, bytes],
         path_type: MetadataArtifactPathType,
     ) -> ModelMetadataArtifactDetails:
         """Update model defined metadata artifact for specified model.
@@ -786,8 +795,10 @@ class OCIDataScienceModel(
         metadata_key_name: str
             The name of the model metadatum in the metadata.
 
-        artifact_path: str
-            The model defined metadata artifact path to be upload.
+        artifact_path_or_content: Union[str,bytes]
+            The path of the file (local or oss) containing metadata artifact or content.
+            The type is string when it represents local path or oss path.
+            The type is bytes when it represents content itself
 
         path_type:MetadataArtifactPathType
             can be one of local , oss or actual content itself.
@@ -809,12 +820,12 @@ class OCIDataScienceModel(
 
         """
         contents = self.get_metadata_content(
-            artifact_path_or_content=artifact_path, path_type=path_type
+            artifact_path_or_content=artifact_path_or_content, path_type=path_type
         )
         response = self.client.update_model_defined_metadatum_artifact(
             self.id,
             metadata_key_name,
-            text_sanitizer(contents),
+            contents,
             content_disposition='form-data; name="file"; filename="readme.*"',
         )
         response_data = convert_model_metadata_response(
@@ -828,7 +839,7 @@ class OCIDataScienceModel(
     def update_custom_metadata_artifact(
         self,
         metadata_key_name: str,
-        artifact_path: str,
+        artifact_path_or_content: Union[str, bytes],
         path_type: MetadataArtifactPathType,
     ) -> ModelMetadataArtifactDetails:
         """Update model custom metadata artifact for specified model.
@@ -838,8 +849,10 @@ class OCIDataScienceModel(
         metadata_key_name: str
             The name of the model metadatum in the metadata.
 
-        artifact_path: str
-            The model custom metadata artifact path to be upload.
+        artifact_path_or_content: Union[str,bytes]
+            The path of the file (local or oss) containing metadata artifact or content.
+            The type is string when it represents local path or oss path.
+            The type is bytes when it represents content itself
 
         path_type: MetadataArtifactPathType
             can be one of local , oss or actual content itself.
@@ -862,12 +875,12 @@ class OCIDataScienceModel(
 
         """
         contents = self.get_metadata_content(
-            artifact_path_or_content=artifact_path, path_type=path_type
+            artifact_path_or_content=artifact_path_or_content, path_type=path_type
         )
         response = self.client.update_model_custom_metadatum_artifact(
             self.id,
             metadata_key_name,
-            text_sanitizer(contents),
+            contents,
             content_disposition="form" '-data; name="file"; filename="readme.*"',
         )
         response_data = convert_model_metadata_response(


### PR DESCRIPTION
# Description
This PR is intended to improve API for creating and updating metadata artifact which was introduced as part of MS enhancements.

# Issue
While uploading metadata artifact , the type of content should always be bytes.  Earlier it was both bytes and strings.

# Example

When uploading the content via local path

```
from ads.model.common.utils import MetadataArtifactPathType
from ads.model.datascience_model import DataScienceModel

ds_model=DataScienceModel.from_id("ocid1.datasciencemodel.oc1.iad.xxyz")

ds_model.create_defined_metadata_artifact(
    "README",
    artifact_path_or_content="/Users/<username>/Downloads/README.md",
    path_type=MetadataArtifactPathType.LOCAL
)
```
When uploading the content via OSS path

```
from ads.model.common.utils import MetadataArtifactPathType
from ads.model.datascience_model import DataScienceModel

ds_model=DataScienceModel.from_id("ocid1.datasciencemodel.oc1.iad.xxyz")

ds_model.create_defined_metadata_artifact(
    "README",
    artifact_path_or_content="oci://path/to/oss/bucket/README.md",
    path_type=MetadataArtifactPathType.OSS
)
```

When uploading the content itself
```
from ads.model.common.utils import MetadataArtifactPathType
from ads.model.datascience_model import DataScienceModel

ds_model=DataScienceModel.from_id(
    "ocid1.datasciencemodel.oc1.iad.amaaaaaav66vvniavg7xmekk2igrj6oybxgswetlmztgaqrz274jryp4hf7a"
)
with open("/Users/kumarran/Downloads/README.md","rb") as f:
    content=f.read()

# type of content here is bytes
ds_model.create_defined_metadata_artifact(
    "README",
    artifact_path_or_content=content,
    path_type=MetadataArtifactPathType.CONTENT
)
```

# Unit tests
<img width="1512" alt="Screenshot 2025-03-21 at 5 37 51 PM" src="https://github.com/user-attachments/assets/0a1c597c-f9a5-4dce-a7d9-591d7aa88bf6" />

