### PR TITLE
[DRCC][AQUA] Completely Removing OSS bucket config dependency

### DIFF
--- a/ads/aqua/__init__.py
+++ b/ads/aqua/__init__.py
@@ -14,7 +14,6 @@ from ads.aqua.client.client import (
     get_async_httpx_client,
     get_httpx_client,
 )
-from ads.aqua.common.utils import fetch_service_compartment
 from ads.config import OCI_RESOURCE_PRINCIPAL_VERSION
 
 ENV_VAR_LOG_LEVEL = "ADS_AQUA_LOG_LEVEL"
@@ -41,5 +40,5 @@ if OCI_RESOURCE_PRINCIPAL_VERSION:
     set_auth("resource_principal")
 
 ODSC_MODEL_COMPARTMENT_OCID = (
-    os.environ.get("ODSC_MODEL_COMPARTMENT_OCID") or fetch_service_compartment()
+    os.environ.get("ODSC_MODEL_COMPARTMENT_OCID") or "ODSC_MODEL_COMPARTMENT_OCID"
 )

--- a/ads/aqua/__init__.py
+++ b/ads/aqua/__init__.py
@@ -38,7 +38,3 @@ def set_log_level(log_level: str):
 
 if OCI_RESOURCE_PRINCIPAL_VERSION:
     set_auth("resource_principal")
-
-ODSC_MODEL_COMPARTMENT_OCID = (
-    os.environ.get("ODSC_MODEL_COMPARTMENT_OCID") or "ODSC_MODEL_COMPARTMENT_OCID"
-)

--- a/ads/aqua/cli.py
+++ b/ads/aqua/cli.py
@@ -1,23 +1,20 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*--
 
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 import os
 
 from ads.aqua import (
     ENV_VAR_LOG_LEVEL,
-    ODSC_MODEL_COMPARTMENT_OCID,
     logger,
     set_log_level,
 )
-from ads.aqua.common.errors import AquaCLIError, AquaConfigError
+from ads.aqua.common.errors import AquaCLIError
 from ads.aqua.evaluation import AquaEvaluationApp
 from ads.aqua.finetuning import AquaFineTuningApp
 from ads.aqua.model import AquaModelApp
 from ads.aqua.modeldeployment import AquaDeploymentApp
 from ads.common.utils import LOG_LEVELS
-from ads.config import NB_SESSION_OCID
 
 
 class AquaCommand:
@@ -81,16 +78,6 @@ class AquaCommand:
             aqua_log_level = log_level.upper()
 
         set_log_level(aqua_log_level)
-
-        if not ODSC_MODEL_COMPARTMENT_OCID:
-            if NB_SESSION_OCID:
-                raise AquaConfigError(
-                    f"Aqua is not available for the notebook session {NB_SESSION_OCID}. For more information, "
-                    f"please refer to the documentation."
-                )
-            raise AquaConfigError(
-                "ODSC_MODEL_COMPARTMENT_OCID environment variable is not set for Aqua."
-            )
 
     @staticmethod
     def _validate_value(flag, value):

--- a/ads/aqua/common/utils.py
+++ b/ads/aqua/common/utils.py
@@ -49,9 +49,7 @@ from ads.aqua.common.errors import (
 )
 from ads.aqua.constants import (
     AQUA_GA_LIST,
-    COMPARTMENT_MAPPING_KEY,
     CONSOLE_LINK_RESOURCE_TYPE_MAPPING,
-    CONTAINER_INDEX,
     DEPLOYMENT_CONFIG,
     FINE_TUNING_CONFIG,
     HF_LOGIN_DEFAULT_TIMEOUT,
@@ -558,36 +556,6 @@ def _build_job_identifier(
             f"DEBUG INFO:{str(e)}"
         )
         return AquaResourceIdentifier()
-
-
-def service_config_path():
-    return f"oci://{AQUA_SERVICE_MODELS_BUCKET}@{CONDA_BUCKET_NS}/service_models/config"
-
-
-def fetch_service_compartment() -> Union[str, None]:
-    """
-    Loads the compartment mapping json from service bucket.
-    This json file has a service-model-compartment key which contains a dictionary of namespaces
-    and the compartment OCID of the service models in that namespace.
-    """
-    config_file_name = (
-        f"oci://{AQUA_SERVICE_MODELS_BUCKET}@{CONDA_BUCKET_NS}/service_models/config"
-    )
-
-    try:
-        config = load_config(
-            file_path=config_file_name,
-            config_file_name=CONTAINER_INDEX,
-        )
-    except Exception as e:
-        logger.debug(
-            f"Config file {config_file_name}/{CONTAINER_INDEX} to fetch service compartment OCID "
-            f"could not be found. \n{str(e)}."
-        )
-        return
-    compartment_mapping = config.get(COMPARTMENT_MAPPING_KEY)
-    if compartment_mapping:
-        return compartment_mapping.get(CONDA_BUCKET_NS)
 
 
 def get_max_version(versions):

--- a/ads/aqua/config/container_config.py
+++ b/ads/aqua/config/container_config.py
@@ -203,12 +203,13 @@ class AquaContainerConfig(Serializable):
                     {
                         "PORT": container.workload_configuration_details_list[
                             0
-                        ].additional_configurations.get("PORT", ""),
+                        ].additional_configurations.get("PORT", "")
+                    },
+                    {
                         "HEALTH_CHECK_PORT": container.workload_configuration_details_list[
                             0
                         ].additional_configurations.get("HEALTH_CHECK_PORT", UNKNOWN),
                     },
-                    {},
                 ]
                 container_spec = AquaContainerConfigSpec(
                     cli_param=container.workload_configuration_details_list[0].cmd,

--- a/ads/aqua/config/container_config.py
+++ b/ads/aqua/config/container_config.py
@@ -7,7 +7,6 @@ from typing import Dict, List, Optional
 from oci.data_science.models import ContainerSummary
 from pydantic import Field
 
-from ads.aqua.common.entities import ContainerSpec
 from ads.aqua.config.utils.serializer import Serializable
 from ads.aqua.constants import (
     SERVICE_MANAGED_CONTAINER_URI_SCHEME,
@@ -185,24 +184,31 @@ class AquaContainerConfig(Serializable):
                             0
                         ].additional_configurations.get(
                             "MODEL_DEPLOY_PREDICT_ENDPOINT", UNKNOWN
-                        ),
+                        )
+                    },
+                    {
                         "MODEL_DEPLOY_HEALTH_ENDPOINT": container.workload_configuration_details_list[
                             0
                         ].additional_configurations.get(
                             "MODEL_DEPLOY_HEALTH_ENDPOINT", UNKNOWN
-                        ),
+                        )
+                    },
+                    {
                         "MODEL_DEPLOY_ENABLE_STREAMING": container.workload_configuration_details_list[
                             0
                         ].additional_configurations.get(
                             "MODEL_DEPLOY_ENABLE_STREAMING", UNKNOWN
-                        ),
+                        )
+                    },
+                    {
                         "PORT": container.workload_configuration_details_list[
                             0
                         ].additional_configurations.get("PORT", ""),
                         "HEALTH_CHECK_PORT": container.workload_configuration_details_list[
                             0
                         ].additional_configurations.get("HEALTH_CHECK_PORT", UNKNOWN),
-                    }
+                    },
+                    {},
                 ]
                 container_spec = AquaContainerConfigSpec(
                     cli_param=container.workload_configuration_details_list[0].cmd,
@@ -236,91 +242,6 @@ class AquaContainerConfig(Serializable):
                 finetune_items[container_type] = container_item
             if "EVALUATION" in usages:
                 evaluate_items[container_type] = container_item
-        return cls(
-            inference=inference_items, finetune=finetune_items, evaluate=evaluate_items
-        )
-
-    @classmethod
-    def from_container_index_json(
-        cls,
-        config: Dict,
-        enable_spec: Optional[bool] = False,
-    ) -> "AquaContainerConfig":
-        """
-        Creates an AquaContainerConfig instance from a container index JSON.
-
-        Parameters
-        ----------
-        config (Optional[Dict]): The container index JSON.
-        enable_spec (Optional[bool]): If True, fetch container specification details.
-
-        Returns
-        -------
-        AquaContainerConfig: The constructed container configuration.
-        """
-        # TODO: Return this logic back if necessary in the next iteraion.
-        # if not config:
-        #     config = get_container_config()
-        inference_items: Dict[str, AquaContainerConfigItem] = {}
-        finetune_items: Dict[str, AquaContainerConfigItem] = {}
-        evaluate_items: Dict[str, AquaContainerConfigItem] = {}
-
-        for container_type, containers in config.items():
-            if isinstance(containers, list):
-                for container in containers:
-                    platforms = container.get("platforms", [])
-                    model_formats = container.get("modelFormats", [])
-                    usages = container.get("usages", [])
-                    container_spec = (
-                        config.get(ContainerSpec.CONTAINER_SPEC, {}).get(
-                            container_type, {}
-                        )
-                        if enable_spec
-                        else None
-                    )
-                    container_item = AquaContainerConfigItem(
-                        name=container.get("name", ""),
-                        version=container.get("version", ""),
-                        display_name=container.get(
-                            "displayName", container.get("version", "")
-                        ),
-                        family=container_type,
-                        platforms=platforms,
-                        model_formats=model_formats,
-                        usages=usages,
-                        spec=(
-                            AquaContainerConfigSpec(
-                                cli_param=container_spec.get(
-                                    ContainerSpec.CLI_PARM, ""
-                                ),
-                                server_port=container_spec.get(
-                                    ContainerSpec.SERVER_PORT, ""
-                                ),
-                                health_check_port=container_spec.get(
-                                    ContainerSpec.HEALTH_CHECK_PORT, ""
-                                ),
-                                env_vars=container_spec.get(ContainerSpec.ENV_VARS, []),
-                                restricted_params=container_spec.get(
-                                    ContainerSpec.RESTRICTED_PARAMS, []
-                                ),
-                            )
-                            if container_spec
-                            else None
-                        ),
-                    )
-                    if container.get("type").lower() == "inference":
-                        inference_items[container_type] = container_item
-                    elif (
-                        container.get("type").lower() == "fine-tune"
-                        or container_type == "odsc-llm-fine-tuning"
-                    ):
-                        finetune_items[container_type] = container_item
-                    elif (
-                        container.get("type").lower() in ("evaluation", "evaluate")
-                        or container_type == "odsc-llm-evaluate"
-                    ):
-                        evaluate_items[container_type] = container_item
-
         return cls(
             inference=inference_items, finetune=finetune_items, evaluate=evaluate_items
         )

--- a/ads/aqua/extension/common_ws_msg_handler.py
+++ b/ads/aqua/extension/common_ws_msg_handler.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import json
@@ -8,15 +8,12 @@ from importlib import metadata
 from typing import List, Union
 
 from ads.aqua.common.decorator import handle_exceptions
-from ads.aqua.common.errors import AquaResourceAccessError
-from ads.aqua.common.utils import known_realm
 from ads.aqua.extension.aqua_ws_msg_handler import AquaWSMsgHandler
 from ads.aqua.extension.models.ws_models import (
     AdsVersionResponse,
     CompatibilityCheckResponse,
     RequestResponseType,
 )
-from ads.aqua.extension.utils import ui_compatability_check
 
 
 class AquaCommonWsMsgHandler(AquaWSMsgHandler):
@@ -39,19 +36,8 @@ class AquaCommonWsMsgHandler(AquaWSMsgHandler):
             )
             return response
         if request.get("kind") == "CompatibilityCheck":
-            if ui_compatability_check():
-                return CompatibilityCheckResponse(
-                    message_id=request.get("message_id"),
-                    kind=RequestResponseType.CompatibilityCheck,
-                    data={"status": "ok"},
-                )
-            elif known_realm():
-                return CompatibilityCheckResponse(
-                    message_id=request.get("message_id"),
-                    kind=RequestResponseType.CompatibilityCheck,
-                    data={"status": "compatible"},
-                )
-            else:
-                raise AquaResourceAccessError(
-                    "The AI Quick actions extension is not compatible in the given region."
-                )
+            return CompatibilityCheckResponse(
+                message_id=request.get("message_id"),
+                kind=RequestResponseType.CompatibilityCheck,
+                data={"status": "ok"},
+            )

--- a/ads/aqua/extension/common_ws_msg_handler.py
+++ b/ads/aqua/extension/common_ws_msg_handler.py
@@ -5,13 +5,12 @@
 
 import json
 from importlib import metadata
-from typing import List, Union
+from typing import List, Optional, Union
 
 from ads.aqua.common.decorator import handle_exceptions
 from ads.aqua.extension.aqua_ws_msg_handler import AquaWSMsgHandler
 from ads.aqua.extension.models.ws_models import (
     AdsVersionResponse,
-    CompatibilityCheckResponse,
     RequestResponseType,
 )
 
@@ -25,7 +24,7 @@ class AquaCommonWsMsgHandler(AquaWSMsgHandler):
         super().__init__(message)
 
     @handle_exceptions
-    def process(self) -> Union[AdsVersionResponse, CompatibilityCheckResponse]:
+    def process(self) -> Optional[AdsVersionResponse]:
         request = json.loads(self.message)
         if request.get("kind") == "AdsVersion":
             version = metadata.version("oracle_ads")
@@ -35,9 +34,3 @@ class AquaCommonWsMsgHandler(AquaWSMsgHandler):
                 data=version,
             )
             return response
-        if request.get("kind") == "CompatibilityCheck":
-            return CompatibilityCheckResponse(
-                message_id=request.get("message_id"),
-                kind=RequestResponseType.CompatibilityCheck,
-                data={"status": "ok"},
-            )

--- a/ads/aqua/extension/model_handler.py
+++ b/ads/aqua/extension/model_handler.py
@@ -15,7 +15,7 @@ from ads.aqua.extension.base_handler import AquaAPIhandler
 from ads.aqua.extension.errors import Errors
 from ads.aqua.model import AquaModelApp
 from ads.aqua.model.entities import AquaModelSummary, HFModelSummary
-from ads.config import USER
+from ads.config import SERVICE
 from ads.model.common.utils import MetadataArtifactPathType
 
 
@@ -82,7 +82,7 @@ class AquaModelHandler(AquaAPIhandler):
         # project_id is no needed.
         project_id = self.get_argument("project_id", default=None)
         model_type = self.get_argument("model_type", default=None)
-        category = self.get_argument("category", default=USER)
+        category = self.get_argument("category", default=SERVICE)
         return self.finish(
             AquaModelApp().list(
                 compartment_id=compartment_id,

--- a/ads/aqua/extension/utils.py
+++ b/ads/aqua/extension/utils.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2024 Oracle and/or its affiliates.
+# Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import re
@@ -14,7 +14,6 @@ from cachetools import TTLCache, cached
 from tornado.web import HTTPError
 
 from ads.aqua import ODSC_MODEL_COMPARTMENT_OCID, logger
-from ads.aqua.common.utils import fetch_service_compartment
 from ads.aqua.constants import (
     AQUA_TROUBLESHOOTING_LINK,
     OCI_OPERATION_FAILURES,
@@ -41,14 +40,14 @@ def ui_compatability_check():
     """This method caches the service compartment OCID details that is set by either the environment variable or if
     fetched from the configuration. The cached result is returned when multiple calls are made in quick succession
     from the UI to avoid multiple config file loads."""
-    return ODSC_MODEL_COMPARTMENT_OCID or fetch_service_compartment()
+    return ODSC_MODEL_COMPARTMENT_OCID
 
 
 def get_default_error_messages(
     service_payload: dict,
     status_code: str,
     default_msg: str = "Unknown HTTP Error.",
-)-> str:
+) -> str:
     """Method that maps the error messages based on the operation performed or the status codes encountered."""
 
     if service_payload and "operation_name" in service_payload:
@@ -66,14 +65,13 @@ def get_documentation_link(key: str) -> str:
     return f"{AQUA_TROUBLESHOOTING_LINK}#{github_header}"
 
 
-def get_troubleshooting_tips(service_payload: dict,
-                             status_code: str) -> str:
+def get_troubleshooting_tips(service_payload: dict, status_code: str) -> str:
     """Maps authorization errors to potential solutions on Troubleshooting Page per Aqua Documentation on oci-data-science-ai-samples"""
 
     tip = f"For general tips on troubleshooting: {AQUA_TROUBLESHOOTING_LINK}"
 
     if status_code in (404, 400):
-        failed_operation = service_payload.get('operation_name')
+        failed_operation = service_payload.get("operation_name")
 
         if failed_operation in OCI_OPERATION_FAILURES:
             link = get_documentation_link(failed_operation)
@@ -118,14 +116,13 @@ def construct_error(status_code: int, **kwargs) -> ReplyDetails:
 
     tips = get_troubleshooting_tips(service_payload, status_code)
 
-
     reply = ReplyDetails(
-        status = status_code,
-        troubleshooting_tips = tips,
-        message = message,
-        service_payload = service_payload,
-        reason = reason,
-        request_id = str(uuid.uuid4()),
+        status=status_code,
+        troubleshooting_tips=tips,
+        message=message,
+        service_payload=service_payload,
+        reason=reason,
+        request_id=str(uuid.uuid4()),
     )
 
     exc_info = kwargs.get("exc_info")

--- a/ads/aqua/extension/utils.py
+++ b/ads/aqua/extension/utils.py
@@ -6,14 +6,12 @@ import re
 import traceback
 import uuid
 from dataclasses import fields
-from datetime import datetime, timedelta
 from http.client import responses
 from typing import Dict, Optional
 
-from cachetools import TTLCache, cached
 from tornado.web import HTTPError
 
-from ads.aqua import ODSC_MODEL_COMPARTMENT_OCID, logger
+from ads.aqua import logger
 from ads.aqua.constants import (
     AQUA_TROUBLESHOOTING_LINK,
     OCI_OPERATION_FAILURES,
@@ -33,14 +31,6 @@ def validate_function_parameters(data_class, input_data: Dict):
             raise HTTPError(
                 400, Errors.MISSING_REQUIRED_PARAMETER.format(required_parameter)
             )
-
-
-@cached(cache=TTLCache(maxsize=1, ttl=timedelta(minutes=1), timer=datetime.now))
-def ui_compatability_check():
-    """This method caches the service compartment OCID details that is set by either the environment variable or if
-    fetched from the configuration. The cached result is returned when multiple calls are made in quick succession
-    from the UI to avoid multiple config file loads."""
-    return ODSC_MODEL_COMPARTMENT_OCID
 
 
 def get_default_error_messages(

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -933,7 +933,7 @@ class AquaModelApp(AquaApp):
         """
 
         models = []
-        category = kwargs.get("category", USER)
+        category = kwargs.pop("category", USER)
         if compartment_id and category != SERVICE:
             # tracks number of times custom model listing was called
             self.telemetry.record_event_async(
@@ -961,8 +961,9 @@ class AquaModelApp(AquaApp):
 
             models = self.list_resource(
                 self.ds_client.list_models,
-                compartment_id=ODSC_MODEL_COMPARTMENT_OCID,
+                compartment_id=compartment_id or COMPARTMENT_OCID,
                 lifecycle_state=lifecycle_state,
+                category=category,
                 **kwargs,
             )
 

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -972,7 +972,6 @@ class AquaModelApp(AquaApp):
             if AQUA_SERVICE_MODELS in self._service_models_cache:
                 logger.info("Returning service models list from cache.")
                 return self._service_models_cache.get(AQUA_SERVICE_MODELS)
-            logger.info("Fetching service models from cache.")
             lifecycle_state = kwargs.pop(
                 "lifecycle_state", Model.LIFECYCLE_STATE_ACTIVE
             )

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -521,9 +521,9 @@ class AquaDeploymentApp(AquaApp):
         if params:
             env_var.update({"PARAMS": params})
         env_vars = container_spec.env_vars if container_spec else []
+        env_vars = [{k: v} for env in env_vars for k, v in env.items() if v]
         for env in env_vars:
             if isinstance(env, dict):
-                env = {k: v for k, v in env.items() if v}
                 for key, _ in env.items():
                     if key not in env_var:
                         env_var.update(env)

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -468,7 +468,6 @@ class AquaDeploymentApp(AquaApp):
             env_var.update({"BASE_MODEL_FILE": f"{model_file}"})
             tags.update({Tags.MODEL_ARTIFACT_FILE: model_file})
 
-        # todo: use AquaContainerConfig.from_container_index_json instead.
         # Fetch the startup cli command for the container
         # container_index.json will have "containerSpec" section which will provide the cli params for
         # a given container family
@@ -521,9 +520,9 @@ class AquaDeploymentApp(AquaApp):
         if params:
             env_var.update({"PARAMS": params})
         env_vars = container_spec.env_vars if container_spec else []
-        env_vars = [{k: v} for env in env_vars for k, v in env.items() if v]
         for env in env_vars:
             if isinstance(env, dict):
+                env = {k: v for k, v in env.items() if v}
                 for key, _ in env.items():
                     if key not in env_var:
                         env_var.update(env)

--- a/ads/config.py
+++ b/ads/config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2020, 2024 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import contextlib
@@ -56,6 +56,7 @@ AQUA_MODEL_FINETUNING_CONFIG = os.environ.get(
 AQUA_CONTAINER_INDEX_CONFIG = os.environ.get(
     "AQUA_CONTAINER_INDEX_CONFIG", "container_index.json"
 )
+AQUA_SERVICE_MODELS = "aqua-service-models-compartment"
 AQUA_DEPLOYMENT_CONTAINER_METADATA_NAME = "deployment-container"
 AQUA_FINETUNING_CONTAINER_METADATA_NAME = "finetune-container"
 AQUA_EVALUATION_CONTAINER_METADATA_NAME = "evaluation-container"
@@ -82,7 +83,6 @@ AQUA_SERVICE_NAME = "aqua"
 DATA_SCIENCE_SERVICE_NAME = "data-science"
 USER = "USER"
 SERVICE = "SERVICE"
-
 
 
 THREADED_DEFAULT_TIMEOUT = 5

--- a/tests/unitary/with_extras/aqua/test_cli.py
+++ b/tests/unitary/with_extras/aqua/test_cli.py
@@ -82,38 +82,6 @@ class TestAquaCLI(TestCase):
         with self.assertRaises(AquaCLIError):
             AquaCommand(**arg)
 
-    @parameterized.expand(
-        [
-            (
-                "default",
-                {"ODSC_MODEL_COMPARTMENT_OCID": ""},
-                "ODSC_MODEL_COMPARTMENT_OCID environment variable is not set for Aqua.",
-            ),
-            (
-                "using jupyter instance",
-                {
-                    "ODSC_MODEL_COMPARTMENT_OCID": "",
-                    "NB_SESSION_OCID": "nb-session-ocid",
-                },
-                "Aqua is not available for the notebook session nb-session-ocid. For more information, please refer to the documentation.",
-            ),
-        ]
-    )
-    def test_aqua_command_without_compartment_env_var(
-        self, name, mock_env_dict, expected_msg
-    ):
-        """Test whether exit is called when ODSC_MODEL_COMPARTMENT_OCID is not set.
-        Also check if NB_SESSION_OCID is set then log the appropriate message."""
-
-        with patch.dict(os.environ, mock_env_dict):
-            reload(ads.config)
-            reload(ads.aqua)
-            reload(ads.aqua.cli)
-            with self.assertRaises(AquaConfigError) as cm:
-                AquaCommand()
-
-            self.assertEqual(str(cm.exception), expected_msg)
-
     @patch("sys.argv", ["ads", "aqua", "--some-option"])
     @patch("ads.cli.serialize")
     @patch("fire.Fire")

--- a/tests/unitary/with_extras/aqua/test_common_handler.py
+++ b/tests/unitary/with_extras/aqua/test_common_handler.py
@@ -13,9 +13,8 @@ from notebook.base.handlers import IPythonHandler
 
 import ads.aqua
 import ads.config
-from ads.aqua.constants import AQUA_GA_LIST
+
 from ads.aqua.extension.common_handler import CompatibilityCheckHandler
-from ads.aqua.extension.utils import ui_compatability_check
 
 
 class TestDataset:
@@ -29,24 +28,17 @@ class TestEvaluationHandler(unittest.TestCase):
         self.common_handler = CompatibilityCheckHandler(MagicMock(), MagicMock())
         self.common_handler.request = MagicMock()
 
-    def tearDown(self) -> None:
-        ui_compatability_check.cache_clear()
-
     def test_get_ok(self):
         """Test to check if ok is returned when ODSC_MODEL_COMPARTMENT_OCID is set."""
-        with patch.dict(
-            os.environ,
-            {"ODSC_MODEL_COMPARTMENT_OCID": TestDataset.SERVICE_COMPARTMENT_ID},
-        ):
-            reload(ads.config)
-            reload(ads.aqua)
-            reload(ads.aqua.extension.utils)
-            reload(ads.aqua.extension.common_handler)
+        reload(ads.config)
+        reload(ads.aqua)
+        reload(ads.aqua.extension.utils)
+        reload(ads.aqua.extension.common_handler)
 
-            with patch(
-                "ads.aqua.extension.base_handler.AquaAPIhandler.finish"
-            ) as mock_finish:
-                mock_finish.side_effect = lambda x: x
-                self.common_handler.request.path = "aqua/hello"
-                result = self.common_handler.get()
-                assert result["status"] == "ok"
+        with patch(
+            "ads.aqua.extension.base_handler.AquaAPIhandler.finish"
+        ) as mock_finish:
+            mock_finish.side_effect = lambda x: x
+            self.common_handler.request.path = "aqua/hello"
+            result = self.common_handler.get()
+            assert result["status"] == "ok"

--- a/tests/unitary/with_extras/aqua/test_common_handler.py
+++ b/tests/unitary/with_extras/aqua/test_common_handler.py
@@ -46,13 +46,7 @@ class TestEvaluationHandler(unittest.TestCase):
             with patch(
                 "ads.aqua.extension.base_handler.AquaAPIhandler.finish"
             ) as mock_finish:
-                with patch(
-                    "ads.aqua.extension.utils.fetch_service_compartment"
-                ) as mock_fetch_service_compartment:
-                    mock_fetch_service_compartment.return_value = (
-                        TestDataset.SERVICE_COMPARTMENT_ID
-                    )
-                    mock_finish.side_effect = lambda x: x
-                    self.common_handler.request.path = "aqua/hello"
-                    result = self.common_handler.get()
-                    assert result["status"] == "ok"
+                mock_finish.side_effect = lambda x: x
+                self.common_handler.request.path = "aqua/hello"
+                result = self.common_handler.get()
+                assert result["status"] == "ok"

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -1458,7 +1458,6 @@ class TestAquaModel:
         )
 
         received_args = self.app.list_resource.call_args.kwargs
-        print("received_args: ", received_args)
         assert received_args.get("compartment_id") == TestDataset.SERVICE_COMPARTMENT_ID
         assert received_args.get("category") == ads.config.SERVICE
         assert len(results) == 2

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -1452,11 +1452,15 @@ class TestAquaModel:
             ]
         )
 
-        results = self.app.list()
+        results = self.app.list(
+            compartment_id=TestDataset.SERVICE_COMPARTMENT_ID,
+            category=ads.config.SERVICE,
+        )
 
         received_args = self.app.list_resource.call_args.kwargs
+        print("received_args: ", received_args)
         assert received_args.get("compartment_id") == TestDataset.SERVICE_COMPARTMENT_ID
-
+        assert received_args.get("category") == ads.config.SERVICE
         assert len(results) == 2
 
         attributes = AquaModelSummary.__annotations__.keys()

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -1483,7 +1483,7 @@ class TestAquaModel:
             ]
         )
 
-        results = self.app.list(TestDataset.COMPARTMENT_ID)
+        results = self.app.list(TestDataset.COMPARTMENT_ID, category=ads.config.USER)
 
         self.app._rqs.assert_called_with(TestDataset.COMPARTMENT_ID, model_type="FT")
 

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -25,7 +25,7 @@ import ads.common.oci_client
 import ads.config
 
 from ads.aqua.common.entities import AquaMultiModelRef
-from ads.aqua.common.enums import ModelFormat
+from ads.aqua.common.enums import ModelFormat, Tags
 from ads.aqua.common.errors import (
     AquaFileNotFoundError,
     AquaRuntimeError,
@@ -307,6 +307,7 @@ class TestAquaModel:
             "organization": "test_organization",
             "task": "test_task",
             "ready_to_fine_tune": "true",
+            "aqua_custom_base_model": "true",
         }
         custom_metadata_list = ModelCustomMetadata()
         custom_metadata_list.add(
@@ -332,7 +333,7 @@ class TestAquaModel:
         mock_model.compartment_id = TestDataset.SERVICE_COMPARTMENT_ID
         mock_from_id.return_value = mock_model
         mock_create.return_value = mock_model
-
+        mock_model.freeform_tags.pop(Tags.BASE_MODEL_CUSTOM)
         # will copy service model
         model = self.app.create(
             model_id="test_model_id",

--- a/tests/unitary/with_extras/aqua/test_model_handler.py
+++ b/tests/unitary/with_extras/aqua/test_model_handler.py
@@ -27,7 +27,7 @@ from ads.aqua.extension.model_handler import (
 )
 from ads.aqua.model import AquaModelApp
 from ads.aqua.model.entities import AquaModel, AquaModelSummary, HFModelSummary
-from ads.config import USER
+from ads.config import USER, SERVICE
 
 
 class ModelHandlerTestCase(TestCase):
@@ -134,7 +134,7 @@ class ModelHandlerTestCase(TestCase):
             mock_finish.side_effect = lambda x: x
             self.model_handler.list()
             mock_list.assert_called_with(
-                compartment_id=None, project_id=None, model_type=None, category=USER
+                compartment_id=None, project_id=None, model_type=None, category=SERVICE
             )
 
     @parameterized.expand(

--- a/tests/unitary/with_extras/aqua/test_ui.py
+++ b/tests/unitary/with_extras/aqua/test_ui.py
@@ -541,7 +541,6 @@ class TestAquaUI(unittest.TestCase):
         mock_list_service_containers.return_value = TestDataset.CONTAINERS_LIST
 
         test_result = self.app.list_containers()
-        print("test_result: ", test_result)
         expected_result = {
             "evaluate": [
                 {
@@ -566,13 +565,11 @@ class TestAquaUI(unittest.TestCase):
                     "spec": {
                         "cli_param": "--served-model-name odsc-llm --disable-custom-all-reduce --seed 42 ",
                         "env_vars": [
-                            {
-                                "HEALTH_CHECK_PORT": "8080",
-                                "MODEL_DEPLOY_ENABLE_STREAMING": "true",
-                                "MODEL_DEPLOY_HEALTH_ENDPOINT": "",
-                                "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions",
-                                "PORT": "8080",
-                            }
+                            {"MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions"},
+                            {"MODEL_DEPLOY_HEALTH_ENDPOINT": ""},
+                            {"MODEL_DEPLOY_ENABLE_STREAMING": "true"},
+                            {"PORT": "8080"},
+                            {"HEALTH_CHECK_PORT": "8080"},
                         ],
                         "health_check_port": "8080",
                         "restricted_params": [


### PR DESCRIPTION
# Description
This PR is intended to completely remove the dependency of AQUA on config stored in Object storage bucket.  Also , this change would ensure Aqua will be available for all realms even when no `ODSC_MODEL_COMPARTMENT_OCID` env variable is set. 

# Unit Tests

<img width="1512" alt="Screenshot 2025-04-05 at 12 28 04 AM" src="https://github.com/user-attachments/assets/8294d441-7e90-4c42-8819-2a1c32f15f2e" />
