### PR TITLE
Exclude the streaming environment variable when creating model deployments.

### DIFF
--- a/ads/aqua/config/container_config.py
+++ b/ads/aqua/config/container_config.py
@@ -194,13 +194,6 @@ class AquaContainerConfig(Serializable):
                         )
                     },
                     {
-                        "MODEL_DEPLOY_ENABLE_STREAMING": container.workload_configuration_details_list[
-                            0
-                        ].additional_configurations.get(
-                            "MODEL_DEPLOY_ENABLE_STREAMING", UNKNOWN
-                        )
-                    },
-                    {
                         "PORT": container.workload_configuration_details_list[
                             0
                         ].additional_configurations.get("PORT", "")

--- a/tests/unitary/with_extras/aqua/test_data/deployment/aqua_create_deployment.yaml
+++ b/tests/unitary/with_extras/aqua/test_data/deployment/aqua_create_deployment.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       env:
         BASE_MODEL: service_models/model-name/artifact
-        MODEL_DEPLOY_ENABLE_STREAMING: 'true'
         MODEL_DEPLOY_PREDICT_ENDPOINT: /v1/completions
         PARAMS: --served-model-name odsc-llm --seed 42 --trust-remote-code --max-model-len 4096
       healthCheckPort: 8080

--- a/tests/unitary/with_extras/aqua/test_data/deployment/aqua_create_gguf_deployment.yaml
+++ b/tests/unitary/with_extras/aqua/test_data/deployment/aqua_create_gguf_deployment.yaml
@@ -28,7 +28,6 @@ spec:
       env:
         BASE_MODEL: service_models/model-name/artifact
         BASE_MODEL_FILE: model-name.gguf
-        MODEL_DEPLOY_ENABLE_STREAMING: 'true'
         MODEL_DEPLOY_PREDICT_ENDPOINT: /v1/completions
         MODEL_DEPLOY_HEALTH_ENDPOINT: /v1/models
       healthCheckPort: 8080

--- a/tests/unitary/with_extras/aqua/test_data/ui/container_index.json
+++ b/tests/unitary/with_extras/aqua/test_data/ui/container_index.json
@@ -10,9 +10,6 @@
           "MODEL_DEPLOY_HEALTH_ENDPOINT": "/v1/models"
         },
         {
-          "MODEL_DEPLOY_ENABLE_STREAMING": "true"
-        },
-        {
           "PORT": "8080"
         },
         {
@@ -32,9 +29,6 @@
       "envVars": [
         {
           "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions"
-        },
-        {
-          "MODEL_DEPLOY_ENABLE_STREAMING": "true"
         },
         {
           "PORT": "8080"
@@ -58,9 +52,6 @@
       "envVars": [
         {
           "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions"
-        },
-        {
-          "MODEL_DEPLOY_ENABLE_STREAMING": "true"
         },
         {
           "PORT": "8080"

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -121,7 +121,6 @@ class TestDataset:
                         "health_check_port": 8080,
                         "additional_configurations": {
                             "HEALTH_CHECK_PORT": "8080",
-                            "MODEL_DEPLOY_ENABLE_STREAMING": "true",
                             "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions",
                             "PORT": "8080",
                             "modelFormats": "SAFETENSORS",
@@ -153,7 +152,6 @@ class TestDataset:
                     {
                         "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions",
                         "MODEL_DEPLOY_HEALTH_ENDPOINT": "",
-                        "MODEL_DEPLOY_ENABLE_STREAMING": "true",
                         "PORT": "8080",
                         "HEALTH_CHECK_PORT": "8080",
                     }
@@ -205,7 +203,6 @@ class TestDataset:
                             "environment_configuration_type": "OCIR_CONTAINER",
                             "environment_variables": {
                                 "BASE_MODEL": "service_models/model-name/artifact",
-                                "MODEL_DEPLOY_ENABLE_STREAMING": "true",
                                 "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions",
                                 "PARAMS": "--served-model-name odsc-llm --seed 42",
                             },
@@ -329,7 +326,6 @@ class TestDataset:
                             "environment_variables": {
                                 "BASE_MODEL": "service_models/model-name/artifact",
                                 "BASE_MODEL_FILE": "model-name.gguf",
-                                "MODEL_DEPLOY_ENABLE_STREAMING": "true",
                                 "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions",
                                 "MODEL_DEPLOY_HEALTH_ENDPOINT": "/v1/models",
                             },
@@ -454,7 +450,6 @@ class TestDataset:
         "model_id": "ocid1.datasciencemodel.oc1.<region>.<OCID>",
         "environment_variables": {
             "BASE_MODEL": "service_models/model-name/artifact",
-            "MODEL_DEPLOY_ENABLE_STREAMING": "true",
             "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions",
             "PARAMS": "--served-model-name odsc-llm --seed 42",
         },
@@ -531,7 +526,6 @@ class TestDataset:
     aqua_deployment_gguf_env_vars = {
         "BASE_MODEL": "service_models/model-name/artifact",
         "BASE_MODEL_FILE": "model-name.gguf",
-        "MODEL_DEPLOY_ENABLE_STREAMING": "true",
         "MODEL_DEPLOY_HEALTH_ENDPOINT": "/v1/models",
         "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions",
     }

--- a/tests/unitary/with_extras/aqua/test_ui.py
+++ b/tests/unitary/with_extras/aqua/test_ui.py
@@ -567,7 +567,6 @@ class TestAquaUI(unittest.TestCase):
                         "env_vars": [
                             {"MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions"},
                             {"MODEL_DEPLOY_HEALTH_ENDPOINT": ""},
-                            {"MODEL_DEPLOY_ENABLE_STREAMING": "true"},
                             {"PORT": "8080"},
                             {"HEALTH_CHECK_PORT": "8080"},
                         ],

--- a/tests/unitary/with_extras/aqua/utils.py
+++ b/tests/unitary/with_extras/aqua/utils.py
@@ -58,7 +58,6 @@ class ServiceManagedContainers:
                             "health_check_port": 8080,
                             "additional_configurations": {
                                 "HEALTH_CHECK_PORT": "8080",
-                                "MODEL_DEPLOY_ENABLE_STREAMING": "true",
                                 "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions",
                                 "PORT": "8080",
                                 "modelFormats": "SAFETENSORS",


### PR DESCRIPTION
## Description
Updated logic to exclude the streaming environment variable when creating model deployments within AQUA
