### PR TITLE
[AQUA][MMD] Add Support for Retrieving Deployment Configuration from Base Model for Fine-Tuned Models

### DIFF
--- a/ads/aqua/app.py
+++ b/ads/aqua/app.py
@@ -289,7 +289,6 @@ class AquaApp:
         self,
         model_id: str,
         metadata_key: str,
-        oci_model: oci.data_science.models.Model = None,
     ) -> ModelConfigResult:
         """Gets the config for the given Aqua model from model catalog metadata content.
 
@@ -299,16 +298,13 @@ class AquaApp:
             The OCID of the Aqua model.
         metadata_key: str
             The metadata key name where artifact content is stored
-        oci_model: oci.data_science.models.Model
-            The OCI Model details
         Returns
         -------
         ModelConfigResult
             A Pydantic model containing the model_details (extracted from OCI) and the config dictionary.
         """
         config: Dict[str, Any] = {}
-        if not oci_model:
-            oci_model = self.ds_client.get_model(model_id).data
+        oci_model = self.ds_client.get_model(model_id).data
 
         try:
             config = self.ds_client.get_model_defined_metadatum_artifact_content(
@@ -335,7 +331,6 @@ class AquaApp:
         model_id: str,
         config_file_name: str,
         config_folder: Optional[str] = ConfigFolder.CONFIG,
-        oci_model: oci.data_science.models.Model = None,
     ) -> ModelConfigResult:
         """
         Gets the configuration for the given Aqua model along with the model details.
@@ -349,8 +344,6 @@ class AquaApp:
         config_folder : Optional[str]
             The subfolder path where config_file_name is searched.
             Defaults to ConfigFolder.CONFIG. For model artifact directories, use ConfigFolder.ARTIFACT.
-        oci_model: oci.data_science.models.Model
-            The OCI Model details
 
         Returns
         -------
@@ -358,9 +351,7 @@ class AquaApp:
             A Pydantic model containing the model_details (extracted from OCI) and the config dictionary.
         """
         config: Dict[str, Any] = {}
-
-        if not oci_model:
-            oci_model = self.ds_client.get_model(model_id).data
+        oci_model = self.ds_client.get_model(model_id).data
 
         config_folder = config_folder or ConfigFolder.CONFIG
         oci_aqua = (

--- a/ads/aqua/modeldeployment/utils.py
+++ b/ads/aqua/modeldeployment/utils.py
@@ -252,14 +252,11 @@ class MultiModelDeploymentConfigLoader:
                 base_model_id,
             )
             model_id = base_model_id
-            oci_model = self.deployment_app.ds_client.get_model(model_id).data
 
         # Attempt to retrieve config from metadata
         metadata_key = AquaModelMetadataKeys.DEPLOYMENT_CONFIGURATION
         config = self.deployment_app.get_config_from_metadata(
-            model_id=model_id,
-            metadata_key=metadata_key,
-            oci_model=oci_model,
+            model_id=model_id, metadata_key=metadata_key
         )
 
         if config and config.config:
@@ -277,9 +274,7 @@ class MultiModelDeploymentConfigLoader:
             model_id,
         )
         config = self.deployment_app.get_config(
-            model_id=model_id,
-            config_file_name=AQUA_MODEL_DEPLOYMENT_CONFIG,
-            oci_model=oci_model,
+            model_id=model_id, config_file_name=AQUA_MODEL_DEPLOYMENT_CONFIG
         )
 
         if config and config.config:
@@ -288,7 +283,7 @@ class MultiModelDeploymentConfigLoader:
                 model_id,
             )
 
-        return config or ModelConfigResult(config={}, model_details=oci_model)
+        return config or ModelConfigResult()
 
     def _extract_model_shape_gpu(
         self,


### PR DESCRIPTION
## Description

This PR enhances the `_fetch_deployment_config_from_metadata_and_oss` function to support retrieving deployment configuration for fine-tuned models by falling back to their base model metadata when necessary.

### Key Updates:

* **Fine-Tuned Model Support:**

  * If the model contains the `AQUA_FINE_TUNED_MODEL_TAG`, the function now attempts to resolve the base model ID from the `custom_metadata_list`.
  * If the base model is found, its metadata or Object Storage entry will be used to retrieve the deployment configuration.

* **Fallback Handling:**

  * If the base model ID is not found or the metadata key is missing, the function logs a clear message and continues with fallback logic.
  * Still supports retrieving configuration from Object Storage if not found in metadata.
