### PR TITLE
Corrected: Improved AQUA Error Messages for Authorization and Tag-Related Uses 

### DIFF
--- a/ads/aqua/constants.py
+++ b/ads/aqua/constants.py
@@ -96,15 +96,15 @@ OCI_OPERATION_FAILURES = {
         "put_object": "Unable to access or find Object Storage Bucket. See tips for troubleshooting: ",
         "list_model_version_sets": "Unable to create or fetch model version set. See tips for troubleshooting:",
         "update_model": "Unable to update model. See tips for troubleshooting: ",
-        "list_data_science_private_endpoints": "Unable to access specified Object Storage Bucket. See tips for troubleshooting:  ",
-        "create_model" : "Unable to register or create model. See tips for troubleshooting: ",
+        "list_data_science_private_endpoints": "Unable to access private endpoint. See tips for troubleshooting:  ",
+        "create_model" : "Unable to register model. See tips for troubleshooting: ",
         "create_deployment": "Unable to create deployment. See tips for troubleshooting: ",
         "create_model_version_sets" : "Unable to create model version set. See tips for troubleshooting: ",
         "create_job": "Unable to create job. See tips for troubleshooting: ",
         "create_job_run": "Unable to create job run. See tips for troubleshooting: ",
 }
 
-ERROR_MESSAGES = {
+STATUS_CODE_MESSAGES = {
         "400": "Could not process your request due to invalid input.",
         "403": "We're having trouble processing your request with the information provided.",
         "404": "Authorization Failed: The resource you're looking for isn't accessible.",

--- a/ads/aqua/constants.py
+++ b/ads/aqua/constants.py
@@ -40,6 +40,7 @@ AQUA_MODEL_ARTIFACT_FILE = "model_file"
 HF_METADATA_FOLDER = ".cache/"
 HF_LOGIN_DEFAULT_TIMEOUT = 2
 MODEL_NAME_DELIMITER = ";"
+AQUA_TROUBLESHOOTING_LINK = "https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md"
 
 TRAINING_METRICS_FINAL = "training_metrics_final"
 VALIDATION_METRICS_FINAL = "validation_metrics_final"
@@ -85,3 +86,27 @@ LLAMA_CPP_INFERENCE_RESTRICTED_PARAMS = {
     "--host",
 }
 TEI_CONTAINER_DEFAULT_HOST = "8080"
+
+OCI_OPERATION_FAILURES = {
+        "list_model_deployments": "Unable to list model deployments. See tips for troubleshooting: ",
+        "list_models": "Unable to list models. See tips for troubleshooting: ",
+        "get_namespace": "Unable to access specified Object Storage Bucket. See tips for troubleshooting: ",
+        "list_log_groups":"Unable to access logs. See tips for troubleshooting: " ,
+        "list_buckets": "Unable to list Object Storage Bucket. See tips for troubleshooting: ",
+        "put_object": "Unable to access or find Object Storage Bucket. See tips for troubleshooting: ",
+        "list_model_version_sets": "Unable to create or fetch model version set. See tips for troubleshooting:",
+        "update_model": "Unable to update model. See tips for troubleshooting: ",
+        "list_data_science_private_endpoints": "Unable to access specified Object Storage Bucket. See tips for troubleshooting:  ",
+        "create_model" : "Unable to register or create model. See tips for troubleshooting: ",
+        "create_deployment": "Unable to create deployment. See tips for troubleshooting: ",
+        "create_model_version_sets" : "Unable to create model version set. See tips for troubleshooting: ",
+        "create_job": "Unable to create job. See tips for troubleshooting: ",
+        "create_job_run": "Unable to create job run. See tips for troubleshooting: ",
+}
+
+ERROR_MESSAGES = {
+        "400": "Could not process your request due to invalid input.",
+        "403": "We're having trouble processing your request with the information provided.",
+        "404": "Authorization Failed: The resource you're looking for isn't accessible.",
+        "408": "Server is taking too long to respond, please try again.",
+}

--- a/ads/aqua/extension/aqua_ws_msg_handler.py
+++ b/ads/aqua/extension/aqua_ws_msg_handler.py
@@ -51,7 +51,7 @@ class AquaWSMsgHandler:
         """AquaWSMSGhandler errors are JSON, not human pages."""
 
         service_payload = kwargs.get("service_payload", {})
-        reply, message, reason = construct_error(status_code, **kwargs)
+        reply_details = construct_error(status_code, **kwargs)
 
         # telemetry may not be present if there is an error while initializing
         if hasattr(self, "telemetry"):
@@ -59,14 +59,14 @@ class AquaWSMsgHandler:
             self.telemetry.record_event_async(
                 category="aqua/error",
                 action=str(status_code),
-                value=reason,
+                value=reply_details.reason,
                 **aqua_api_details,
             )
         response = AquaWsError(
             status=status_code,
-            message=message,
+            message=reply_details.message,
             service_payload=service_payload,
-            reason=reason,
+            reason=reply_details.reason,
         )
         base_message = BaseRequest.from_json(self.message, ignore_unknown=True)
         return ErrorResponse(

--- a/ads/aqua/extension/base_handler.py
+++ b/ads/aqua/extension/base_handler.py
@@ -76,12 +76,9 @@ class AquaAPIhandler(APIHandler):
 
         self.set_header("Content-Type", "application/json")
         self.set_status(status_code, reason=reason)
-        print("**")
-        print(hasattr(self, "telemetry"))
 
         # telemetry may not be present if there is an error while initializing
         if hasattr(self, "telemetry"):
-            print("--")
             aqua_api_details = kwargs.get("aqua_api_details", {})
             self.telemetry.record_event_async(
                 category="aqua/error",

--- a/ads/aqua/extension/base_handler.py
+++ b/ads/aqua/extension/base_handler.py
@@ -2,20 +2,16 @@
 # Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-
 import json
-import traceback
-import uuid
 from dataclasses import asdict, is_dataclass
-from http.client import responses
 from typing import Any
 
 from notebook.base.handlers import APIHandler
 from tornado import httputil
-from tornado.web import Application, HTTPError
+from tornado.web import Application
 
-from ads.aqua import logger
 from ads.aqua.common.utils import is_pydantic_model
+from ads.aqua.extension.utils import construct_error
 from ads.config import AQUA_TELEMETRY_BUCKET, AQUA_TELEMETRY_BUCKET_NS
 from ads.telemetry.client import TelemetryClient
 
@@ -75,40 +71,17 @@ class AquaAPIhandler(APIHandler):
 
     def write_error(self, status_code, **kwargs):
         """AquaAPIhandler errors are JSON, not human pages."""
+
+        reply, message, reason = construct_error(status_code, **kwargs)
+
         self.set_header("Content-Type", "application/json")
-        reason = kwargs.get("reason")
         self.set_status(status_code, reason=reason)
-        service_payload = kwargs.get("service_payload", {})
-        default_msg = responses.get(status_code, "Unknown HTTP Error")
-        message = self.get_default_error_messages(
-            service_payload, str(status_code), kwargs.get("message", default_msg)
-        )
-
-        reply = {
-            "status": status_code,
-            "message": message,
-            "service_payload": service_payload,
-            "reason": reason,
-            "request_id": str(uuid.uuid4()),
-        }
-        exc_info = kwargs.get("exc_info")
-        if exc_info:
-            logger.error(
-                f"Error Request ID: {reply['request_id']}\n"
-                f"Error: {''.join(traceback.format_exception(*exc_info))}"
-            )
-            e = exc_info[1]
-            if isinstance(e, HTTPError):
-                reply["message"] = e.log_message or message
-                reply["reason"] = e.reason if e.reason else reply["reason"]
-
-        logger.error(
-            f"Error Request ID: {reply['request_id']}\n"
-            f"Error: {reply['message']} {reply['reason']}"
-        )
+        print("**")
+        print(hasattr(self, "telemetry"))
 
         # telemetry may not be present if there is an error while initializing
         if hasattr(self, "telemetry"):
+            print("--")
             aqua_api_details = kwargs.get("aqua_api_details", {})
             self.telemetry.record_event_async(
                 category="aqua/error",
@@ -118,35 +91,3 @@ class AquaAPIhandler(APIHandler):
             )
 
         self.finish(json.dumps(reply))
-
-    @staticmethod
-    def get_default_error_messages(
-        service_payload: dict,
-        status_code: str,
-        default_msg: str = "Unknown HTTP Error.",
-    ):
-        """Method that maps the error messages based on the operation performed or the status codes encountered."""
-
-        messages = {
-            "400": "Something went wrong with your request.",
-            "403": "We're having trouble processing your request with the information provided.",
-            "404": "Authorization Failed: The resource you're looking for isn't accessible.",
-            "408": "Server is taking too long to response, please try again.",
-            "create": "Authorization Failed: Could not create resource.",
-            "get": "Authorization Failed: The resource you're looking for isn't accessible.",
-        }
-
-        if service_payload and "operation_name" in service_payload:
-            operation_name = service_payload["operation_name"]
-            if operation_name:
-                if operation_name.startswith("create"):
-                    return messages["create"] + f" Operation Name: {operation_name}."
-                elif operation_name.startswith("list") or operation_name.startswith(
-                    "get"
-                ):
-                    return messages["get"] + f" Operation Name: {operation_name}."
-
-        if status_code in messages:
-            return messages[status_code]
-        else:
-            return default_msg

--- a/ads/aqua/extension/base_handler.py
+++ b/ads/aqua/extension/base_handler.py
@@ -72,10 +72,10 @@ class AquaAPIhandler(APIHandler):
     def write_error(self, status_code, **kwargs):
         """AquaAPIhandler errors are JSON, not human pages."""
 
-        reply, message, reason = construct_error(status_code, **kwargs)
+        reply_details = construct_error(status_code, **kwargs)
 
         self.set_header("Content-Type", "application/json")
-        self.set_status(status_code, reason=reason)
+        self.set_status(status_code, reason=reply_details.reason)
 
         # telemetry may not be present if there is an error while initializing
         if hasattr(self, "telemetry"):
@@ -83,8 +83,8 @@ class AquaAPIhandler(APIHandler):
             self.telemetry.record_event_async(
                 category="aqua/error",
                 action=str(status_code),
-                value=reason,
+                value=reply_details.reason,
                 **aqua_api_details,
             )
 
-        self.finish(json.dumps(reply))
+        self.finish(reply_details)

--- a/ads/aqua/extension/errors.py
+++ b/ads/aqua/extension/errors.py
@@ -1,7 +1,16 @@
 #!/usr/bin/env python
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+import uuid
+from typing import Any, Dict, List, Optional
 
+from pydantic import Field
+
+from ads.aqua.config.utils.serializer import Serializable
+
+from ads.aqua.constants import (
+    AQUA_TROUBLESHOOTING_LINK
+)
 
 class Errors(str):
     INVALID_INPUT_DATA_FORMAT = "Invalid format of input data."
@@ -9,3 +18,13 @@ class Errors(str):
     MISSING_REQUIRED_PARAMETER = "Missing required parameter: '{}'"
     MISSING_ONEOF_REQUIRED_PARAMETER = "Either '{}' or '{}' is required."
     INVALID_VALUE_OF_PARAMETER = "Invalid value of parameter: '{}'"
+
+class ReplyDetails(Serializable):
+    """Structured reply to be returned to the client."""
+    status: int
+    troubleshooting_tips: str = Field(f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
+                                      description="GitHub Link for troubleshooting documentation")
+    message: str = Field("Unknown HTTP Error.", description="GitHub Link for troubleshooting documentation")
+    service_payload: Optional[Dict[str, Any]] = Field(default_factory=dict)
+    reason: str = Field("Unknown error", description="Reason for Error")
+    request_id: str = Field(str(uuid.uuid4()), description="Unique ID for tracking the error.")

--- a/ads/aqua/extension/utils.py
+++ b/ads/aqua/extension/utils.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python
 # Copyright (c) 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+import re
+import traceback
+import uuid
 from dataclasses import fields
 from datetime import datetime, timedelta
+from http.client import responses
 from typing import Dict, Optional
 
 from cachetools import TTLCache, cached
 from tornado.web import HTTPError
 
-from ads.aqua import ODSC_MODEL_COMPARTMENT_OCID
+from ads.aqua import ODSC_MODEL_COMPARTMENT_OCID, logger
 from ads.aqua.common.utils import fetch_service_compartment
 from ads.aqua.extension.errors import Errors
 
@@ -32,3 +37,126 @@ def ui_compatability_check():
     fetched from the configuration. The cached result is returned when multiple calls are made in quick succession
     from the UI to avoid multiple config file loads."""
     return ODSC_MODEL_COMPARTMENT_OCID or fetch_service_compartment()
+
+
+def get_default_error_messages(
+    service_payload: dict,
+    status_code: str,
+    default_msg: str = "Unknown HTTP Error.",
+)-> str:
+    """Method that maps the error messages based on the operation performed or the status codes encountered."""
+
+    messages = {
+        "400": "Something went wrong with your request.",
+        "403": "We're having trouble processing your request with the information provided.",
+        "404": "Authorization Failed: The resource you're looking for isn't accessible.",
+        "408": "Server is taking too long to respond, please try again.",
+        "create": "Authorization Failed: Could not create resource.",
+    }
+
+    if service_payload and "operation_name" in service_payload:
+        operation_name = service_payload.get("operation_name")
+
+        if operation_name:
+            if operation_name.startswith("create"):
+                return f"{messages['create']} Operation Name: {operation_name}."
+            elif status_code in messages:
+                return f"{messages[status_code]} Operation Name: {operation_name}."
+
+    return messages.get(status_code, default_msg)
+
+
+def get_documentation_link(key: str) -> str:
+    """Generates appropriate GitHub link to AQUA Troubleshooting Documentation per the user's error."""
+    github_header = re.sub(r"_", "-", key)
+    return f"https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md#{github_header}"
+
+
+def get_troubleshooting_tips(service_payload: str,
+                             status_code: str) -> str:
+    """Maps authorization errors to potential solutions on Troubleshooting Page per Aqua Documentation on oci-data-science-ai-samples"""
+
+    operations = {
+        "list_model_deployments": "Unable to list model deployments. See tips for troubleshooting: ",
+        "list_models": "Unable to list models. See tips for troubleshooting: ",
+        "get_namespace": "Unable to access specified Object Storage Bucket. See tips for troubleshooting: ",
+        "list_log_groups":"Unable to access logs. See tips for troubleshooting: " ,
+        "list_buckets": "Unable to find versioned Object Storage Bucket. See tips for troubleshooting: ",
+        "list_model_version_sets": "Unable to create or fetch model version set. See tips for troubleshooting:",
+        "update_model": "Unable to update model. See tips for troubleshooting: ",
+        "list_data_science_private_endpoints": "Unable to access specified Object Storage Bucket. See tips for troubleshooting:  ",
+        "create_model" : "Unable to register or create model. See tips for troubleshooting: ",
+    }
+    tip = "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md"
+
+    if status_code in (404, 400):
+        failed_operation = service_payload.get('operation_name')
+
+        if failed_operation in operations:
+            link = get_documentation_link(failed_operation)
+            tip = operations[failed_operation] + link
+
+    return tip
+
+
+def construct_error(status_code, **kwargs) -> tuple[dict[str, int], str, str]:
+    """
+    Formats an error response based on the provided status code and optional details.
+
+    Args:
+        status_code (int): The HTTP status code of the error.
+        **kwargs: Additional optional parameters:
+            - reason (str, optional): A brief reason for the error.
+            - service_payload (dict, optional): Contextual error data from OCI SDK methods
+            - message (str, optional): A custom error message, from error raised from failed AQUA methods calling OCI SDK methods
+            - exc_info (tuple, optional): Exception information (e.g., from `sys.exc_info()`), used for logging.
+
+    Returns:
+        reply (dict) : The formatted error response with:
+                - "status" (int): The HTTP status code.
+                - "troubleshooting_tips" (list): Suggested troubleshooting steps.
+                - "message" (str): The formatted error message.
+                - "service_payload" (dict): Additional service context.
+                - "reason" (str or None): The reason for the error.
+                - "request_id" (str): A unique identifier for tracking the error.
+        message (str) : A custom message based on the OCI Service Error Message
+        reason (str) : The reason for error (from exception caught by AQUA methods)
+
+    Logs:
+        - Logs the error details with a unique request ID.
+        - If `exc_info` is provided and contains an `HTTPError`, updates the response message and reason accordingly.
+
+    """
+    reason = kwargs.get("reason")
+    service_payload = kwargs.get("service_payload", {})
+    default_msg = responses.get(status_code, "Unknown HTTP Error")
+    message = get_default_error_messages(
+        service_payload, str(status_code), kwargs.get("message", default_msg)
+    )
+
+    tips = get_troubleshooting_tips(service_payload, status_code)
+
+    reply = {
+        "status": status_code,
+        "troubleshooting_tips": tips,
+        "message": message,
+        "service_payload": service_payload,
+        "reason": reason,
+        "request_id": str(uuid.uuid4()),
+    }
+    exc_info = kwargs.get("exc_info")
+    if exc_info:
+        logger.error(
+            f"Error Request ID: {reply['request_id']}\n"
+            f"Error: {''.join(traceback.format_exception(*exc_info))}"
+        )
+        e = exc_info[1]
+        if isinstance(e, HTTPError):
+            reply["message"] = e.log_message or message
+            reply["reason"] = e.reason if e.reason else reply["reason"]
+
+    logger.error(
+        f"Error Request ID: {reply['request_id']}\n"
+        f"Error: {reply['message']} {reply['reason']}"
+    )
+    return reply, message, reason

--- a/ads/aqua/extension/utils.py
+++ b/ads/aqua/extension/utils.py
@@ -95,15 +95,14 @@ def construct_error(status_code: int, **kwargs) -> ReplyDetails:
             - exc_info (tuple, optional): Exception information (e.g., from `sys.exc_info()`), used for logging.
 
     Returns:
-        reply (dict) : The formatted error response with:
+        ReplyDetails: A Pydantic object containing details about the formatted error response.
+        kwargs:
                 - "status" (int): The HTTP status code.
-                - "troubleshooting_tips" (list): Suggested troubleshooting steps.
-                - "message" (str): The formatted error message.
-                - "service_payload" (dict): Additional service context.
-                - "reason" (str or None): The reason for the error.
+                - "troubleshooting_tips" (str): a GitHub link to AQUA troubleshooting docs, may be linked to a specific header.
+                - "message" (str): error message.
+                - "service_payload" (Dict[str, Any], optional) : Additional context from OCI Python SDK call.
+                - "reason" (str): The reason for the error.
                 - "request_id" (str): A unique identifier for tracking the error.
-        message (str) : A custom message based on the OCI Service Error Message
-        reason (str) : The reason for error (from exception caught by AQUA methods)
 
     Logs:
         - Logs the error details with a unique request ID.

--- a/docs/source/user_guide/aqua/apiserver.rst
+++ b/docs/source/user_guide/aqua/apiserver.rst
@@ -82,3 +82,32 @@ Once you have the ``.env`` file ready, you can start the server from the same fo
 .. code-block:: shell
 
     python -m ads.aqua.server
+
+Docker Image
+============
+
+1. Copy following code into file called ``Dockerfile`` 
+   
+   .. code-block:: docker
+
+        FROM ghcr.io/oracle/oraclelinux8-python:3.11-oracledb
+
+        RUN pip3 install "oracle-ads[aqua]"
+        CMD ["python3.11","-m","ads.aqua.server"]
+
+2. Build the image using following command. Set the <tag> with the any value - 
+   
+    .. code-block:: shell
+
+        TAG=1.0
+        docker build -t aqua:$TAG .
+
+3. Start the image - 
+   
+   .. code-block:: shell
+
+        KEY_PATH=$HOME/.oci
+        docker run --rm -it --env-file .env \
+            -v ~/.oci:/root/.oci \
+            -v $KEY_PATH:$KEY_PATH \
+            -p 8081:8080 aqua:$TAG

--- a/tests/unitary/with_extras/aqua/test_decorator.py
+++ b/tests/unitary/with_extras/aqua/test_decorator.py
@@ -23,13 +23,13 @@ from parameterized import parameterized
 from tornado.web import HTTPError
 
 from ads.aqua.common.errors import AquaError
-from ads.aqua.extension.base_handler import AquaAPIhandler
-
 from ads.aqua.constants import (
     AQUA_TROUBLESHOOTING_LINK,
-    ERROR_MESSAGES,
-    OCI_OPERATION_FAILURES
+    OCI_OPERATION_FAILURES,
+    STATUS_CODE_MESSAGES,
 )
+from ads.aqua.extension.base_handler import AquaAPIhandler
+from ads.aqua.extension.errors import ReplyDetails
 
 
 class TestDataset:
@@ -91,7 +91,7 @@ class TestAquaDecorators(TestCase):
                 {
                     "status": 400,
                     "troubleshooting_tips": f"{OCI_OPERATION_FAILURES['create_model']}{AQUA_TROUBLESHOOTING_LINK}#create-model",
-                    "message": f"{ERROR_MESSAGES['400']}\nInvalid tags\nOperation Name: create_model.",
+                    "message": f"{STATUS_CODE_MESSAGES['400']}\nInvalid tags\nOperation Name: create_model.",
                     "service_payload": {
                         "target_service": None,
                         "status": 400,
@@ -121,7 +121,7 @@ class TestAquaDecorators(TestCase):
                 {
                     "status": 400,
                     "troubleshooting_tips": f"{OCI_OPERATION_FAILURES['update_model']}{AQUA_TROUBLESHOOTING_LINK}#update-model",
-                    "message": f"{ERROR_MESSAGES['400']}\nInvalid tags\nOperation Name: update_model.",
+                    "message": f"{STATUS_CODE_MESSAGES['400']}\nInvalid tags\nOperation Name: update_model.",
                     "service_payload": {
                         "target_service": None,
                         "status": 400,
@@ -151,7 +151,7 @@ class TestAquaDecorators(TestCase):
                 {
                     "status": 400,
                     "troubleshooting_tips": f"{OCI_OPERATION_FAILURES['update_model']}{AQUA_TROUBLESHOOTING_LINK}#update-model",
-                    "message": f"{ERROR_MESSAGES['400']}\nInvalid tags\nOperation Name: update_model.",
+                    "message": f"{STATUS_CODE_MESSAGES['400']}\nInvalid tags\nOperation Name: update_model.",
                     "service_payload": {
                         "target_service": None,
                         "status": 400,
@@ -181,7 +181,7 @@ class TestAquaDecorators(TestCase):
                 {
                     "status": 404,
                     "troubleshooting_tips": f"{OCI_OPERATION_FAILURES['put_object']}{AQUA_TROUBLESHOOTING_LINK}#put-object",
-                    "message": f"{ERROR_MESSAGES['404']}\nEither the bucket named 'xxx' does not exist in the namespace 'xxx' or you are not authorized to access it\nOperation Name: put_object.",
+                    "message": f"{STATUS_CODE_MESSAGES['404']}\nEither the bucket named 'xxx' does not exist in the namespace 'xxx' or you are not authorized to access it\nOperation Name: put_object.",
                     "service_payload": {
                         "target_service": None,
                         "status": 404,
@@ -205,7 +205,7 @@ class TestAquaDecorators(TestCase):
                 {
                     "status": 400,
                     "troubleshooting_tips": f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
-                    "message": ERROR_MESSAGES["400"],
+                    "message": STATUS_CODE_MESSAGES["400"],
                     "service_payload": {},
                     "reason": "ConfigFileNotFound: Could not find config file at the given path.",
                     "request_id": TestDataset.mock_request_id,
@@ -219,7 +219,7 @@ class TestAquaDecorators(TestCase):
                 {
                     "status": 400,
                     "troubleshooting_tips": f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
-                    "message": ERROR_MESSAGES["400"],
+                    "message": STATUS_CODE_MESSAGES["400"],
                     "service_payload": {},
                     "reason": "MissingEndpointForNonRegionalServiceClientError: An endpoint must be provided for a non-regional service client",
                     "request_id": TestDataset.mock_request_id,
@@ -231,7 +231,7 @@ class TestAquaDecorators(TestCase):
                 {
                     "status": 400,
                     "troubleshooting_tips": f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
-                    "message": ERROR_MESSAGES["400"],
+                    "message": STATUS_CODE_MESSAGES["400"],
                     "service_payload": {},
                     "reason": "RequestException: An exception occurred when making the request",
                     "request_id": TestDataset.mock_request_id,
@@ -319,7 +319,7 @@ class TestAquaDecorators(TestCase):
         from ads.aqua.common.decorator import handle_exceptions
 
         mock_uuid.return_value = TestDataset.mock_request_id
-        expected_call = json.dumps(expected_reply)
+        expected_call = ReplyDetails(**expected_reply)
 
         @handle_exceptions
         def mock_function(self):

--- a/tests/unitary/with_extras/aqua/test_decorator.py
+++ b/tests/unitary/with_extras/aqua/test_decorator.py
@@ -53,6 +53,7 @@ class TestAquaDecorators(TestCase):
                 ),
                 {
                     "status": 500,
+                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
                     "message": "An internal error occurred.",
                     "service_payload": {
                         "target_service": None,
@@ -76,6 +77,7 @@ class TestAquaDecorators(TestCase):
                 ConfigFileNotFound("Could not find config file at the given path."),
                 {
                     "status": 400,
+                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
                     "message": "Something went wrong with your request.",
                     "service_payload": {},
                     "reason": "ConfigFileNotFound: Could not find config file at the given path.",
@@ -89,6 +91,7 @@ class TestAquaDecorators(TestCase):
                 ),
                 {
                     "status": 400,
+                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
                     "message": "Something went wrong with your request.",
                     "service_payload": {},
                     "reason": "MissingEndpointForNonRegionalServiceClientError: An endpoint must be provided for a non-regional service client",
@@ -100,6 +103,7 @@ class TestAquaDecorators(TestCase):
                 RequestException("An exception occurred when making the request"),
                 {
                     "status": 400,
+                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
                     "message": "Something went wrong with your request.",
                     "service_payload": {},
                     "reason": "RequestException: An exception occurred when making the request",
@@ -113,7 +117,8 @@ class TestAquaDecorators(TestCase):
                 ),
                 {
                     "status": 408,
-                    "message": "Server is taking too long to response, please try again.",
+                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
+                    "message": "Server is taking too long to respond, please try again.",
                     "service_payload": {},
                     "reason": "ConnectTimeout: The request timed out while trying to connect to the remote server.",
                     "request_id": TestDataset.mock_request_id,
@@ -124,6 +129,7 @@ class TestAquaDecorators(TestCase):
                 MultipartUploadError(),
                 {
                     "status": 500,
+                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
                     "message": "Internal Server Error",
                     "service_payload": {},
                     "reason": f"MultipartUploadError: MultipartUploadError exception has occurred. {UPLOAD_MANAGER_DEBUG_INFORMATION_LOG}",
@@ -135,6 +141,7 @@ class TestAquaDecorators(TestCase):
                 CompositeOperationError(),
                 {
                     "status": 500,
+                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
                     "message": "Internal Server Error",
                     "service_payload": {},
                     "reason": "CompositeOperationError: ",
@@ -146,6 +153,7 @@ class TestAquaDecorators(TestCase):
                 AquaError(reason="Mocking AQUA error.", status=403, service_payload={}),
                 {
                     "status": 403,
+                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
                     "message": "We're having trouble processing your request with the information provided.",
                     "service_payload": {},
                     "reason": "Mocking AQUA error.",
@@ -157,6 +165,7 @@ class TestAquaDecorators(TestCase):
                 HTTPError(400, "The request `/test` is invalid."),
                 {
                     "status": 400,
+                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
                     "message": "The request `/test` is invalid.",
                     "service_payload": {},
                     "reason": "The request `/test` is invalid.",
@@ -168,6 +177,7 @@ class TestAquaDecorators(TestCase):
                 ValueError("Mocking ADS internal error."),
                 {
                     "status": 500,
+                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
                     "message": "Internal Server Error",
                     "service_payload": {},
                     "reason": "ValueError: Mocking ADS internal error.",

--- a/tests/unitary/with_extras/aqua/test_decorator.py
+++ b/tests/unitary/with_extras/aqua/test_decorator.py
@@ -25,6 +25,12 @@ from tornado.web import HTTPError
 from ads.aqua.common.errors import AquaError
 from ads.aqua.extension.base_handler import AquaAPIhandler
 
+from ads.aqua.constants import (
+    AQUA_TROUBLESHOOTING_LINK,
+    ERROR_MESSAGES,
+    OCI_OPERATION_FAILURES
+)
+
 
 class TestDataset:
     mock_request_id = "1234"
@@ -40,6 +46,7 @@ class TestAquaDecorators(TestCase):
         self.test_instance.finish = MagicMock()
         self.test_instance.set_header = MagicMock()
         self.test_instance.set_status = MagicMock()
+        self.test_instance.set_service_payload = MagicMock()
 
     @parameterized.expand(
         [
@@ -53,7 +60,7 @@ class TestAquaDecorators(TestCase):
                 ),
                 {
                     "status": 500,
-                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
+                    "troubleshooting_tips": f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
                     "message": "An internal error occurred.",
                     "service_payload": {
                         "target_service": None,
@@ -72,13 +79,133 @@ class TestAquaDecorators(TestCase):
                     "request_id": TestDataset.mock_request_id,
                 },
             ],
+                        [
+                "oci ServiceError",
+                ServiceError(
+                    status=400,
+                    code="InvalidParameter",
+                    message="Invalid tags",
+                    operation_name= "create_model",
+                    headers={},
+                ),
+                {
+                    "status": 400,
+                    "troubleshooting_tips": f"{OCI_OPERATION_FAILURES['create_model']}{AQUA_TROUBLESHOOTING_LINK}#create-model",
+                    "message": f"{ERROR_MESSAGES['400']}\nInvalid tags\nOperation Name: create_model.",
+                    "service_payload": {
+                        "target_service": None,
+                        "status": 400,
+                        "code": "InvalidParameter",
+                        "opc-request-id": None,
+                        "message": "Invalid tags",
+                        "operation_name": "create_model",
+                        "timestamp": None,
+                        "client_version": None,
+                        "request_endpoint": None,
+                        "logging_tips": "To get more info on the failing request, refer to https://docs.oracle.com/en-us/iaas/tools/python/latest/logging.html for ways to log the request/response details.",
+                        "troubleshooting_tips": "See https://docs.oracle.com/iaas/Content/API/References/apierrors.htm#apierrors_400__400_invalidparameter for more information about resolving this error. If you are unable to resolve this None issue, please contact Oracle support and provide them this full error message.",
+                    },
+                    "reason": "Invalid tags",
+                    "request_id": TestDataset.mock_request_id,
+                },
+            ],
+                                    [
+                "oci ServiceError",
+                ServiceError(
+                    status=400,
+                    code="InvalidParameter",
+                    message="Invalid tags",
+                    operation_name= "update_model",
+                    headers={},
+                ),
+                {
+                    "status": 400,
+                    "troubleshooting_tips": f"{OCI_OPERATION_FAILURES['update_model']}{AQUA_TROUBLESHOOTING_LINK}#update-model",
+                    "message": f"{ERROR_MESSAGES['400']}\nInvalid tags\nOperation Name: update_model.",
+                    "service_payload": {
+                        "target_service": None,
+                        "status": 400,
+                        "code": "InvalidParameter",
+                        "opc-request-id": None,
+                        "message": "Invalid tags",
+                        "operation_name": "update_model",
+                        "timestamp": None,
+                        "client_version": None,
+                        "request_endpoint": None,
+                        "logging_tips": "To get more info on the failing request, refer to https://docs.oracle.com/en-us/iaas/tools/python/latest/logging.html for ways to log the request/response details.",
+                        "troubleshooting_tips": "See https://docs.oracle.com/iaas/Content/API/References/apierrors.htm#apierrors_400__400_invalidparameter for more information about resolving this error. If you are unable to resolve this None issue, please contact Oracle support and provide them this full error message.",
+                    },
+                    "reason": "Invalid tags",
+                    "request_id": TestDataset.mock_request_id,
+                },
+            ],
+            [
+                "oci ServiceError",
+                ServiceError(
+                    status=400,
+                    code="InvalidParameter",
+                    message="Invalid tags",
+                    operation_name= "update_model",
+                    headers={},
+                ),
+                {
+                    "status": 400,
+                    "troubleshooting_tips": f"{OCI_OPERATION_FAILURES['update_model']}{AQUA_TROUBLESHOOTING_LINK}#update-model",
+                    "message": f"{ERROR_MESSAGES['400']}\nInvalid tags\nOperation Name: update_model.",
+                    "service_payload": {
+                        "target_service": None,
+                        "status": 400,
+                        "code": "InvalidParameter",
+                        "opc-request-id": None,
+                        "message": "Invalid tags",
+                        "operation_name": "update_model",
+                        "timestamp": None,
+                        "client_version": None,
+                        "request_endpoint": None,
+                        "logging_tips": "To get more info on the failing request, refer to https://docs.oracle.com/en-us/iaas/tools/python/latest/logging.html for ways to log the request/response details.",
+                        "troubleshooting_tips": "See https://docs.oracle.com/iaas/Content/API/References/apierrors.htm#apierrors_400__400_invalidparameter for more information about resolving this error. If you are unable to resolve this None issue, please contact Oracle support and provide them this full error message.",
+                    },
+                    "reason": "Invalid tags",
+                    "request_id": TestDataset.mock_request_id,
+                },
+            ],
+                        [
+                "oci ServiceError",
+                ServiceError(
+                    status=404,
+                    code="BucketNotFound",
+                    message="Either the bucket named 'xxx' does not exist in the namespace 'xxx' or you are not authorized to access it",
+                    operation_name= "put_object",
+                    headers={},
+                ),
+                {
+                    "status": 404,
+                    "troubleshooting_tips": f"{OCI_OPERATION_FAILURES['put_object']}{AQUA_TROUBLESHOOTING_LINK}#put-object",
+                    "message": f"{ERROR_MESSAGES['404']}\nEither the bucket named 'xxx' does not exist in the namespace 'xxx' or you are not authorized to access it\nOperation Name: put_object.",
+                    "service_payload": {
+                        "target_service": None,
+                        "status": 404,
+                        "code": "BucketNotFound",
+                        "opc-request-id": None,
+                        "message": "Either the bucket named 'xxx' does not exist in the namespace 'xxx' or you are not authorized to access it",
+                        "operation_name": "put_object",
+                        "timestamp": None,
+                        "client_version": None,
+                        "request_endpoint": None,
+                        "logging_tips": "To get more info on the failing request, refer to https://docs.oracle.com/en-us/iaas/tools/python/latest/logging.html for ways to log the request/response details.",
+                        "troubleshooting_tips": "See https://docs.oracle.com/iaas/Content/API/References/apierrors.htm#apierrors_404__404_bucketnotfound for more information about resolving this error. If you are unable to resolve this None issue, please contact Oracle support and provide them this full error message.",
+                    },
+                    "reason": "Either the bucket named 'xxx' does not exist in the namespace 'xxx' or you are not authorized to access it" ,
+                    "request_id": TestDataset.mock_request_id,
+                },
+            ],
             [
                 "oci ClientError",
                 ConfigFileNotFound("Could not find config file at the given path."),
                 {
                     "status": 400,
-                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
-                    "message": "Something went wrong with your request.",
+                    "troubleshooting_tips": f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
+                    "message": ERROR_MESSAGES["400"],
                     "service_payload": {},
                     "reason": "ConfigFileNotFound: Could not find config file at the given path.",
                     "request_id": TestDataset.mock_request_id,
@@ -91,8 +218,8 @@ class TestAquaDecorators(TestCase):
                 ),
                 {
                     "status": 400,
-                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
-                    "message": "Something went wrong with your request.",
+                    "troubleshooting_tips": f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
+                    "message": ERROR_MESSAGES["400"],
                     "service_payload": {},
                     "reason": "MissingEndpointForNonRegionalServiceClientError: An endpoint must be provided for a non-regional service client",
                     "request_id": TestDataset.mock_request_id,
@@ -103,8 +230,8 @@ class TestAquaDecorators(TestCase):
                 RequestException("An exception occurred when making the request"),
                 {
                     "status": 400,
-                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
-                    "message": "Something went wrong with your request.",
+                    "troubleshooting_tips": f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
+                    "message": ERROR_MESSAGES["400"],
                     "service_payload": {},
                     "reason": "RequestException: An exception occurred when making the request",
                     "request_id": TestDataset.mock_request_id,
@@ -117,7 +244,7 @@ class TestAquaDecorators(TestCase):
                 ),
                 {
                     "status": 408,
-                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
+                    "troubleshooting_tips": f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
                     "message": "Server is taking too long to respond, please try again.",
                     "service_payload": {},
                     "reason": "ConnectTimeout: The request timed out while trying to connect to the remote server.",
@@ -129,7 +256,7 @@ class TestAquaDecorators(TestCase):
                 MultipartUploadError(),
                 {
                     "status": 500,
-                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
+                    "troubleshooting_tips": f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
                     "message": "Internal Server Error",
                     "service_payload": {},
                     "reason": f"MultipartUploadError: MultipartUploadError exception has occurred. {UPLOAD_MANAGER_DEBUG_INFORMATION_LOG}",
@@ -141,7 +268,7 @@ class TestAquaDecorators(TestCase):
                 CompositeOperationError(),
                 {
                     "status": 500,
-                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
+                    "troubleshooting_tips": f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
                     "message": "Internal Server Error",
                     "service_payload": {},
                     "reason": "CompositeOperationError: ",
@@ -153,7 +280,7 @@ class TestAquaDecorators(TestCase):
                 AquaError(reason="Mocking AQUA error.", status=403, service_payload={}),
                 {
                     "status": 403,
-                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
+                    "troubleshooting_tips": f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
                     "message": "We're having trouble processing your request with the information provided.",
                     "service_payload": {},
                     "reason": "Mocking AQUA error.",
@@ -165,7 +292,7 @@ class TestAquaDecorators(TestCase):
                 HTTPError(400, "The request `/test` is invalid."),
                 {
                     "status": 400,
-                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
+                    "troubleshooting_tips": f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
                     "message": "The request `/test` is invalid.",
                     "service_payload": {},
                     "reason": "The request `/test` is invalid.",
@@ -177,7 +304,7 @@ class TestAquaDecorators(TestCase):
                 ValueError("Mocking ADS internal error."),
                 {
                     "status": 500,
-                    "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
+                    "troubleshooting_tips": f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
                     "message": "Internal Server Error",
                     "service_payload": {},
                     "reason": "ValueError: Mocking ADS internal error.",

--- a/tests/unitary/with_extras/aqua/test_handlers.py
+++ b/tests/unitary/with_extras/aqua/test_handlers.py
@@ -22,6 +22,10 @@ import ads.aqua.extension
 import ads.aqua.extension.common_handler
 import ads.config
 from ads.aqua.common.errors import AquaError
+from ads.aqua.constants import (
+    AQUA_TROUBLESHOOTING_LINK,
+    ERROR_MESSAGES,
+)
 from ads.aqua.data import AquaResourceIdentifier
 from ads.aqua.evaluation import AquaEvaluationApp
 from ads.aqua.extension.base_handler import AquaAPIhandler
@@ -113,7 +117,7 @@ class TestBaseHandlers(unittest.TestCase):
                         None,
                     ),
                 ),
-                "Authorization Failed: Could not create resource. Operation Name: create_resources.",
+                f"{ERROR_MESSAGES['404']}\nThe required information to complete authentication was not provided or was incorrect.\nOperation Name: create_resources.",
             ],
             [
                 "oci ServiceError",
@@ -139,7 +143,7 @@ class TestBaseHandlers(unittest.TestCase):
                         ],
                     ),
                 ),
-                "Authorization Failed: The resource you're looking for isn't accessible. Operation Name: get_job_run.",
+                f"{ERROR_MESSAGES['404']}\nThe required information to complete authentication was not provided or was incorrect.\nOperation Name: get_job_run.",
             ],
         ]
     )
@@ -162,7 +166,7 @@ class TestBaseHandlers(unittest.TestCase):
         )
         expected_reply = {
             "status": input.get("status_code"),
-            "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
+            "troubleshooting_tips": f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
             "message": expected_msg,
             "service_payload": input.get("service_payload", {}),
             "reason": input.get("reason"),

--- a/tests/unitary/with_extras/aqua/test_handlers.py
+++ b/tests/unitary/with_extras/aqua/test_handlers.py
@@ -117,7 +117,7 @@ class TestBaseHandlers(unittest.TestCase):
             ],
             [
                 "oci ServiceError",
-                dict(
+                dict(  # noqa: C408
                     status_code=404,
                     reason="Testing ServiceError happen when get_job_run.",
                     service_payload=TestDataset.mock_service_payload_get,
@@ -143,7 +143,7 @@ class TestBaseHandlers(unittest.TestCase):
             ],
         ]
     )
-    @patch("ads.aqua.extension.base_handler.logger")
+    @patch("ads.aqua.extension.utils.logger")
     @patch("uuid.uuid4")
     def test_write_error(self, name, input, expected_msg, mock_uuid, mock_logger):
         """Tests AquaAPIhandler.write_error"""
@@ -162,13 +162,16 @@ class TestBaseHandlers(unittest.TestCase):
         )
         expected_reply = {
             "status": input.get("status_code"),
+            "troubleshooting_tips": "For general tips on troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md",
             "message": expected_msg,
             "service_payload": input.get("service_payload", {}),
             "reason": input.get("reason"),
             "request_id": "1234",
         }
+
         self.test_instance.finish.assert_called_once_with(json.dumps(expected_reply))
         aqua_api_details = input.get("aqua_api_details", {})
+
         self.test_instance.telemetry.record_event_async.assert_called_with(
             category="aqua/error",
             action=str(
@@ -177,10 +180,12 @@ class TestBaseHandlers(unittest.TestCase):
             value=input.get("reason"),
             **aqua_api_details,
         )
+
         error_message = (
             f"Error Request ID: {expected_reply['request_id']}\n"
             f"Error: {expected_reply['message']} {expected_reply['reason']}"
         )
+
         mock_logger.error.assert_called_with(error_message)
 
 

--- a/tests/unitary/with_extras/aqua/test_model_handler.py
+++ b/tests/unitary/with_extras/aqua/test_model_handler.py
@@ -16,8 +16,9 @@ from ads.aqua.common.errors import AquaRuntimeError
 from ads.aqua.common.utils import get_hf_model_info
 from ads.aqua.constants import (
     AQUA_TROUBLESHOOTING_LINK,
-    ERROR_MESSAGES,
+    STATUS_CODE_MESSAGES,
 )
+from ads.aqua.extension.errors import ReplyDetails
 from ads.aqua.extension.model_handler import (
     AquaHuggingFaceHandler,
     AquaModelHandler,
@@ -359,7 +360,15 @@ class TestAquaHuggingFaceHandler:
         self.mock_handler.get_json_body = MagicMock(side_effect=ValueError())
         self.mock_handler.post()
         self.mock_handler.finish.assert_called_with(
-            f'{{"status": 400, "troubleshooting_tips": "For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}", "message": "Invalid format of input data.", "service_payload": {{}}, "reason": "Invalid format of input data.", "request_id": "###"}}'
+            ReplyDetails(
+                status=400,
+                troubleshooting_tips= f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
+                message= "Invalid format of input data.",
+                service_payload = {},
+                reason = "Invalid format of input data.",
+                request_id = "###"
+
+            )
         )
         get_hf_model_info.cache_clear()
 
@@ -367,7 +376,15 @@ class TestAquaHuggingFaceHandler:
         self.mock_handler.get_json_body = MagicMock(return_value={})
         self.mock_handler.post()
         self.mock_handler.finish.assert_called_with(
-            f'{{"status": 400, "troubleshooting_tips": "For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}", "message": "No input data provided.", "service_payload": {{}}, "reason": "No input data provided.", "request_id": "###"}}'
+            ReplyDetails(
+                status=400,
+                troubleshooting_tips= f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
+                message=  "No input data provided.",
+                service_payload = {},
+                reason =  "No input data provided.",
+                request_id = "###"
+
+            )
         )
         get_hf_model_info.cache_clear()
 
@@ -375,7 +392,15 @@ class TestAquaHuggingFaceHandler:
         self.mock_handler.get_json_body = MagicMock(return_value={"some_field": None})
         self.mock_handler.post()
         self.mock_handler.finish.assert_called_with(
-            f'{{"status": 400, "troubleshooting_tips": "For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}", "message": "Missing required parameter: \'model_id\'", "service_payload": {{}}, "reason": "Missing required parameter: \'model_id\'", "request_id": "###"}}'
+            ReplyDetails(
+                status=400,
+                troubleshooting_tips= f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
+                message= "Missing required parameter: \'model_id\'",
+                service_payload = {},
+                reason =  "Missing required parameter: \'model_id\'",
+                request_id = "###"
+
+            )
         )
         get_hf_model_info.cache_clear()
 
@@ -391,7 +416,15 @@ class TestAquaHuggingFaceHandler:
             mock_model_info.side_effect = GatedRepoError(message="test message")
             self.mock_handler.post()
             self.mock_handler.finish.assert_called_with(
-                f'{{"status": 400, "troubleshooting_tips": "For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}", "message": "{ERROR_MESSAGES["400"]}", "service_payload": {{}}, "reason": "test error message", "request_id": "###"}}'
+                ReplyDetails(
+                    status=400,
+                    troubleshooting_tips= f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
+                    message= STATUS_CODE_MESSAGES["400"],
+                    service_payload = {},
+                    reason =  "test error message",
+                    request_id = "###"
+
+                )
             )
         get_hf_model_info.cache_clear()
 
@@ -404,7 +437,15 @@ class TestAquaHuggingFaceHandler:
             self.mock_handler.post()
 
             self.mock_handler.finish.assert_called_with(
-                f'{{"status": 400, "troubleshooting_tips": "For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}", "message": "{ERROR_MESSAGES["400"]}", "service_payload": {{}}, "reason": "The chosen model \'test_model_id\' is currently disabled and cannot be imported into AQUA. Please verify the model\'s status on the Hugging Face Model Hub or select a different model.", "request_id": "###"}}'
+                ReplyDetails(
+                    status=400,
+                    troubleshooting_tips= f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}",
+                    message= STATUS_CODE_MESSAGES["400"],
+                    service_payload = {},
+                    reason = "The chosen model \'test_model_id\' is currently disabled and cannot be imported into AQUA. Please verify the model\'s status on the Hugging Face Model Hub or select a different model.",
+                    request_id = "###"
+
+                )
             )
         get_hf_model_info.cache_clear()
 


### PR DESCRIPTION
Currently, the AQUA UI throws generic errors when auth issues arise- not informing the user of potential solutions and suggested policy additions to fix the error.

Added 'troubleshooting_tips' section (see example json below)
- links to the specific section (as specified by the operation error from the OCI Service Error) to our AQUA troubleshooting page 
**result** : user will obtain a specific action to fix their auth issue 

Distinguish between Auth error versus tag related error.
- certain operations have two methods for failure- auth related and tag related. We use the OCI Service Error to single out 'Invalid tag' errors for the create_model and update_model operations
**result**: user obtains a different fix for a tag-related error vs. an auth error

Refactored write_error in used in base_handler.py and WS handlers to utils.py (basically common code between these handlers were stuck into a single file)

Passed all test cases 
```
{
  "status": 404,
  "troubleshooting_tips": "Unable to list model deployments. See tips for troubleshooting: https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md#list-model-deployments",
  "message": "Authorization Failed: The resource you're looking for isn't accessible. Operation Name: list_model_deployments.",
  "service_payload": {
    "target_service": "data_science",
    "status": 404,
```