### PR TITLE
Add defined_tag when creating the model instead of updating the model.

### DIFF
--- a/ads/aqua/evaluation/evaluation.py
+++ b/ads/aqua/evaluation/evaluation.py
@@ -260,6 +260,10 @@ class AquaEvaluationApp(AquaApp):
             **create_aqua_evaluation_details.model_parameters,
         )
 
+        evaluation_model_defined_tags = (
+            create_aqua_evaluation_details.defined_tags or {}
+        )
+
         target_compartment = (
             create_aqua_evaluation_details.compartment_id or COMPARTMENT_OCID
         )
@@ -311,9 +315,7 @@ class AquaEvaluationApp(AquaApp):
                         create_aqua_evaluation_details.experiment_description
                     )
                     .with_freeform_tags(**evaluation_mvs_freeform_tags)
-                    .with_defined_tags(
-                        **(create_aqua_evaluation_details.defined_tags or {})
-                    )
+                    .with_defined_tags(**evaluation_model_defined_tags)
                     # TODO: decide what parameters will be needed
                     .create(**kwargs)
                 )
@@ -358,6 +360,7 @@ class AquaEvaluationApp(AquaApp):
             .with_custom_metadata_list(evaluation_model_custom_metadata)
             .with_defined_metadata_list(evaluation_model_taxonomy_metadata)
             .with_provenance_metadata(ModelProvenanceMetadata(training_id=UNKNOWN))
+            .with_defined_tags(**evaluation_model_defined_tags)
             # TODO uncomment this once the evaluation container will get the updated version of the ADS
             # .with_input_schema(create_aqua_evaluation_details.to_dict())
             # TODO: decide what parameters will be needed
@@ -390,7 +393,7 @@ class AquaEvaluationApp(AquaApp):
             .with_shape_name(create_aqua_evaluation_details.shape_name)
             .with_block_storage_size(create_aqua_evaluation_details.block_storage_size)
             .with_freeform_tag(**evaluation_job_freeform_tags)
-            .with_defined_tag(**(create_aqua_evaluation_details.defined_tags or {}))
+            .with_defined_tag(**evaluation_model_defined_tags)
         )
         if (
             create_aqua_evaluation_details.memory_in_gbs
@@ -429,7 +432,9 @@ class AquaEvaluationApp(AquaApp):
                 metrics=create_aqua_evaluation_details.metrics,
                 inference_configuration=eval_inference_configuration or {},
             )
-        ).create(**kwargs)  ## TODO: decide what parameters will be needed
+        ).create(
+            **kwargs
+        )  ## TODO: decide what parameters will be needed
         logger.debug(
             f"Successfully created evaluation job {evaluation_job.id} for {create_aqua_evaluation_details.evaluation_source_id}."
         )
@@ -437,7 +442,7 @@ class AquaEvaluationApp(AquaApp):
         evaluation_job_run = evaluation_job.run(
             name=evaluation_model.display_name,
             freeform_tags=evaluation_job_freeform_tags,
-            defined_tags=(create_aqua_evaluation_details.defined_tags or {}),
+            defined_tags=evaluation_model_defined_tags,
             wait=False,
         )
         logger.debug(
@@ -461,16 +466,12 @@ class AquaEvaluationApp(AquaApp):
             Tags.AQUA_EVALUATION: Tags.AQUA_EVALUATION,
             **(create_aqua_evaluation_details.freeform_tags or {}),
         }
-        evaluation_model_defined_tags = (
-            create_aqua_evaluation_details.defined_tags or {}
-        )
 
         self.ds_client.update_model(
             model_id=evaluation_model.id,
             update_model_details=UpdateModelDetails(
                 custom_metadata_list=updated_custom_metadata_list,
                 freeform_tags=evaluation_model_freeform_tags,
-                defined_tags=evaluation_model_defined_tags,
             ),
         )
 


### PR DESCRIPTION
Similar to #1122, the workflow for creating an AQUA evaluation also needs to be updated to avoid permission issue.

Defined tags will be added when creating the model instead of updating the model, so that tags added by the tenancy automatically will not be updated.