### PR TITLE
Param parsing issue fix

### DIFF
--- a/ads/aqua/common/utils.py
+++ b/ads/aqua/common/utils.py
@@ -832,7 +832,9 @@ def get_params_dict(params: Union[str, List[str]]) -> dict:
     """
     params_list = get_params_list(params) if isinstance(params, str) else params
     return {
-        split_result[0]: split_result[1] if len(split_result) > 1 else UNKNOWN
+        split_result[0]: " ".join(split_result[1:])
+        if len(split_result) > 1
+        else UNKNOWN
         for split_result in (x.split() for x in params_list)
     }
 
@@ -881,7 +883,9 @@ def build_params_string(params: dict) -> str:
         A params string.
     """
     return (
-        " ".join(f"{name} {value}" for name, value in params.items()).strip()
+        " ".join(
+            f"{name} {value}" if value else f"{name}" for name, value in params.items()
+        ).strip()
         if params
         else UNKNOWN
     )

--- a/tests/unitary/with_extras/aqua/test_utils.py
+++ b/tests/unitary/with_extras/aqua/test_utils.py
@@ -171,3 +171,15 @@ class TestAquaUtils(unittest.TestCase):
         oss_mock_client.filepath = prefix
         resp = utils.list_os_files_with_extension(prefix, ".gguf")
         self.assertIn(obj2_name, resp)
+
+    @parameterized.expand(
+        [
+            "--gpu-memory-utilization 0.98 --max-loras 2 --lora-modules speech=artifact/speech-lora vision=artifact/vision-lora --dtype auto --trust-remote-code",
+            "--gpu-memory-utilization 0.98 --dtype auto --trust-remote-code",
+            "--trust-remote-code --max-model-len 4096",
+            "",
+        ]
+    )
+    def test_parse_params(self, params):
+        params_dict = utils.get_params_dict(params)
+        self.assertEqual(params, utils.build_params_string(params_dict))


### PR DESCRIPTION
### Description

When a parameter has more than 1 values, the current parsing logic only takes in 1 value and ignores the remaining ones. These changes would fix this and accept all values.

```
params = "--gpu-memory-utilization 0.98 --max-loras 2 --lora-modules speech=1234 vision=2345 --dtype auto"
get_params_dict(params)
```
#### Current Behavior
```
{'--gpu-memory-utilization': '0.98',
 '--max-loras': '2',
 '--lora-modules': 'speech=1234',
 '--dtype': 'auto'}
```
#### After Fix
```
{'--gpu-memory-utilization': '0.98',
 '--max-loras': '2',
 '--lora-modules': 'speech=1234 vision=2345',
 '--dtype': 'auto'}
```

### Tests

```
> python -m pytest -q tests/unitary/with_extras/aqua/test_utils.py
=============================================== test session starts ================================================
platform darwin -- Python 3.11.11, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/user/workspace/git/accelerated-data-science
configfile: pytest.ini
plugins: Faker-37.3.0, langsmith-0.3.42, asyncio-0.26.0, anyio-4.6.2, cov-6.1.1, xdist-3.6.1, dash-3.0.4
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 15 items

tests/unitary/with_extras/aqua/test_utils.py ...............                                                 [100%]

================================================ 15 passed in 2.62s ================================================
```