### PR TITLE
ODSC-70761 Update telemetry model classifications

### DIFF
--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -803,7 +803,7 @@ class AquaDeploymentApp(AquaApp):
         )
 
         # we arbitrarily choose last 8 characters of OCID to identify MD in telemetry
-        telemetry_kwargs = {"ocid": get_ocid_substring(deployment_id, key_len=8)}
+        telemetry_kwargs = {"ocid": get_ocid_substring(deployment_id, key_len=8), "custom_base_model": True}
 
         # tracks unique deployments that were created in the user compartment
         self.telemetry.record_event_async(


### PR DESCRIPTION
https://jira.oci.oraclecorp.com/browse/ODSC-70761 

**ADS changes**

In deployment.py, when logging telemetry details for the category 
"aqua/{model_type}/deployment", add the {"custom_base_model" : true} indicator in the telemetry_kwargs. 
 
This flag is available in the freeform tags of the model that is being deployed. If Tags.BASE_MODEL_CUSTOM is present, then it is a custom base model. 
 