### PR TITLE
Adding defined metadata to fine-tuned model

### DIFF
--- a/ads/aqua/finetuning/finetuning.py
+++ b/ads/aqua/finetuning/finetuning.py
@@ -321,8 +321,8 @@ class AquaFineTuningApp(AquaApp):
         for defined_metadata in defined_metadata_list_source:
             if (
                 defined_metadata.has_artifact
-                and defined_metadata.key
-                != AquaModelMetadataKeys.FINE_TUNING_CONFIGURATION
+                and defined_metadata.key.lower()
+                != AquaModelMetadataKeys.FINE_TUNING_CONFIGURATION.lower()
             ):
                 content = self.ds_client.get_model_defined_metadatum_artifact_content(
                     source.id, defined_metadata.key

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -80,7 +80,6 @@ from ads.aqua.model.entities import (
     ImportModelDetails,
     ModelValidationResult,
 )
-from ads.aqua.model.enums import MultiModelSupportedTaskType
 from ads.common.auth import default_signer
 from ads.common.oci_resource import SEARCH_TYPE, OCIResource
 from ads.common.utils import (
@@ -184,8 +183,12 @@ class AquaModelApp(AquaApp):
         target_project = project_id or PROJECT_OCID
         target_compartment = compartment_id or COMPARTMENT_OCID
 
-        # Skip model copying if it is registered model
-        if service_model.freeform_tags.get(Tags.BASE_MODEL_CUSTOM, None) is not None:
+        # Skip model copying if it is registered model or fine-tuned model
+        if (
+            service_model.freeform_tags.get(Tags.BASE_MODEL_CUSTOM, None) is not None
+            or service_model.freeform_tags.get(Tags.AQUA_FINE_TUNED_MODEL_TAG)
+            is not None
+        ):
             logger.info(
                 f"Aqua Model {model_id} already exists in the user's compartment."
                 "Skipped copying."


### PR DESCRIPTION
# Description
For fine-tuned model , we need to update defined metadata to include Deployment Configuration , Readme , and License so that the call to fetch these config doesn't go to service tenancy bucket (for cached model).

# Unit tests

<img width="1512" alt="Screenshot 2025-04-23 at 10 19 06 PM" src="https://github.com/user-attachments/assets/18059cf0-4bea-4914-8035-d323be2585d9" />
