### PR TITLE
[AQUA][MMD] Enhance Multi-Model Deployment Configuration to Support FT Models

### DIFF
--- a/ads/aqua/common/entities.py
+++ b/ads/aqua/common/entities.py
@@ -135,7 +135,8 @@ class ComputeShapeSummary(Serializable):
             )
         return model
 
-class LoraModule(Serializable):
+
+class LoraModuleSpec(Serializable):
     """
     Lightweight descriptor for LoRA Modules used in fine-tuning models.
     Attributes
@@ -145,8 +146,13 @@ class LoraModule(Serializable):
     model_path : str
         The model-by-reference path to the LoRA Module within the model artifact
     """
-    model_name : str = Field(..., description="The name of the fine-tuned model.")
-    model_path : str = Field(..., description="The model-by-reference path to the LoRA Module within the model artifact.")
+
+    model_name: str = Field(..., description="The name of the fine-tuned model.")
+    model_path: str = Field(
+        ...,
+        description="The model-by-reference path to the LoRA Module within the model artifact.",
+    )
+
 
 class AquaMultiModelRef(Serializable):
     """
@@ -169,7 +175,7 @@ class AquaMultiModelRef(Serializable):
         Optional environment variables to override during deployment.
     artifact_location : Optional[str]
         Artifact path of model in the multimodel group.
-    fine_tune_weights : Optional[List[LoraModule]]
+    fine_tune_weights : Optional[List[LoraModuleSpec]]
         For fine tuned models, the artifact path of the modified model weights
     """
 
@@ -178,15 +184,19 @@ class AquaMultiModelRef(Serializable):
     gpu_count: Optional[int] = Field(
         None, description="The gpu count allocation for the model."
     )
-    model_task: Optional[str] = Field(None, description="The task that model operates on. Supported tasks are in MultiModelSupportedTaskType")
+    model_task: Optional[str] = Field(
+        None,
+        description="The task that model operates on. Supported tasks are in MultiModelSupportedTaskType",
+    )
     env_var: Optional[dict] = Field(
         default_factory=dict, description="The environment variables of the model."
     )
     artifact_location: Optional[str] = Field(
         None, description="Artifact path of model in the multimodel group."
     )
-    fine_tune_weights: Optional[List[LoraModule]] = Field(
-        None, description="For fine tuned models, the artifact path of the modified model weights"
+    fine_tune_weights: Optional[List[LoraModuleSpec]] = Field(
+        None,
+        description="For fine tuned models, the artifact path of the modified model weights",
     )
 
     class Config:

--- a/ads/aqua/common/entities.py
+++ b/ads/aqua/common/entities.py
@@ -169,7 +169,7 @@ class AquaMultiModelRef(Serializable):
         Optional environment variables to override during deployment.
     artifact_location : Optional[str]
         Artifact path of model in the multimodel group.
-    fine_tune_weights : Optional[str]
+    fine_tune_weights : Optional[List[LoraModule]]
         For fine tuned models, the artifact path of the modified model weights
     """
 

--- a/ads/aqua/common/entities.py
+++ b/ads/aqua/common/entities.py
@@ -3,7 +3,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from oci.data_science.models import Model
 from pydantic import BaseModel, Field, model_validator
@@ -135,6 +135,18 @@ class ComputeShapeSummary(Serializable):
             )
         return model
 
+class LoraModule(Serializable):
+    """
+    Lightweight descriptor for LoRA Modules used in fine-tuning models.
+    Attributes
+    ----------
+    model_name : str
+        The name of the fine-tuned model.
+    model_path : str
+        The model-by-reference path to the LoRA Module within the model artifact
+    """
+    model_name : str = Field(..., description="The name of the fine-tuned model.")
+    model_path : str = Field(..., description="The model-by-reference path to the LoRA Module within the model artifact.")
 
 class AquaMultiModelRef(Serializable):
     """
@@ -157,7 +169,7 @@ class AquaMultiModelRef(Serializable):
         Optional environment variables to override during deployment.
     artifact_location : Optional[str]
         Artifact path of model in the multimodel group.
-    fine_tune_weights_location : Optional[str]
+    fine_tune_weights : Optional[str]
         For fine tuned models, the artifact path of the modified model weights
     """
 
@@ -173,7 +185,7 @@ class AquaMultiModelRef(Serializable):
     artifact_location: Optional[str] = Field(
         None, description="Artifact path of model in the multimodel group."
     )
-    fine_tune_weights_location: Optional[str] = Field(
+    fine_tune_weights: Optional[List[LoraModule]] = Field(
         None, description="For fine tuned models, the artifact path of the modified model weights"
     )
 

--- a/ads/aqua/common/utils.py
+++ b/ads/aqua/common/utils.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 from functools import wraps
 from pathlib import Path
 from string import Template
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, Tuple
 
 import fsspec
 import oci
@@ -643,7 +643,7 @@ def get_resource_name(ocid: str) -> str:
     return name
 
 
-def get_model_by_reference_paths(model_file_description: dict):
+def get_model_by_reference_paths(model_file_description: dict) -> Tuple[str, List[str]]:
     """Reads the model file description json dict and returns the base model path and fine-tuned path for
         models created by reference.
 
@@ -657,7 +657,7 @@ def get_model_by_reference_paths(model_file_description: dict):
         a tuple with base_model_path and fine_tune_output_path
     """
     base_model_path = UNKNOWN
-    fine_tune_output_path = UNKNOWN
+    fine_tune_output_paths = UNKNOWN
     models = model_file_description["models"]
 
     if not models:
@@ -666,21 +666,23 @@ def get_model_by_reference_paths(model_file_description: dict):
             "Please check if the model created by reference has the correct artifact."
         )
 
-    if len(models) > 0:
+    if len(models) == 1:
         # since the model_file_description json does not have a flag to identify the base model, we consider
         # the first instance to be the base model.
         base_model_artifact = models[0]
         base_model_path = f"oci://{base_model_artifact['bucketName']}@{base_model_artifact['namespace']}/{base_model_artifact['prefix']}".rstrip(
             "/"
         )
-    if len(models) > 1:
-        # second model is considered as fine-tuned model
-        ft_model_artifact = models[1]
-        fine_tune_output_path = f"oci://{ft_model_artifact['bucketName']}@{ft_model_artifact['namespace']}/{ft_model_artifact['prefix']}".rstrip(
-            "/"
-        )
+    else:
+        # subsequent models are LoRA modules of the fine-tuned models
+        fine_tune_output_paths = []
+        for ft_model_artifact in models:
+            output_path = f"oci://{ft_model_artifact['bucketName']}@{ft_model_artifact['namespace']}/{ft_model_artifact['prefix']}".rstrip(
+                "/"
+            )
+            fine_tune_output_paths.append(output_path)
 
-    return base_model_path, fine_tune_output_path
+    return base_model_path, fine_tune_output_paths
 
 
 def _is_valid_mvs(mvs: ModelVersionSet, target_tag: str) -> bool:
@@ -868,6 +870,40 @@ def get_combined_params(params1: str = None, params2: str = None) -> str:
     ]
 
     return " ".join(combined_params)
+
+def find_restricted_params(
+        default_params: Union[str, List[str]],
+        user_params: Union[str, List[str]],
+        container_family: str,
+    ) -> List[str]:
+        """Returns a list of restricted params that user chooses to override when creating an Aqua deployment.
+        The default parameters coming from the container index json file cannot be overridden.
+
+        Parameters
+        ----------
+        default_params:
+            Inference container parameter string with default values.
+        user_params:
+            Inference container parameter string with user provided values.
+        container_family: str
+            The image family of model deployment container runtime.
+
+        Returns
+        -------
+            A list with params keys common between params1 and params2.
+
+        """
+        restricted_params = []
+        if default_params and user_params:
+            default_params_dict = get_params_dict(default_params)
+            user_params_dict = get_params_dict(user_params)
+
+            restricted_params_set = get_restricted_params_by_container(container_family)
+            for key, _items in user_params_dict.items():
+                if key in default_params_dict or key in restricted_params_set:
+                    restricted_params.append(key.lstrip("-"))
+
+        return restricted_params
 
 
 def build_params_string(params: dict) -> str:

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -85,7 +85,7 @@ from ads.aqua.model.entities import (
 from ads.aqua.model.enums import MultiModelSupportedTaskType
 from ads.aqua.model.utils import (
     extract_base_model_from_ft,
-    extract_fine_tune_artifacts_path,
+    extract_multi_ft_artifacts_path,
 )
 from ads.common.auth import default_signer
 from ads.common.oci_resource import SEARCH_TYPE, OCIResource
@@ -320,7 +320,7 @@ class AquaModelApp(AquaApp):
 
             if is_fine_tuned_model:
                 model.model_id, model.model_name = extract_base_model_from_ft(source_model)
-                model_artifact_path, model.fine_tune_weights_location = extract_fine_tune_artifacts_path(source_model)
+                model_artifact_path, model.fine_tune_weights = extract_multi_ft_artifacts_path(source_model)
 
             else:
                 # Retrieve model artifact for base models

--- a/ads/aqua/model/utils.py
+++ b/ads/aqua/model/utils.py
@@ -3,9 +3,9 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 """AQUA model utils"""
 
-from typing import Dict, Optional, Tuple
+from typing import Tuple, List
 
-from ads.aqua.common.entities import AquaMultiModelRef
+from ads.aqua.common.entities import LoraModule
 from ads.aqua.common.errors import AquaValueError
 from ads.aqua.common.utils import get_model_by_reference_paths
 from ads.aqua.finetuning.constants import FineTuneCustomMetadata
@@ -35,9 +35,11 @@ def extract_base_model_from_ft(aqua_model: DataScienceModel) -> Tuple[str, str]:
 def extract_fine_tune_artifacts_path(aqua_model: DataScienceModel) -> Tuple[str, str]:
     """Extracts the fine tuning source (fine_tune_output_path) and base model path from the DataScienceModel Object"""
 
-    base_model_path, fine_tune_output_path = get_model_by_reference_paths(
+    base_model_path, fine_tune_output_paths = get_model_by_reference_paths(
         aqua_model.model_file_description
     )
+
+    fine_tune_output_path = fine_tune_output_paths[0]
 
     if not fine_tune_output_path or not ObjectStorageDetails.is_oci_path(
         fine_tune_output_path
@@ -50,3 +52,33 @@ def extract_fine_tune_artifacts_path(aqua_model: DataScienceModel) -> Tuple[str,
     fine_tune_output_path = os_path.filepath.rstrip("/")
 
     return base_model_path, fine_tune_output_path
+
+
+def extract_multi_ft_artifacts_path(
+    aqua_model: DataScienceModel,
+) -> Tuple[str, List[LoraModule]]:
+    """Extracts the fine tuning source (fine_tune_output_path) and base model path from the DataScienceModel Object"""
+
+    base_model_path, fine_tune_output_paths = get_model_by_reference_paths(
+        aqua_model.model_file_description
+    )
+
+    lora_modules = []
+
+    _, model_name = extract_base_model_from_ft(aqua_model)
+
+    # assign FT names to each LoRA module "meta-llama/Llama-3.1-8B-Instruct-FT1"
+    for i, path in enumerate(fine_tune_output_paths, start=1):
+        if not path or not ObjectStorageDetails.is_oci_path(path):
+            raise AquaValueError(
+                "Fine tuned output path is not available in the model artifact."
+            )
+
+        os_path = ObjectStorageDetails.from_path(path)
+        fine_tune_output_path = os_path.filepath.rstrip("/")
+
+        module_name = f"{model_name}-FT{i}"
+        module = LoraModule(model_name=module_name, model_path=fine_tune_output_path)
+        lora_modules.append(module)
+
+    return base_model_path, lora_modules

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -5,7 +5,7 @@
 import json
 import shlex
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 from cachetools import TTLCache, cached
 from oci.data_science.models import ModelDeploymentShapeSummary
@@ -21,13 +21,11 @@ from ads.aqua.common.enums import InferenceContainerTypeFamily, ModelFormat, Tag
 from ads.aqua.common.errors import AquaRuntimeError, AquaValueError
 from ads.aqua.common.utils import (
     DEFINED_METADATA_TO_FILE_MAP,
-    build_params_string,
     build_pydantic_error_message,
     find_restricted_params,
     get_combined_params,
     get_container_params_type,
     get_ocid_substring,
-    get_params_dict,
     get_params_list,
     get_resource_name,
     get_restricted_params_by_container,
@@ -65,7 +63,6 @@ from ads.aqua.modeldeployment.entities import (
     CreateModelDeploymentDetails,
 )
 from ads.aqua.modeldeployment.group_model_metadata import (
-    BaseModelSpec,
     GroupModelDeploymentMetadata,
 )
 from ads.common.object_storage_details import ObjectStorageDetails
@@ -573,7 +570,7 @@ class AquaDeploymentApp(AquaApp):
                 create_deployment_details,
                 model_config_summary,
                 container_type_key,
-                container_params
+                container_params,
             )
         )
 

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -23,6 +23,7 @@ from ads.aqua.common.utils import (
     DEFINED_METADATA_TO_FILE_MAP,
     build_params_string,
     build_pydantic_error_message,
+    find_restricted_params,
     get_combined_params,
     get_container_params_type,
     get_ocid_substring,
@@ -62,6 +63,10 @@ from ads.aqua.modeldeployment.entities import (
     AquaDeploymentDetail,
     ConfigValidationError,
     CreateModelDeploymentDetails,
+)
+from ads.aqua.modeldeployment.group_model_metadata import (
+    BaseModelSpec,
+    GroupModelDeploymentMetadata,
 )
 from ads.common.object_storage_details import ObjectStorageDetails
 from ads.common.utils import UNKNOWN, get_log_links
@@ -484,7 +489,7 @@ class AquaDeploymentApp(AquaApp):
                     f"with deployment without parameter overrides."
                 )
 
-            restricted_params = self._find_restricted_params(
+            restricted_params = find_restricted_params(
                 params, user_params, container_type_key
             )
             if restricted_params:
@@ -551,7 +556,6 @@ class AquaDeploymentApp(AquaApp):
         AquaDeployment
             An Aqua deployment instance.
         """
-        model_config = []
         model_name_list = []
         env_var = {**(create_deployment_details.env_var or UNKNOWN_DICT)}
 
@@ -564,80 +568,16 @@ class AquaDeploymentApp(AquaApp):
 
         container_params = container_spec.cli_param if container_spec else UNKNOWN
 
-        for model in create_deployment_details.models:
-            user_params = build_params_string(model.env_var)
-            if user_params:
-                restricted_params = self._find_restricted_params(
-                    container_params, user_params, container_type_key
-                )
-                if restricted_params:
-                    selected_model = model.model_name or model.model_id
-                    raise AquaValueError(
-                        f"Parameters {restricted_params} are set by Aqua "
-                        f"and cannot be overridden or are invalid."
-                        f"Select other parameters for model {selected_model}."
-                    )
-
-            # replaces `--served-model-name`` with user's model name
-            container_params_dict = get_params_dict(container_params)
-            container_params_dict.update({"--served-model-name": model.model_name})
-            # replaces `--tensor-parallel-size` with model gpu count
-            container_params_dict.update({"--tensor-parallel-size": model.gpu_count})
-            params = build_params_string(container_params_dict)
-
-            deployment_config = model_config_summary.deployment_config.get(
-                model.model_id, AquaDeploymentConfig()
-            ).configuration.get(
-                create_deployment_details.instance_shape, ConfigurationItem()
+        multi_model_config = (
+            GroupModelDeploymentMetadata.from_create_model_deployment_details(
+                create_deployment_details,
+                model_config_summary,
+                container_type_key,
+                container_params
             )
+        )
 
-            # finds the corresponding deployment parameters based on the gpu count
-            # and combines them with user's parameters. Existing deployment parameters
-            # will be overriden by user's parameters.
-            params_found = False
-            for item in deployment_config.multi_model_deployment:
-                if (
-                    model.gpu_count
-                    and item.gpu_count
-                    and item.gpu_count == model.gpu_count
-                ):
-                    config_parameters = item.parameters.get(
-                        get_container_params_type(container_type_key), UNKNOWN
-                    )
-                    params = f"{params} {get_combined_params(config_parameters, user_params)}".strip()
-                    params_found = True
-                    break
-
-            if not params_found and deployment_config.parameters:
-                config_parameters = deployment_config.parameters.get(
-                    get_container_params_type(container_type_key), UNKNOWN
-                )
-                params = f"{params} {get_combined_params(config_parameters, user_params)}".strip()
-                params_found = True
-
-            # if no config parameters found, append user parameters directly.
-            if not params_found:
-                params = f"{params} {user_params}".strip()
-
-            artifact_path_prefix = model.artifact_location.rstrip("/")
-            if ObjectStorageDetails.is_oci_path(artifact_path_prefix):
-                os_path = ObjectStorageDetails.from_path(artifact_path_prefix)
-                artifact_path_prefix = os_path.filepath.rstrip("/")
-
-            # override by-default completion/ chat endpoint with other endpoint (embedding)
-            config_data = {"params": params, "model_path": artifact_path_prefix}
-            if model.model_task:
-                config_data["model_task"] = model.model_task
-
-            if model.fine_tune_weights_location:
-                config_data["fine_tune_weights_location"] = (
-                    model.fine_tune_weights_location
-                )
-
-            model_config.append(config_data)
-            model_name_list.append(model.model_name)
-
-        env_var.update({AQUA_MULTI_MODEL_CONFIG: json.dumps({"models": model_config})})
+        env_var.update({AQUA_MULTI_MODEL_CONFIG: multi_model_config.model_dump_json()})
 
         env_vars = container_spec.env_vars if container_spec else []
         for env in env_vars:
@@ -1232,7 +1172,7 @@ class AquaDeploymentApp(AquaApp):
             container_spec = container_config.spec if container_config else UNKNOWN
             cli_params = container_spec.cli_param if container_spec else UNKNOWN
 
-            restricted_params = self._find_restricted_params(
+            restricted_params = find_restricted_params(
                 cli_params, params, container_type_key
             )
 
@@ -1242,41 +1182,6 @@ class AquaDeploymentApp(AquaApp):
                 f"and cannot be overridden or are invalid."
             )
         return {"valid": True}
-
-    @staticmethod
-    def _find_restricted_params(
-        default_params: Union[str, List[str]],
-        user_params: Union[str, List[str]],
-        container_family: str,
-    ) -> List[str]:
-        """Returns a list of restricted params that user chooses to override when creating an Aqua deployment.
-        The default parameters coming from the container index json file cannot be overridden.
-
-        Parameters
-        ----------
-        default_params:
-            Inference container parameter string with default values.
-        user_params:
-            Inference container parameter string with user provided values.
-        container_family: str
-            The image family of model deployment container runtime.
-
-        Returns
-        -------
-            A list with params keys common between params1 and params2.
-
-        """
-        restricted_params = []
-        if default_params and user_params:
-            default_params_dict = get_params_dict(default_params)
-            user_params_dict = get_params_dict(user_params)
-
-            restricted_params_set = get_restricted_params_by_container(container_family)
-            for key, _items in user_params_dict.items():
-                if key in default_params_dict or key in restricted_params_set:
-                    restricted_params.append(key.lstrip("-"))
-
-        return restricted_params
 
     @telemetry(entry_point="plugin=deployment&action=list_shapes", name="aqua")
     @cached(cache=TTLCache(maxsize=1, ttl=timedelta(minutes=5), timer=datetime.now))

--- a/ads/aqua/modeldeployment/group_model_metadata.py
+++ b/ads/aqua/modeldeployment/group_model_metadata.py
@@ -4,9 +4,28 @@
 
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+from typing_extensions import Self
 
+from ads.aqua import logger
+from ads.aqua.common.entities import AquaMultiModelRef
+from ads.aqua.common.errors import AquaValueError
+from ads.aqua.common.utils import (
+    build_params_string,
+    find_restricted_params,
+    get_combined_params,
+    get_container_params_type,
+    get_params_dict,
+)
 from ads.aqua.config.utils.serializer import Serializable
+from ads.aqua.modeldeployment.config_loader import (
+    AquaDeploymentConfig,
+    ConfigurationItem,
+    ModelDeploymentConfigSummary,
+)
+from ads.aqua.modeldeployment.entities import CreateModelDeploymentDetails
+from ads.common.object_storage_details import ObjectStorageDetails
+from ads.common.utils import UNKNOWN
 
 __all__ = ["GroupModelDeploymentMetadata"]
 
@@ -18,7 +37,7 @@ class FineTunedModelSpec(BaseModel):
     Attributes
     ----------
     model_path : str
-        Object Storage path to the fine-tuned model artifacts.
+        Object Storage path to the fine-tuned model artifacts. Path is already cleaned.
     model_name : str
         Unique name for the fine-tuned model (used for inference routing).
     """
@@ -35,21 +54,59 @@ class BaseModelSpec(BaseModel):
     ----------
     model_path : str
         Path to the model in OCI Object Storage.
-    model_task : str
-        Model task type (e.g., text-generation, image-to-text).
     params : str
         Additional vLLM launch parameters for this model (e.g. parallelism, max context).
-    fine_tuned_weights : List[FineTunedModel], optional
+    model_task : str, optional
+        Model task type (e.g., text-generation, image-to-text).
+    fine_tuned_weights : List[FineTunedModelSpec], optional
         List of associated fine-tuned models.
     """
 
     model_path: str = Field(..., description="Path to the base model.")
-    model_task: str = Field(..., description="Task type the model is intended for.")
     params: str = Field(..., description="Startup parameters passed to vLLM.")
+    model_task: Optional[str] = Field(..., description="Task type the model is intended for.")
     fine_tuned_weights: Optional[List[FineTunedModelSpec]] = Field(
         default_factory=list,
         description="Optional list of fine-tuned model variants associated with this base model.",
     )
+
+    @field_validator("model_path")
+    @classmethod
+    def clean_artifact_path(cls, artifact_path_prefix: str):
+        if ObjectStorageDetails.is_oci_path(artifact_path_prefix):
+            os_path = ObjectStorageDetails.from_path(artifact_path_prefix)
+            artifact_path_prefix = os_path.filepath.rstrip("/")
+            return artifact_path_prefix
+
+
+    @field_validator("fine_tuned_weights")
+    @classmethod
+    def set_fine_tuned_weights(cls, fine_tuned_weights: List[FineTunedModelSpec]):
+        seen_modules = set()
+        unique_modules: List[FineTunedModelSpec] = []
+
+        for lora_module in fine_tuned_weights:
+            if lora_module.model_name not in seen_modules:
+                seen_modules.add(lora_module.model_name)
+                unique_modules.append(lora_module)
+            else:
+                logger.warning(
+                    f"Duplicate LoRA Modules Detected. Previously loaded LoRA Module {lora_module.model_name,}",
+                )
+        return unique_modules
+
+    @classmethod
+    def from_aqua_multi_model_ref(cls, model: AquaMultiModelRef, model_params) -> Self:
+
+        if model.fine_tune_weights:
+            ft_modules = [FineTunedModelSpec(**lora_module) for lora_module in model.fine_tune_weights]
+
+        return cls(
+            model_path = model.artifact_location,
+            params = model_params,
+            model_task = model.model_task,
+            fine_tuned_weights = ft_modules
+        )
 
 
 class GroupModelDeploymentMetadata(Serializable):
@@ -65,3 +122,97 @@ class GroupModelDeploymentMetadata(Serializable):
     models: List[BaseModelSpec] = Field(
         ..., description="List of models in the multi-model deployment."
     )
+
+    @staticmethod
+    def extract_model_params(model: AquaMultiModelRef, container_params, container_type_key):
+        user_params = build_params_string(model.env_var)
+        if user_params:
+            restricted_params = find_restricted_params(
+                container_params, user_params, container_type_key
+            )
+            if restricted_params:
+                selected_model = model.model_name or model.model_id
+                raise AquaValueError(
+                    f"Parameters {restricted_params} are set by Aqua "
+                    f"and cannot be overridden or are invalid."
+                    f"Select other parameters for model {selected_model}."
+                )
+
+        # replaces `--served-model-name`` with user's model name
+        container_params_dict = get_params_dict(container_params)
+        container_params_dict.update({"--served-model-name": model.model_name})
+        # replaces `--tensor-parallel-size` with model gpu count
+        container_params_dict.update({"--tensor-parallel-size": model.gpu_count})
+        params = build_params_string(container_params_dict)
+
+        return user_params, params
+
+    # finds the corresponding deployment parameters based on the gpu count
+    # and combines them with user's parameters. Existing deployment parameters
+    # will be overriden by user's parameters.
+    @staticmethod
+    def merge_gpu_count_params(model: AquaMultiModelRef,
+                                model_config_summary: ModelDeploymentConfigSummary,
+                                create_deployment_details: CreateModelDeploymentDetails,
+                                container_type_key: str,
+                                container_params):
+
+        user_params, params = GroupModelDeploymentMetadata.extract_model_params(model, container_params, container_type_key)
+
+        deployment_config = model_config_summary.deployment_config.get(
+            model.model_id, AquaDeploymentConfig()
+        ).configuration.get(
+            create_deployment_details.instance_shape, ConfigurationItem()
+        )
+        params_found = False
+        for item in deployment_config.multi_model_deployment:
+            if (
+                model.gpu_count
+                and item.gpu_count
+                and item.gpu_count == model.gpu_count
+            ):
+                config_parameters = item.parameters.get(
+                    get_container_params_type(container_type_key), UNKNOWN
+                )
+                params = f"{params} {get_combined_params(config_parameters, user_params)}".strip()
+                params_found = True
+                break
+
+        if not params_found and deployment_config.parameters:
+            config_parameters = deployment_config.parameters.get(
+                get_container_params_type(container_type_key), UNKNOWN
+            )
+            params = f"{params} {get_combined_params(config_parameters, user_params)}".strip()
+            params_found = True
+
+        # if no config parameters found, append user parameters directly.
+        if not params_found:
+            params = f"{params} {user_params}".strip()
+
+        return params
+
+    @classmethod
+    def from_create_model_deployment_details(cls,
+                                            create_deployment_details: CreateModelDeploymentDetails,
+                                            model_config_summary: ModelDeploymentConfigSummary,
+                                            container_type_key,
+                                            container_params) -> Self:
+
+        models = []
+        seen_models = set()
+        for model in create_deployment_details.models:
+            params = GroupModelDeploymentMetadata.merge_gpu_count_params(model, model_config_summary,
+                                create_deployment_details,
+                                container_type_key,
+                                container_params)
+
+            if model.model_name not in seen_models:
+                seen_models.add(model.model_name)
+                base_model_spec = BaseModelSpec.from_aqua_multi_model_ref(model, params)
+                models.append(base_model_spec)
+            else:
+                raise AquaValueError("Stack inferencing with the same base model is not supported.")
+
+        return cls(
+            models = models
+        )

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -6,6 +6,7 @@
 
 import copy
 import json
+import logging
 import os
 import unittest
 from importlib import reload
@@ -18,6 +19,7 @@ from oci.data_science.models import (
     ModelDeployWorkloadConfigurationDetails,
 )
 from parameterized import parameterized
+from pydantic import ValidationError
 
 import ads.aqua.modeldeployment.deployment
 import ads.config
@@ -25,6 +27,7 @@ from ads.aqua.app import AquaApp
 from ads.aqua.common.entities import (
     AquaMultiModelRef,
     ComputeShapeSummary,
+    LoraModuleSpec,
     ModelConfigResult,
 )
 from ads.aqua.common.enums import Tags
@@ -47,6 +50,7 @@ from ads.aqua.modeldeployment.entities import (
     CreateModelDeploymentDetails,
     ModelParams,
 )
+from ads.aqua.modeldeployment.group_model_metadata import BaseModelSpec
 from ads.model.datascience_model import DataScienceModel
 from ads.model.deployment.model_deployment import ModelDeployment
 from ads.model.model_metadata import ModelCustomMetadata
@@ -277,7 +281,7 @@ class TestDataset:
                         "environment_configuration_type": "OCIR_CONTAINER",
                         "environment_variables": {
                             "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions",
-                            "MULTI_MODEL_CONFIG": '{ "models": [{ "params": "--served-model-name model_one --tensor-parallel-size 1 --max-model-len 2096", "model_path": "models/model_one/5be6479/artifact/", "model_task": "text_embedding"}, {"params": "--served-model-name model_two --tensor-parallel-size 1 --max-model-len 2096", "model_path": "models/model_two/83e9aa1/artifact/", "model_task": "image_text_to_text"}, {"params": "--served-model-name model_three --tensor-parallel-size 1 --max-model-len 2096", "model_path": "models/model_three/83e9aa1/artifact/", "model_task": "code_synthesis", "fine_tune_weights_location": "oci://test_bucket@test_namespace/models/ft-models/meta-llama-3b/ocid1.datasciencejob.oc1.iad.<ocid>"}]}',
+                            "MULTI_MODEL_CONFIG": '{ "models": [{ "params": "--served-model-name model_one --tensor-parallel-size 1 --max-model-len 2096", "model_path": "models/model_one/5be6479/artifact/", "model_task": "text_embedding"}, {"params": "--served-model-name model_two --tensor-parallel-size 1 --max-model-len 2096", "model_path": "models/model_two/83e9aa1/artifact/", "model_task": "image_text_to_text"}, {"params": "--served-model-name model_three --tensor-parallel-size 1 --max-model-len 2096", "model_path": "models/model_three/83e9aa1/artifact/", "model_task": "code_synthesis", "fine_tune_weights": [{"model_name": "ft_model", "model_path": "oci://test_bucket@test_namespace/models/ft-models/meta-llama-3b/ocid1.datasciencejob.oc1.iad.<ocid>"}] }]}',
                         },
                         "health_check_port": 8080,
                         "image": "dsmc://image-name:1.0.0.0",
@@ -488,8 +492,8 @@ class TestDataset:
                 "model_id": "test_model_id_1",
                 "model_name": "test_model_1",
                 "model_task": "text_embedding",
-                "artifact_location": "test_location_1",
-                "fine_tune_weights_location": None,
+                "artifact_location": "oci://test_location_1",
+                "fine_tune_weights": None,
             },
             {
                 "env_var": {},
@@ -497,8 +501,8 @@ class TestDataset:
                 "model_id": "test_model_id_2",
                 "model_name": "test_model_2",
                 "model_task": "image_text_to_text",
-                "artifact_location": "test_location_2",
-                "fine_tune_weights_location": None,
+                "artifact_location": "oci://test_location_2",
+                "fine_tune_weights": None,
             },
             {
                 "env_var": {},
@@ -506,14 +510,19 @@ class TestDataset:
                 "model_id": "test_model_id_3",
                 "model_name": "test_model_3",
                 "model_task": "code_synthesis",
-                "artifact_location": "test_location_3",
-                "fine_tune_weights_location": "oci://test_bucket@test_namespace/models/ft-models/meta-llama-3b/ocid1.datasciencejob.oc1.iad.<ocid>",
+                "artifact_location": "oci://test_location_3",
+                "fine_tune_weights": [
+                    {
+                        "model_name": "ft_model",
+                        "model_path": "oci://test_bucket@test_namespace/models/ft-models/meta-llama-3b/ocid1.datasciencejob.oc1.iad.<ocid>",
+                    }
+                ],
             },
         ],
         "model_id": "ocid1.datasciencemodel.oc1.<region>.<OCID>",
         "environment_variables": {
             "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions",
-            "MULTI_MODEL_CONFIG": '{ "models": [{ "params": "--served-model-name model_one --tensor-parallel-size 1 --max-model-len 2096", "model_path": "models/model_one/5be6479/artifact/", "model_task": "text_embedding"}, {"params": "--served-model-name model_two --tensor-parallel-size 1 --max-model-len 2096", "model_path": "models/model_two/83e9aa1/artifact/", "model_task": "image_text_to_text"}, {"params": "--served-model-name model_three --tensor-parallel-size 1 --max-model-len 2096", "model_path": "models/model_three/83e9aa1/artifact/", "model_task": "code_synthesis", "fine_tune_weights_location": "oci://test_bucket@test_namespace/models/ft-models/meta-llama-3b/ocid1.datasciencejob.oc1.iad.<ocid>"}]}',
+            "MULTI_MODEL_CONFIG": '{ "models": [{ "params": "--served-model-name model_one --tensor-parallel-size 1 --max-model-len 2096", "model_path": "models/model_one/5be6479/artifact/", "model_task": "text_embedding"}, {"params": "--served-model-name model_two --tensor-parallel-size 1 --max-model-len 2096", "model_path": "models/model_two/83e9aa1/artifact/", "model_task": "image_text_to_text"}, {"params": "--served-model-name model_three --tensor-parallel-size 1 --max-model-len 2096", "model_path": "models/model_three/83e9aa1/artifact/", "model_task": "code_synthesis", "fine_tune_weights": [{"model_name": "ft_model", "model_path": "oci://test_bucket@test_namespace/models/ft-models/meta-llama-3b/ocid1.datasciencejob.oc1.iad.<ocid>"}] }]}',
         },
         "cmd": [],
         "console_link": "https://cloud.oracle.com/data-science/model-deployments/ocid1.datasciencemodeldeployment.oc1.<region>.<MD_OCID>?region=region-name",
@@ -974,7 +983,7 @@ class TestDataset:
             "model_name": "model_one",
             "model_task": "text_embedding",
             "artifact_location": "artifact_location_one",
-            "fine_tune_weights_location": None,
+            "fine_tune_weights": None,
         },
         {
             "env_var": {"--test_key_two": "test_value_two"},
@@ -983,7 +992,7 @@ class TestDataset:
             "model_name": "model_two",
             "model_task": "image_text_to_text",
             "artifact_location": "artifact_location_two",
-            "fine_tune_weights_location": None,
+            "fine_tune_weights": None,
         },
         {
             "env_var": {"--test_key_three": "test_value_three"},
@@ -992,7 +1001,12 @@ class TestDataset:
             "model_name": "model_three",
             "model_task": "code_synthesis",
             "artifact_location": "artifact_location_three",
-            "fine_tune_weights_location": "oci://test_bucket@test_namespace/models/ft-models/meta-llama-3b/ocid1.datasciencejob.oc1.iad.<ocid>",
+            "fine_tune_weights": [
+                {
+                    "model_name": "ft_model",
+                    "model_path": "oci://test_bucket@test_namespace/models/ft-models/meta-llama-3b/ocid1.datasciencejob.oc1.iad.<ocid>",
+                }
+            ],
         },
     ]
 
@@ -1802,7 +1816,7 @@ class TestAquaDeployment(unittest.TestCase):
             model_name="test_model_1",
             model_task="text_embedding",
             gpu_count=2,
-            artifact_location="test_location_1",
+            artifact_location="oci://test_location_1",
         )
 
         model_info_2 = AquaMultiModelRef(
@@ -1810,16 +1824,23 @@ class TestAquaDeployment(unittest.TestCase):
             model_name="test_model_2",
             model_task="image_text_to_text",
             gpu_count=2,
-            artifact_location="test_location_2",
+            artifact_location="oci://test_location_2",
         )
 
+        # successful deployment with model_info1, model_info2, model_info3
+        ft_weights = [
+            LoraModuleSpec(
+                model_name="ft_model",
+                model_path="oci://test_bucket@test_namespace/models/ft-models/meta-llama-3b/ocid1.datasciencejob.oc1.iad.<ocid>",
+            )
+        ]
         model_info_3 = AquaMultiModelRef(
             model_id="test_model_id_3",
             model_name="test_model_3",
             model_task="code_synthesis",
             gpu_count=2,
-            artifact_location="test_location_3",
-            fine_tune_weights_location="oci://test_bucket@test_namespace/models/ft-models/meta-llama-3b/ocid1.datasciencejob.oc1.iad.<ocid>",
+            artifact_location="oci://test_location_3",
+            fine_tune_weights=ft_weights,
         )
 
         result = self.app.create(
@@ -2318,3 +2339,61 @@ class TestMDInferenceResponse(unittest.TestCase):
 
         result = self.app.get_model_deployment_response(endpoint)
         assert result["choices"][0]["text"] == " The answer is 2"
+
+
+class TestBaseModelSpec:
+    VALID_WEIGHT = LoraModuleSpec(
+        model_name="ft_model",
+        model_path="oci://test_bucket@test_namespace/",
+    )
+
+    @pytest.mark.parametrize(
+        "model_path, ft_weights, expect_warning",
+        [
+            ("oci://test_location_3", [VALID_WEIGHT, VALID_WEIGHT], True),
+            ("oci://test_location_3", [], False),
+            ("not-a-valid-uri", [VALID_WEIGHT], False),
+        ],
+    )
+    def test_invalid_base_model_spec(
+        self,
+        model_path,
+        ft_weights,
+        expect_warning,
+        caplog,
+    ):
+        logger = logging.getLogger("ads.aqua.modeldeployment.group_model_metadata")
+        logger.propagate = True
+
+        caplog.set_level(logging.WARNING, logger=logger.name)
+
+        with pytest.raises(ValidationError) as excinfo:
+            BaseModelSpec(
+                model_id="test_model_id_3",
+                model_name="test_model_3",
+                model_task="code_synthesis",
+                model_path=model_path,
+                fine_tune_weights=ft_weights,
+            )
+
+        messages = [rec.getMessage().lower() for rec in caplog.records]
+
+        if expect_warning:
+            assert any(
+                "duplicate lora modules detected" in m for m in messages
+            ), f"Expected warning, got none. Captured messages: {messages}"
+        else:
+            assert not messages, f"Did not expect any warnings, but got: {messages}"
+
+        # inspecting if errors are thrown
+        errs = excinfo.value.errors()
+        if not model_path.startswith("oci://"):
+            model_path_errors = [e for e in errs if e["loc"] == ("model_path",)]
+            assert model_path_errors, f"expected a model_path error, got: {errs!r}"
+            assert (
+                "the base model path is not available in the model artifact."
+                in model_path_errors[0]["msg"].lower()
+            )
+        else:
+            # e.g. for the duplicate‐weights case you might check for a different loc/msg
+            pass

--- a/tests/unitary/with_extras/aqua/test_deployment_handler.py
+++ b/tests/unitary/with_extras/aqua/test_deployment_handler.py
@@ -8,9 +8,9 @@ import os
 import unittest
 from importlib import reload
 from unittest.mock import MagicMock, patch
-from parameterized import parameterized
 
 from notebook.base.handlers import IPythonHandler
+from parameterized import parameterized
 
 import ads.aqua
 import ads.config


### PR DESCRIPTION
**TODO:**
- writing docstrings for methods in group_model_metadata
- unit tests (want to seek feedback on implementation before writing tests)

This PR migrates the construction of the 'MULTI_MODEL_CONFIG', an environment variable passed to start a multi-model deployment, from the _create_multi method in deployment.py to group_model_metadata.py. 

**In group_model_metadata.py**
- we convert CreateModelDeploymentDetails -> GroupModelDeploymentMetadata (pydantic object representing MULTI_MODEL_CONFIG)
- during ^^ conversion, we validate if duplicate model entries exist or if duplicate LoRA Modules exist per model.

When constructing CreateModelDeploymentDetails in model.py, we construct a new field ```fine_tune_weights``` with the following format:
```
"fine_tuned_weights": [
                {
                    "model_path": "oci://model-path-ft1",
                    "model_name": "meta-llama/Llama-3.1-8B-Instruct-FT1"
                },
                {
                    "model_path": "oci://model-path-ft2",
                    "model_name": "meta-llama/Llama-3.1-8B-Instruct-FT2"
                }
```

**Final Result, create GroupModelDeploymentMetadata,** which represents MULTI_MODEL_CONFIG as seen below
```
{
    "models": [
        {
            "params": "--served-model-name meta-llama/Llama-3.1-8B-Instruct --tensor-parallel-size 2 --max-model-len 16000",
            "model_path": "oci://model-path",
            "model_task": "image-text-to-text",
            "fine_tuned_weights": [
                {
                    "model_path": "oci://model-path-ft1",
                    "model_name": "meta-llama/Llama-3.1-8B-Instruct-FT1"
                },
                {
                    "model_path": "oci://model-path-ft2",
                    "model_name": "meta-llama/Llama-3.1-8B-Instruct-FT2"
                }
            ]
        }
    ]
} 

```
