### PR TITLE
Fix ft params issue

### DIFF
--- a/ads/aqua/common/entities.py
+++ b/ads/aqua/common/entities.py
@@ -139,14 +139,20 @@ class ComputeShapeSummary(Serializable):
 class LoraModuleSpec(Serializable):
     """
     Lightweight descriptor for LoRA Modules used in fine-tuning models.
+
     Attributes
     ----------
+    model_id : str
+        The unique identifier of the fine tuned model.
     model_name : str
         The name of the fine-tuned model.
     model_path : str
         The model-by-reference path to the LoRA Module within the model artifact
     """
 
+    model_id: str = Field(
+        ..., description="The fine tuned model OCID to deploy.", exclude=True
+    )
     model_name: str = Field(..., description="The name of the fine-tuned model.")
     model_path: str = Field(
         ...,

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -321,7 +321,11 @@ class AquaModelApp(AquaApp):
                 )
                 # once we support multiple LoRA Modules use [LoraModuleSpec(**lora_module) for lora_module in model.fine_tune_weights]
                 model.fine_tune_weights = [
-                    LoraModuleSpec(model_name=display_name, model_path=fine_tune_path)
+                    LoraModuleSpec(
+                        model_id=model.model_id,
+                        model_name=display_name,
+                        model_path=fine_tune_path,
+                    )
                 ]
                 model.model_id, model.model_name = extract_base_model_from_ft(
                     source_model

--- a/ads/aqua/modeldeployment/model_group_config.py
+++ b/ads/aqua/modeldeployment/model_group_config.py
@@ -162,8 +162,14 @@ class ModelGroupConfig(Serializable):
             model, container_params, container_type_key
         )
 
+        model_id = (
+            model.fine_tune_weights[0].model_id
+            if model.fine_tune_weights
+            else model.model_id
+        )
+
         deployment_config = model_config_summary.deployment_config.get(
-            model.model_id, AquaDeploymentConfig()
+            model_id, AquaDeploymentConfig()
         ).configuration.get(
             create_deployment_details.instance_shape, ConfigurationItem()
         )

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -1002,6 +1002,7 @@ class TestDataset:
             "artifact_location": "artifact_location_three",
             "fine_tune_weights": [
                 {
+                    "model_id": "ocid1.datasciencemodel.oc1..<OCID>",
                     "model_name": "ft_model",
                     "model_path": "oci://test_bucket@test_namespace/models/ft-models/meta-llama-3b/ocid1.datasciencejob.oc1.iad.<ocid>",
                 }
@@ -1190,9 +1191,13 @@ class TestAquaDeployment(unittest.TestCase):
         actual_attributes = result.to_dict()
         assert set(actual_attributes) == set(expected_attributes), "Attributes mismatch"
         assert len(result.models) == 3
+        actual_attributes_no_ft_id = copy.deepcopy(
+            TestDataset.multi_model_deployment_model_attributes
+        )
+        actual_attributes_no_ft_id[2]["fine_tune_weights"][0].pop("model_id")
         assert [
             model.model_dump() for model in result.models
-        ] == TestDataset.multi_model_deployment_model_attributes
+        ] == actual_attributes_no_ft_id
 
     def test_get_deployment_missing_tags(self):
         """Test for returning a runtime error if OCI_AQUA tag is missing."""
@@ -1874,6 +1879,7 @@ class TestAquaDeployment(unittest.TestCase):
         # successful deployment with model_info1, model_info2, model_info3
         ft_weights = [
             LoraModuleSpec(
+                model_id="ocid1.datasciencemodel.oc1..<OCID>",
                 model_name="ft_model",
                 model_path="oci://test_bucket@test_namespace/models/ft-models/meta-llama-3b/ocid1.datasciencejob.oc1.iad.<ocid>",
             )
@@ -2354,6 +2360,7 @@ class TestAquaDeployment(unittest.TestCase):
 
 class TestBaseModelSpec:
     VALID_WEIGHT = LoraModuleSpec(
+        model_id="ocid1.datasciencemodel.oc1..<OCID>",
         model_name="ft_model",
         model_path="oci://test_bucket@test_namespace/",
     )
@@ -2442,6 +2449,7 @@ class TestModelGroupConfig(TestAquaDeployment):
 
         ft_weights = [
             LoraModuleSpec(
+                model_id="ocid1.datasciencemodel.oc1..<OCID>",
                 model_name="ft_model",
                 model_path="oci://test_bucket@test_namespace/models/ft-models/meta-llama-3b/ocid1.datasciencejob.oc1.iad.<ocid>",
             )


### PR DESCRIPTION
### Fix ft params issue

```
==================================== test session starts =====================================
platform darwin -- Python 3.13.2, pytest-8.3.5, pluggy-1.5.0 -- /Library/Frameworks/Python.framework/Versions/3.13/bin/python3.13
cachedir: .pytest_cache
rootdir: /Users/Downloads/fix_logic/accelerated-data-science
configfile: pytest.ini
plugins: anyio-4.9.0, langsmith-0.3.15, mock-3.14.0, xdist-3.6.1
collected 82 items                                                                           

tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_fine_tuned_model PASSED [  1%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_foundation_model PASSED [  2%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_gguf_model PASSED [  3%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_multi_model PASSED [  4%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_tei_byoc_embedding_model PASSED [  6%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment PASSED [  7%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_config PASSED [  8%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_0_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [  9%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_1_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 10%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_2_TGI_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 12%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_3_CUSTOM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 13%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_missing_tags PASSED [ 14%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_multi_model_deployment PASSED [ 15%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_multimodel_deployment_config_hybrid PASSED [ 17%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_multimodel_deployment_config_single PASSED [ 18%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_list_deployments PASSED [ 19%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 20%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_1_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 21%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_2_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 23%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_3_custom_container_key <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 24%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_4_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 25%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_5_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 26%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_for_unverified_models_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 28%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_for_unverified_models_1_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 29%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_for_unverified_models_2_ <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 30%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_0 PASSED [ 31%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_1 PASSED [ 32%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_2 PASSED [ 34%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_3 PASSED [ 35%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_4 PASSED [ 36%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_5 PASSED [ 37%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_single_0 PASSED [ 39%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_single_1 PASSED [ 40%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_0 PASSED [ 41%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_1 PASSED [ 42%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_2 PASSED [ 43%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_single_0 PASSED [ 45%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_single_1 PASSED [ 46%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_verify_compatibility PASSED [ 47%]
tests/unitary/with_extras/aqua/test_deployment.py::TestBaseModelSpec::test_invalid_from_aqua_multi_model_ref[oci://test_location_3-ft_weights0-True-False] PASSED [ 48%]
tests/unitary/with_extras/aqua/test_deployment.py::TestBaseModelSpec::test_invalid_from_aqua_multi_model_ref[oci://test_location_3-ft_weights1-False-False] PASSED [ 50%]
tests/unitary/with_extras/aqua/test_deployment.py::TestBaseModelSpec::test_invalid_from_aqua_multi_model_ref[not-a-valid-uri-ft_weights2-False-True] PASSED [ 51%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_fine_tuned_model PASSED [ 52%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_foundation_model PASSED [ 53%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_gguf_model PASSED [ 54%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_multi_model PASSED [ 56%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_tei_byoc_embedding_model PASSED [ 57%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_from_create_model_deployment_details PASSED [ 58%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment PASSED [ 59%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_config PASSED [ 60%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_0_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 62%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_1_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 63%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_2_TGI_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 64%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_3_CUSTOM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 65%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_missing_tags PASSED [ 67%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_multi_model_deployment PASSED [ 68%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_multimodel_deployment_config_hybrid PASSED [ 69%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_multimodel_deployment_config_single PASSED [ 70%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_list_deployments PASSED [ 71%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 73%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_1_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 74%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_2_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 75%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_3_custom_container_key <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 76%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_4_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 78%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_5_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 79%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_for_unverified_models_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 80%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_for_unverified_models_1_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 81%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_for_unverified_models_2_ <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 82%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_0 PASSED [ 84%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_1 PASSED [ 85%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_2 PASSED [ 86%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_3 PASSED [ 87%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_4 PASSED [ 89%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_5 PASSED [ 90%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_single_0 PASSED [ 91%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_single_1 PASSED [ 92%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_0 PASSED [ 93%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_1 PASSED [ 95%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_2 PASSED [ 96%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_single_0 PASSED [ 97%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_single_1 PASSED [ 98%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_verify_compatibility PASSED [100%]

==================================== 82 passed in 21.78s =====================================
```