### PR TITLE
Updating chat completions inference data retrieval logic

### DIFF
--- a/ads/aqua/extension/deployment_handler.py
+++ b/ads/aqua/extension/deployment_handler.py
@@ -246,7 +246,10 @@ class AquaDeploymentStreamingInferenceHandler(AquaAPIhandler):
                     stream=True,
                 ):
                     try:
-                        yield chunk["choices"][0]["delta"]["content"]
+                        if "text" in chunk["choices"][0]:
+                            yield chunk["choices"][0]["text"]
+                        elif "content" in chunk["choices"][0]["delta"]:
+                            yield chunk["choices"][0]["delta"]["content"]
                     except Exception as e:
                         logger.debug(
                             f"Exception occurred while parsing streaming response: {e}"


### PR DESCRIPTION
# Description
This PR is intended to update the inference logic when user overrides the header to /v1/chat/completions in case of model deployed with llama-cpp container.   MD with llama cpp container returns chunked response in different format than vllm/tgi containers.



