### PR TITLE
Adds VLLM LLaMA 4 support to the list of compatible container families for Multi-Model deployment.

### DIFF
--- a/ads/aqua/common/enums.py
+++ b/ads/aqua/common/enums.py
@@ -49,6 +49,7 @@ class InferenceContainerType(ExtendedEnum):
 class InferenceContainerTypeFamily(ExtendedEnum):
     AQUA_VLLM_CONTAINER_FAMILY = "odsc-vllm-serving"
     AQUA_VLLM_V1_CONTAINER_FAMILY = "odsc-vllm-serving-v1"
+    AQUA_VLLM_LLAMA4_CONTAINER_FAMILY = "odsc-vllm-serving-llama4"
     AQUA_TGI_CONTAINER_FAMILY = "odsc-tgi-serving"
     AQUA_LLAMA_CPP_CONTAINER_FAMILY = "odsc-llama-cpp-serving"
 
@@ -116,6 +117,11 @@ class Platform(ExtendedEnum):
 #   - Value: A list of all compatible families (including the preferred one).
 CONTAINER_FAMILY_COMPATIBILITY: Dict[str, List[str]] = {
     InferenceContainerTypeFamily.AQUA_VLLM_V1_CONTAINER_FAMILY: [
+        InferenceContainerTypeFamily.AQUA_VLLM_V1_CONTAINER_FAMILY,
+        InferenceContainerTypeFamily.AQUA_VLLM_CONTAINER_FAMILY,
+    ],
+    InferenceContainerTypeFamily.AQUA_VLLM_LLAMA4_CONTAINER_FAMILY: [
+        InferenceContainerTypeFamily.AQUA_VLLM_LLAMA4_CONTAINER_FAMILY,
         InferenceContainerTypeFamily.AQUA_VLLM_V1_CONTAINER_FAMILY,
         InferenceContainerTypeFamily.AQUA_VLLM_CONTAINER_FAMILY,
     ],

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -316,11 +316,17 @@ class AquaModelApp(AquaApp):
             #     )
 
             # check if model is a fine-tuned model and if so, add the fine tuned weights path to the fine_tune_weights_location pydantic field
-            is_fine_tuned_model = Tags.AQUA_FINE_TUNED_MODEL_TAG in source_model.freeform_tags
+            is_fine_tuned_model = (
+                Tags.AQUA_FINE_TUNED_MODEL_TAG in source_model.freeform_tags
+            )
 
             if is_fine_tuned_model:
-                model.model_id, model.model_name = extract_base_model_from_ft(source_model)
-                model_artifact_path, model.fine_tune_weights_location = extract_fine_tune_artifacts_path(source_model)
+                model.model_id, model.model_name = extract_base_model_from_ft(
+                    source_model
+                )
+                model_artifact_path, model.fine_tune_weights_location = (
+                    extract_fine_tune_artifacts_path(source_model)
+                )
 
             else:
                 # Retrieve model artifact for base models
@@ -380,7 +386,8 @@ class AquaModelApp(AquaApp):
                 raise AquaValueError(
                     "The selected models are associated with different container families: "
                     f"{list(selected_models_deployment_containers)}."
-                    "For multi-model deployment, all models in the group must share the same container family."
+                    "For multi-model deployment, all models in the group must belong to the same container "
+                    "family or to compatible container families."
                 )
         else:
             deployment_container = selected_models_deployment_containers.pop()

--- a/tests/unitary/with_extras/aqua/test_common_utils.py
+++ b/tests/unitary/with_extras/aqua/test_common_utils.py
@@ -16,8 +16,26 @@ class TestCommonUtils:
                 {"odsc-vllm-serving", "odsc-vllm-serving-v1"},
                 "odsc-vllm-serving-v1",
             ),
+            (
+                {"odsc-vllm-serving", "odsc-vllm-serving-llama4"},
+                "odsc-vllm-serving-llama4",
+            ),
+            (
+                {"odsc-vllm-serving-v1", "odsc-vllm-serving-llama4"},
+                "odsc-vllm-serving-llama4",
+            ),
+            (
+                {
+                    "odsc-vllm-serving",
+                    "odsc-vllm-serving-v1",
+                    "odsc-vllm-serving-llama4",
+                },
+                "odsc-vllm-serving-llama4",
+            ),
             ({"odsc-tgi-serving", "odsc-vllm-serving"}, None),
             ({"non-existing-one", "odsc-tgi-serving"}, None),
+            ({"odsc-tgi-serving", "odsc-vllm-serving-llama4"}, None),
+            ({"odsc-tgi-serving", "odsc-vllm-serving-v1"}, None),
         ],
     )
     def test_get_preferred_compatible_family(self, input_families, expected):


### PR DESCRIPTION
## Description
Adds VLLM LLaMA 4 support to the list of compatible container families for Multi-Model deployment.