### PR TITLE
Adopt model file descriptions while creating multi model

### DIFF
--- a/ads/aqua/constants.py
+++ b/ads/aqua/constants.py
@@ -43,6 +43,8 @@ HF_METADATA_FOLDER = ".cache/"
 HF_LOGIN_DEFAULT_TIMEOUT = 2
 MODEL_NAME_DELIMITER = ";"
 AQUA_TROUBLESHOOTING_LINK = "https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md"
+MODEL_FILE_DESCRIPTION_VERSION = "1.0"
+MODEL_FILE_DESCRIPTION_TYPE = "modelOSSReferenceDescription"
 
 TRAINING_METRICS_FINAL = "training_metrics_final"
 VALIDATION_METRICS_FINAL = "validation_metrics_final"


### PR DESCRIPTION
### Adopt model file descriptions while creating multi model

- Adopt model file description while creating multi model, instead of calling `add_artifact` as this may cause authentication error to object storage.

### Unit test
```
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_create_model PASSED   [  2%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_create_multimodel PASSED [  5%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_get_foundation_models[service] PASSED [  8%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_get_foundation_models[verified] PASSED [ 11%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_get_model_fine_tuned PASSED [ 14%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_verified_model[True-True-True] PASSED [ 17%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_verified_model[True-False-True] PASSED [ 20%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_verified_model[False-True-False] PASSED [ 23%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_verified_model[False-False-True] PASSED [ 26%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_any_model_no_containers_specified PASSED [ 29%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_project_compartment_override[True] PASSED [ 32%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_project_compartment_override[False] PASSED [ 35%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_missing_config[True-True] PASSED [ 38%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_missing_config[True-False] PASSED [ 41%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_missing_config[False-True] PASSED [ 44%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_missing_config[False-False] PASSED [ 47%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_missing_config[None-False] PASSED [ 50%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_missing_config[None-True] PASSED [ 52%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_any_model_smc_container PASSED [ 55%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_tei_model_byoc[True] PASSED [ 58%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_tei_model_byoc[False] PASSED [ 61%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_input_tags PASSED [ 64%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_cli[data0-ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf True --cleanup_model_cache False --inference_container odsc-vllm-serving] PASSED [ 67%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_cli[data1-ads aqua model register --model ocid1.datasciencemodel.oc1.iad.<OCID> --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf True --cleanup_model_cache False] PASSED [ 70%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_cli[data2-ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf False --cleanup_model_cache False] PASSED [ 73%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_cli[data3-ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf True --cleanup_model_cache False --model_file test_model_file] PASSED [ 76%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_cli[data4-ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf True --cleanup_model_cache False --inference_container odsc-tei-serving --inference_container_uri <region>.ocir.io/<your_tenancy>/<your_image>] PASSED [ 79%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_cli[data5-ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf True --cleanup_model_cache False --inference_container odsc-vllm-serving --freeform_tags {"ftag1": "fvalue1", "ftag2": "fvalue2"} --defined_tags {"dtag1": "dvalue1", "dtag2": "dvalue2"}] PASSED [ 82%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_cli[data6-ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf True --cleanup_model_cache True --inference_container odsc-vllm-serving --ignore_model_artifact_check True] PASSED [ 85%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_load_license PASSED   [ 88%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_list_service_models PASSED [ 91%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_list_custom_models PASSED [ 94%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_build_search_text_0 PASSED [ 97%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_build_search_text_1_This_is_a_description_ PASSED [100%]

===================================== 34 passed in 6.85s ======================================
```

### Notebook
<img width="871" alt="Screenshot 2025-04-29 at 2 12 06 PM" src="https://github.com/user-attachments/assets/0cd78d6c-f7a3-47b6-8c87-4aeaa5e6fd36" />
<img width="473" alt="Screenshot 2025-04-29 at 2 11 08 PM" src="https://github.com/user-attachments/assets/19aab905-89f8-4c22-a3e2-34788c1e8a00" />
