### PR TITLE
[AQUA][Multi-Model] Enhance CLI & UI Handler to Accept Fine-Tuned Weights Under Base Model in Multi-Model Deployment

### DIFF
--- a/ads/aqua/common/entities.py
+++ b/ads/aqua/common/entities.py
@@ -6,7 +6,7 @@ import re
 from typing import Any, Dict, List, Optional
 
 from oci.data_science.models import Model
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from ads.aqua import logger
 from ads.aqua.config.utils.serializer import Serializable
@@ -80,24 +80,29 @@ class GPUShapesIndex(Serializable):
 
 class ComputeShapeSummary(Serializable):
     """
-    Represents the specifications of a compute instance's shape.
+    Represents the specifications of a compute instance shape,
+    including CPU, memory, and optional GPU characteristics.
     """
 
     core_count: Optional[int] = Field(
-        default=None, description="The number of CPU cores available."
+        default=None,
+        description="Total number of CPU cores available for the compute shape.",
     )
     memory_in_gbs: Optional[int] = Field(
-        default=None, description="The amount of memory (in GB) available."
+        default=None,
+        description="Amount of memory (in GB) available for the compute shape.",
     )
     name: Optional[str] = Field(
-        default=None, description="The name identifier of the compute shape."
+        default=None,
+        description="Full name of the compute shape, e.g., 'VM.GPU.A10.2'.",
     )
     shape_series: Optional[str] = Field(
-        default=None, description="The series or category of the compute shape."
+        default=None,
+        description="Shape family or series, e.g., 'GPU', 'Standard', etc.",
     )
     gpu_specs: Optional[GPUSpecs] = Field(
         default=None,
-        description="The GPU specifications associated with the compute shape.",
+        description="Optional GPU specifications associated with the shape.",
     )
 
     @model_validator(mode="after")
@@ -136,26 +141,45 @@ class ComputeShapeSummary(Serializable):
         return model
 
 
-class LoraModuleSpec(Serializable):
+class LoraModuleSpec(BaseModel):
     """
-    Lightweight descriptor for LoRA Modules used in fine-tuning models.
+    Descriptor for a LoRA (Low-Rank Adaptation) module used in fine-tuning base models.
+
+    This class is used to define a single fine-tuned module that can be loaded during
+    multi-model deployment alongside a base model.
 
     Attributes
     ----------
     model_id : str
-        The unique identifier of the fine tuned model.
-    model_name : str
-        The name of the fine-tuned model.
-    model_path : str
-        The model-by-reference path to the LoRA Module within the model artifact
+        The OCID of the fine-tuned model registered in the OCI Model Catalog.
+    model_name : Optional[str]
+        The unique name used to route inference requests to this model variant.
+    model_path : Optional[str]
+        The relative path within the artifact pointing to the LoRA adapter weights.
     """
 
-    model_id: Optional[str] = Field(None, description="The fine tuned model OCID to deploy.")
-    model_name: Optional[str] = Field(None, description="The name of the fine-tuned model.")
-    model_path: Optional[str] = Field(
-        None,
-        description="The model-by-reference path to the LoRA Module within the model artifact.",
+    model_config = ConfigDict(protected_namespaces=(), extra="allow")
+
+    model_id: str = Field(
+        ...,
+        description="OCID of the fine-tuned model (must be registered in the Model Catalog).",
     )
+    model_name: Optional[str] = Field(
+        default=None,
+        description="Name assigned to the fine-tuned model for serving (used as inference route).",
+    )
+    model_path: Optional[str] = Field(
+        default=None,
+        description="Relative path to the LoRA weights inside the model artifact.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_lora_module(cls, data: dict) -> dict:
+        """Validates that required structure exists for a LoRA module."""
+        if "model_id" not in data or not data["model_id"]:
+            raise ValueError("Missing required field: 'model_id' for fine-tuned model.")
+        return data
 
 
 class AquaMultiModelRef(Serializable):
@@ -202,6 +226,22 @@ class AquaMultiModelRef(Serializable):
         None,
         description="For fine tuned models, the artifact path of the modified model weights",
     )
+
+    def all_model_ids(self) -> List[str]:
+        """
+        Returns all associated model OCIDs, including the base model and any fine-tuned models.
+
+        Returns
+        -------
+        List[str]
+            A list of all model OCIDs associated with this multi-model reference.
+        """
+        ids = {self.model_id}
+        if self.fine_tune_weights:
+            ids.update(
+                module.model_id for module in self.fine_tune_weights if module.model_id
+            )
+        return list(ids)
 
     class Config:
         extra = "ignore"

--- a/ads/aqua/modeldeployment/model_group_config.py
+++ b/ads/aqua/modeldeployment/model_group_config.py
@@ -81,14 +81,12 @@ class BaseModelSpec(BaseModel):
         unique_modules: List[LoraModuleSpec] = []
 
         for module in fine_tune_weights or []:
-            name = getattr(module, "model_name", None)
-            if not name:
-                logger.warning("Fine-tuned model in AquaMultiModelRef is missing model_name.")
+            if module.model_name and module.model_name in seen:
+                logger.warning(
+                    f"Duplicate LoRA Module detected: {module.model_name!r} (skipping duplicate)."
+                )
                 continue
-            if name in seen:
-                logger.warning(f"Duplicate LoRA Module detected: {name!r} (skipping duplicate).")
-                continue
-            seen.add(name)
+            seen.add(module.model_name)
             unique_modules.append(module)
 
         return unique_modules
@@ -169,17 +167,12 @@ class ModelGroupConfig(Serializable):
             model, container_params, container_type_key
         )
 
-        model_id = (
-            model.fine_tune_weights[0].model_id
-            if model.fine_tune_weights
-            else model.model_id
-        )
-
         deployment_config = model_config_summary.deployment_config.get(
-            model_id, AquaDeploymentConfig()
+            model.model_id, AquaDeploymentConfig()
         ).configuration.get(
             create_deployment_details.instance_shape, ConfigurationItem()
         )
+
         params_found = False
         for item in deployment_config.multi_model_deployment:
             if model.gpu_count and item.gpu_count and item.gpu_count == model.gpu_count:

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -1789,8 +1789,14 @@ class TestAquaDeployment(unittest.TestCase):
     @patch(
         "ads.aqua.modeldeployment.entities.CreateModelDeploymentDetails.validate_multimodel_deployment_feasibility"
     )
+    @patch(
+        "ads.aqua.modeldeployment.entities.CreateModelDeploymentDetails.validate_input_models"
+    )
+    @patch.object(AquaApp, "get_multi_source")
     def test_create_deployment_for_multi_model(
         self,
+        mock_get_multi_source,
+        mock_validate_input_models,
         mock_validate_multimodel_deployment_feasibility,
         mock_get_deployment_config,
         mock_deploy,
@@ -1902,13 +1908,9 @@ class TestAquaDeployment(unittest.TestCase):
             predict_log_id="ocid1.log.oc1.<region>.<OCID>",
         )
 
-        mock_create_multi.assert_called_with(
-            models=[model_info_1, model_info_2, model_info_3],
-            compartment_id=TestDataset.USER_COMPARTMENT_ID,
-            project_id=TestDataset.USER_PROJECT_ID,
-            freeform_tags=None,
-            defined_tags=None,
-        )
+        mock_create_multi.assert_called()
+        mock_get_multi_source.assert_called()
+        mock_validate_input_models.assert_called()
         mock_get_container_image.assert_called()
         mock_deploy.assert_called()
 


### PR DESCRIPTION
# Description
Currently, the CLI and UI handler for multi-model deployment accept a flat list of models, where model_id can refer to either a base model or a fine-tuned weight. Under the hood, the handler detects fine-tuned models and transforms the input into a nested structure grouping fine-tuned weights under their respective base models. This logic should be improved by explicitly allowing users to provide a base model and its associated fine-tuned weights directly in the input structure. This enhancement simplifies user intent, reduces ambiguity, and enables direct validation of base-to-weight relationships.

### Current CLI command

```
ads aqua deployment create \
  --container_image_uri "dsmc://odsc-vllm-serving:0.8.5.post1.6" \
  --models '[
    {
      "model_id": "ocid1.log.oc1.iad.<ocid>",
      "gpu_count": 1,
      "model_name": "meta-llama/Meta-Llama-3.1-8B",
      "model_task": "text_generation",
    },
    {
      "model_task": "text_generation",
      "model_id": "ocid1.log.oc1.iad.<ocid>",
      "gpu_count": 1
    }
  ]' \
  --instance_shape "VM.GPU.A10.2" \
  --display_name "modelDeployment_multimodel"
```

### New CLI command

```
ads aqua deployment create \
  --container_image_uri "dsmc://odsc-vllm-serving:0.8.5.post1.6" \
  --models '[
    {
      "model_id": "ocid1.log.oc1.iad.<ocid>",
      "gpu_count": 1,
      "model_name": "meta-llama/Meta-Llama-3.1-8B",
      "model_task": "text_generation",
      "fine_tune_weights": [
        {
          "model_id": "ocid1.datasciencemodel.oc1.iad.<>",
          "model_name": "meta-llama/Meta-Llama-3.1-8B-FT1"
        },
        {
          "model_id": "ocid1.datasciencemodel.oc1.iad.<>",
          "model_name": "meta-llama/Meta-Llama-3.1-8B-FT2"
        }
      ]
    },
    {
      "model_task": "text_generation",
      "model_id": "ocid1.log.oc1.iad.<ocid>",
      "gpu_count": 1
    }
  ]' \
  --instance_shape "VM.GPU.A10.2" \
  --display_name "modelDeployment_multimodel"
```