### PR TITLE
Enhance the container family validation for multi-model deployment

### DIFF
--- a/ads/aqua/common/enums.py
+++ b/ads/aqua/common/enums.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2024, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
+from typing import Dict, List
+
 from ads.common.extended_enum import ExtendedEnum
 
 
@@ -106,3 +108,15 @@ class ModelFormat(ExtendedEnum):
 class Platform(ExtendedEnum):
     ARM_CPU = "ARM_CPU"
     NVIDIA_GPU = "NVIDIA_GPU"
+
+
+# This dictionary defines compatibility groups for container families.
+# The structure is:
+#   - Key: The preferred container family to use when multiple compatible families are selected.
+#   - Value: A list of all compatible families (including the preferred one).
+CONTAINER_FAMILY_COMPATIBILITY: Dict[str, List[str]] = {
+    InferenceContainerTypeFamily.AQUA_VLLM_V1_CONTAINER_FAMILY: [
+        InferenceContainerTypeFamily.AQUA_VLLM_V1_CONTAINER_FAMILY,
+        InferenceContainerTypeFamily.AQUA_VLLM_CONTAINER_FAMILY,
+    ],
+}

--- a/tests/unitary/with_extras/aqua/test_common_utils.py
+++ b/tests/unitary/with_extras/aqua/test_common_utils.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*--
+
+# Copyright (c) 2025 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+import pytest
+from ads.aqua.common.utils import get_preferred_compatible_family
+
+
+class TestCommonUtils:
+    @pytest.mark.parametrize(
+        "input_families, expected",
+        [
+            (
+                {"odsc-vllm-serving", "odsc-vllm-serving-v1"},
+                "odsc-vllm-serving-v1",
+            ),
+            ({"odsc-tgi-serving", "odsc-vllm-serving"}, None),
+            ({"non-existing-one", "odsc-tgi-serving"}, None),
+        ],
+    )
+    def test_get_preferred_compatible_family(self, input_families, expected):
+        assert get_preferred_compatible_family(input_families) == expected


### PR DESCRIPTION
## Description

This PR introduces support for relaxing container family validation in multi-model deployment by incorporating container family compatibility rules.

### Enhancements:
- Introduced `CONTAINER_FAMILY_COMPATIBILITY` map, which defines compatible container families and preferred family when multiple compatible types are detected.
  - Example: `"odsc-vllm-serving"` and `"odsc-vllm-serving-v1"` are now treated as compatible; `"odsc-vllm-serving-v1"` is preferred.
- Updated model validation logic to:
  - Detect when all models belong to compatible families.
  - Automatically select the preferred container family for deployment.
  - Raise errors when incompatible or missing families are found.

### Added:
- Utility function: `get_preferred_compatible_family(...)`
  - Returns the best-suited family from a list based on the compatibility map.
- Unit tests for `get_preferred_compatible_family`.

