### PR TITLE
[AQUA] Block legacy ft model

### DIFF
--- a/ads/aqua/common/utils.py
+++ b/ads/aqua/common/utils.py
@@ -643,7 +643,9 @@ def get_resource_name(ocid: str) -> str:
     return name
 
 
-def get_model_by_reference_paths(model_file_description: dict):
+def get_model_by_reference_paths(
+    model_file_description: dict, is_ft_model_v2: bool = False
+):
     """Reads the model file description json dict and returns the base model path and fine-tuned path for
         models created by reference.
 
@@ -651,6 +653,8 @@ def get_model_by_reference_paths(model_file_description: dict):
     ----------
     model_file_description: dict
         json dict containing model paths and objects for models created by reference.
+    is_ft_model_v2: bool
+        Flag to indicate if it's fine tuned model v2. Defaults to False.
 
     Returns
     -------
@@ -666,8 +670,18 @@ def get_model_by_reference_paths(model_file_description: dict):
             "Please check if the model created by reference has the correct artifact."
         )
 
+    if is_ft_model_v2:
+        # model_file_description json for fine tuned model v2 contains only fine tuned model artifacts
+        # so first model is always the fine tuned model
+        ft_model_artifact = models[0]
+        fine_tune_output_path = f"oci://{ft_model_artifact['bucketName']}@{ft_model_artifact['namespace']}/{ft_model_artifact['prefix']}".rstrip(
+            "/"
+        )
+
+        return UNKNOWN, fine_tune_output_path
+
     if len(models) > 0:
-        # since the model_file_description json does not have a flag to identify the base model, we consider
+        # since the model_file_description json for legacy fine tuned model does not have a flag to identify the base model, we consider
         # the first instance to be the base model.
         base_model_artifact = models[0]
         base_model_path = f"oci://{base_model_artifact['bucketName']}@{base_model_artifact['namespace']}/{base_model_artifact['prefix']}".rstrip(

--- a/ads/aqua/constants.py
+++ b/ads/aqua/constants.py
@@ -45,6 +45,8 @@ MODEL_NAME_DELIMITER = ";"
 AQUA_TROUBLESHOOTING_LINK = "https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md"
 MODEL_FILE_DESCRIPTION_VERSION = "1.0"
 MODEL_FILE_DESCRIPTION_TYPE = "modelOSSReferenceDescription"
+AQUA_FINE_TUNE_MODEL_VERSION = "v2"
+INCLUDE_BASE_MODEL = 1
 
 TRAINING_METRICS_FINAL = "training_metrics_final"
 VALIDATION_METRICS_FINAL = "validation_metrics_final"

--- a/ads/aqua/finetuning/finetuning.py
+++ b/ads/aqua/finetuning/finetuning.py
@@ -25,6 +25,7 @@ from ads.aqua.common.utils import (
     upload_local_to_os,
 )
 from ads.aqua.constants import (
+    AQUA_FINE_TUNE_MODEL_VERSION,
     DEFAULT_FT_BATCH_SIZE,
     DEFAULT_FT_BLOCK_STORAGE_SIZE,
     DEFAULT_FT_REPLICA,
@@ -306,7 +307,9 @@ class AquaFineTuningApp(AquaApp):
         }
         # needs to add 'fine_tune_model_version' tag when creating the ft model for the
         # ft container to block merging base model artifact with ft model artifact.
-        ft_model_freeform_tags = {Tags.AQUA_FINE_TUNE_MODEL_VERSION: "v2"}
+        ft_model_freeform_tags = {
+            Tags.AQUA_FINE_TUNE_MODEL_VERSION: AQUA_FINE_TUNE_MODEL_VERSION
+        }
 
         ft_model = self.create_model_catalog(
             display_name=create_fine_tuning_details.ft_name,

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -171,8 +171,10 @@ class AquaModelApp(AquaApp):
             The instance of DataScienceModel or DataScienceModelGroup.
         """
         fine_tune_weights = []
+        model_name = ""
         if isinstance(model, AquaMultiModelRef):
             fine_tune_weights = model.fine_tune_weights
+            model_name = model.model_name
             model = model.model_id
 
         service_model = DataScienceModel.from_id(model)
@@ -193,6 +195,7 @@ class AquaModelApp(AquaApp):
         if fine_tune_weights:
             custom_model = self._create_model_group(
                 model_id=model,
+                model_name=model_name,
                 compartment_id=target_compartment,
                 project_id=target_project,
                 freeform_tags=combined_freeform_tags,
@@ -267,6 +270,7 @@ class AquaModelApp(AquaApp):
     def _create_model_group(
         self,
         model_id: str,
+        model_name: str,
         compartment_id: str,
         project_id: str,
         freeform_tags: Dict,
@@ -275,6 +279,20 @@ class AquaModelApp(AquaApp):
         service_model: DataScienceModel,
     ):
         """Creates a data science model group."""
+        member_models = [
+            {
+                "inference_key": fine_tune_weight.model_name,
+                "model_id": fine_tune_weight.model_id,
+            }
+            for fine_tune_weight in fine_tune_weights
+        ]
+        # must also include base model info in member models to create stacked model group
+        member_models.append(
+            {
+                "inference_key": model_name or service_model.display_name,
+                "model_id": model_id,
+            }
+        )
         custom_model = (
             DataScienceModelGroup()
             .with_compartment_id(compartment_id)
@@ -285,15 +303,7 @@ class AquaModelApp(AquaApp):
             .with_defined_tags(**defined_tags)
             .with_custom_metadata_list(service_model.custom_metadata_list)
             .with_base_model_id(model_id)
-            .with_member_models(
-                [
-                    {
-                        "inference_key": fine_tune_weight.model_name,
-                        "model_id": fine_tune_weight.model_id,
-                    }
-                    for fine_tune_weight in fine_tune_weights
-                ]
-            )
+            .with_member_models(member_models)
             .create()
         )
 

--- a/ads/aqua/model/utils.py
+++ b/ads/aqua/model/utils.py
@@ -5,6 +5,7 @@
 
 from typing import Tuple
 
+from ads.aqua.common.enums import Tags
 from ads.aqua.common.errors import AquaValueError
 from ads.aqua.common.utils import get_model_by_reference_paths
 from ads.aqua.finetuning.constants import FineTuneCustomMetadata
@@ -34,8 +35,12 @@ def extract_base_model_from_ft(aqua_model: DataScienceModel) -> Tuple[str, str]:
 def extract_fine_tune_artifacts_path(aqua_model: DataScienceModel) -> Tuple[str, str]:
     """Extracts the fine tuning source (fine_tune_output_path) and base model path from the DataScienceModel Object"""
 
+    is_ft_model_v2 = (
+        aqua_model.freeform_tags.get(Tags.AQUA_FINE_TUNE_MODEL_VERSION, "").lower()
+        == "v2"
+    )
     base_model_path, fine_tune_output_path = get_model_by_reference_paths(
-        aqua_model.model_file_description
+        aqua_model.model_file_description, is_ft_model_v2
     )
 
     if not fine_tune_output_path or not ObjectStorageDetails.is_oci_path(

--- a/ads/aqua/model/utils.py
+++ b/ads/aqua/model/utils.py
@@ -8,6 +8,7 @@ from typing import Tuple
 from ads.aqua.common.enums import Tags
 from ads.aqua.common.errors import AquaValueError
 from ads.aqua.common.utils import get_model_by_reference_paths
+from ads.aqua.constants import AQUA_FINE_TUNE_MODEL_VERSION
 from ads.aqua.finetuning.constants import FineTuneCustomMetadata
 from ads.common.object_storage_details import ObjectStorageDetails
 from ads.model.datascience_model import DataScienceModel
@@ -37,7 +38,7 @@ def extract_fine_tune_artifacts_path(aqua_model: DataScienceModel) -> Tuple[str,
 
     is_ft_model_v2 = (
         aqua_model.freeform_tags.get(Tags.AQUA_FINE_TUNE_MODEL_VERSION, "").lower()
-        == "v2"
+        == AQUA_FINE_TUNE_MODEL_VERSION
     )
     base_model_path, fine_tune_output_path = get_model_by_reference_paths(
         aqua_model.model_file_description, is_ft_model_v2

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -232,7 +232,7 @@ class AquaDeploymentApp(AquaApp):
                 model = create_deployment_details.models[0]
             else:
                 try:
-                    create_deployment_details.validate_input_model_id(model_id=model)
+                    create_deployment_details.validate_ft_model_v2(model_id=model)
                 except ConfigValidationError as err:
                     raise AquaValueError(f"{err}") from err
 

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -924,8 +924,8 @@ class AquaDeploymentApp(AquaApp):
             params_dict = get_params_dict(params)
             # updates `--served-model-name` with service model id
             params_dict.update({"--served-model-name": aqua_model.base_model_id})
-            # TODO: sets `--max-lora-rank` as 30 in params for now, will revisit later
-            params_dict.update({"--max-lora-rank": 30})
+            # TODO: sets `--max-lora-rank` as 32 in params for now, will revisit later
+            params_dict.update({"--max-lora-rank": 32})
             # adds `--enable_lora` to parameters
             params_dict.update({"--enable_lora": UNKNOWN})
             params = build_params_string(params_dict)

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -228,7 +228,13 @@ class AquaDeploymentApp(AquaApp):
                     raise AquaValueError(
                         "Invalid 'models' provided. Only one base model is required for model stack deployment."
                     )
+                self._validate_input_models(create_deployment_details)
                 model = create_deployment_details.models[0]
+            else:
+                try:
+                    create_deployment_details.validate_input_model_id(model_id=model)
+                except ConfigValidationError as err:
+                    raise AquaValueError(f"{err}") from err
 
             service_model_id = model if isinstance(model, str) else model.model_id
             logger.debug(
@@ -258,26 +264,9 @@ class AquaDeploymentApp(AquaApp):
             )
         # TODO: add multi model validation from deployment_type
         else:
-            # Collect all unique model IDs (including fine-tuned models)
-            source_model_ids = list(
-                {
-                    model_id
-                    for model in create_deployment_details.models
-                    for model_id in model.all_model_ids()
-                }
+            source_models, source_model_ids = self._validate_input_models(
+                create_deployment_details
             )
-            logger.debug(
-                "Fetching source model metadata for model IDs: %s", source_model_ids
-            )
-            # Fetch source model metadata
-            source_models = self.get_multi_source(source_model_ids) or {}
-
-            try:
-                create_deployment_details.validate_input_models(
-                    model_details=source_models
-                )
-            except ConfigValidationError as err:
-                raise AquaValueError(f"{err}") from err
 
             base_model_ids = [
                 model.model_id for model in create_deployment_details.models
@@ -393,6 +382,32 @@ class AquaDeploymentApp(AquaApp):
                 create_deployment_details=create_deployment_details,
                 container_config=container_config,
             )
+
+    def _validate_input_models(
+        self,
+        create_deployment_details: CreateModelDeploymentDetails,
+    ):
+        """Validates the base models and associated fine tuned models from 'models' in create_deployment_details for stacked or multi model deployment."""
+        # Collect all unique model IDs (including fine-tuned models)
+        source_model_ids = list(
+            {
+                model_id
+                for model in create_deployment_details.models
+                for model_id in model.all_model_ids()
+            }
+        )
+        logger.debug(
+            "Fetching source model metadata for model IDs: %s", source_model_ids
+        )
+        # Fetch source model metadata
+        source_models = self.get_multi_source(source_model_ids) or {}
+
+        try:
+            create_deployment_details.validate_input_models(model_details=source_models)
+        except ConfigValidationError as err:
+            raise AquaValueError(f"{err}") from err
+
+        return source_models, source_model_ids
 
     def _build_model_group_configs(
         self,

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -924,6 +924,8 @@ class AquaDeploymentApp(AquaApp):
             params_dict = get_params_dict(params)
             # updates `--served-model-name` with service model id
             params_dict.update({"--served-model-name": aqua_model.base_model_id})
+            # TODO: sets `--max-lora-rank` as 30 in params for now, will revisit later
+            params_dict.update({"--max-lora-rank": 30})
             # adds `--enable_lora` to parameters
             params_dict.update({"--enable_lora": UNKNOWN})
             params = build_params_string(params_dict)

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -51,7 +51,11 @@ from ads.aqua.constants import (
 )
 from ads.aqua.data import AquaResourceIdentifier
 from ads.aqua.model import AquaModelApp
-from ads.aqua.model.constants import AquaModelMetadataKeys, ModelCustomMetadataFields
+from ads.aqua.model.constants import (
+    AquaModelMetadataKeys,
+    ModelCustomMetadataFields,
+    ModelTask,
+)
 from ads.aqua.model.enums import MultiModelSupportedTaskType
 from ads.aqua.model.utils import (
     extract_base_model_from_ft,

--- a/ads/model/datascience_model_group.py
+++ b/ads/model/datascience_model_group.py
@@ -530,7 +530,6 @@ class DataScienceModelGroup(Builder):
                 custom_metadata_list=custom_metadata_list,
                 base_model_id=self.base_model_id,
             )
-            member_model_details.append(MemberModelDetails(model_id=self.base_model_id))
         else:
             model_group_details = HomogeneousModelGroupDetails(
                 custom_metadata_list=custom_metadata_list

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -1437,8 +1437,12 @@ class TestAquaDeployment(unittest.TestCase):
     @patch.object(AquaApp, "get_container_image")
     @patch("ads.model.deployment.model_deployment.ModelDeployment.deploy")
     @patch.object(AquaApp, "get_container_config")
+    @patch(
+        "ads.aqua.modeldeployment.entities.CreateModelDeploymentDetails.validate_ft_model_v2"
+    )
     def test_create_deployment_for_foundation_model(
         self,
+        mock_validate_ft_model_v2,
         mock_get_container_config,
         mock_deploy,
         mock_get_container_image,
@@ -1514,6 +1518,7 @@ class TestAquaDeployment(unittest.TestCase):
             defined_tags=defined_tags,
         )
 
+        mock_validate_ft_model_v2.assert_called()
         mock_create.assert_called_with(
             model=TestDataset.MODEL_ID,
             compartment_id=TestDataset.USER_COMPARTMENT_ID,
@@ -1538,8 +1543,12 @@ class TestAquaDeployment(unittest.TestCase):
     @patch.object(AquaApp, "get_container_image")
     @patch("ads.model.deployment.model_deployment.ModelDeployment.deploy")
     @patch.object(AquaApp, "get_container_config")
+    @patch(
+        "ads.aqua.modeldeployment.entities.CreateModelDeploymentDetails.validate_ft_model_v2"
+    )
     def test_create_deployment_for_fine_tuned_model(
         self,
+        mock_validate_ft_model_v2,
         mock_get_container_config,
         mock_deploy,
         mock_get_container_image,
@@ -1610,6 +1619,7 @@ class TestAquaDeployment(unittest.TestCase):
             predict_log_id="ocid1.log.oc1.<region>.<OCID>",
         )
 
+        mock_validate_ft_model_v2.assert_called()
         mock_create.assert_called_with(
             model=TestDataset.MODEL_ID,
             compartment_id=TestDataset.USER_COMPARTMENT_ID,
@@ -1632,8 +1642,12 @@ class TestAquaDeployment(unittest.TestCase):
     @patch.object(AquaApp, "get_container_image")
     @patch("ads.model.deployment.model_deployment.ModelDeployment.deploy")
     @patch.object(AquaApp, "get_container_config")
+    @patch(
+        "ads.aqua.modeldeployment.entities.CreateModelDeploymentDetails.validate_ft_model_v2"
+    )
     def test_create_deployment_for_gguf_model(
         self,
+        mock_validate_ft_model_v2,
         mock_get_container_config,
         mock_deploy,
         mock_get_container_image,
@@ -1706,6 +1720,7 @@ class TestAquaDeployment(unittest.TestCase):
             memory_in_gbs=60.0,
         )
 
+        mock_validate_ft_model_v2.assert_called()
         mock_create.assert_called_with(
             model=TestDataset.MODEL_ID,
             compartment_id=TestDataset.USER_COMPARTMENT_ID,
@@ -1732,8 +1747,12 @@ class TestAquaDeployment(unittest.TestCase):
     @patch.object(AquaApp, "get_container_image")
     @patch("ads.model.deployment.model_deployment.ModelDeployment.deploy")
     @patch.object(AquaApp, "get_container_config")
+    @patch(
+        "ads.aqua.modeldeployment.entities.CreateModelDeploymentDetails.validate_ft_model_v2"
+    )
     def test_create_deployment_for_tei_byoc_embedding_model(
         self,
+        mock_validate_ft_model_v2,
         mock_get_container_config,
         mock_deploy,
         mock_get_container_image,
@@ -1809,6 +1828,7 @@ class TestAquaDeployment(unittest.TestCase):
             cmd_var=[],
         )
 
+        mock_validate_ft_model_v2.assert_called()
         mock_create.assert_called_with(
             model=TestDataset.MODEL_ID,
             compartment_id=TestDataset.USER_COMPARTMENT_ID,
@@ -1838,8 +1858,14 @@ class TestAquaDeployment(unittest.TestCase):
     @patch.object(AquaApp, "get_container_image")
     @patch("ads.model.deployment.model_deployment.ModelDeployment.deploy")
     @patch.object(AquaApp, "get_container_config")
+    @patch(
+        "ads.aqua.modeldeployment.entities.CreateModelDeploymentDetails.validate_input_models"
+    )
+    @patch.object(AquaApp, "get_multi_source")
     def test_create_deployment_for_stack_model(
         self,
+        mock_get_multi_source,
+        mock_validate_input_models,
         mock_get_container_config,
         mock_deploy,
         mock_get_container_image,
@@ -1931,6 +1957,8 @@ class TestAquaDeployment(unittest.TestCase):
             deployment_type="STACKED",
         )
 
+        mock_get_multi_source.assert_called()
+        mock_validate_input_models.assert_called()
         mock_create.assert_called()
         mock_get_container_image.assert_called()
         mock_deploy.assert_called()


### PR DESCRIPTION
### Block legacy ft model from stack/multi/single deployment

- Block legacy ft model from stack/multi/single deployment

### Integration
- create multi deployment with legacy AQUA model
<img width="956" height="118" alt="Screenshot 2025-08-05 at 3 32 13 PM" src="https://github.com/user-attachments/assets/7bf06cf8-d727-44a6-b129-af4544d2fc4e" />

- create stacked deployment with legacy AQUA model
<img width="958" height="111" alt="Screenshot 2025-08-05 at 3 33 41 PM" src="https://github.com/user-attachments/assets/7baab1ef-ddbf-4b64-a7d9-2e954cce1070" />

- create single deployment with legacy AQUA model
<img width="954" height="111" alt="Screenshot 2025-08-05 at 3 35 48 PM" src="https://github.com/user-attachments/assets/1088b3ba-8635-4a8f-a67e-a18ead3a9a25" />

### Unit 
```
============================================= test session starts =============================================
platform darwin -- Python 3.13.2, pytest-8.3.5, pluggy-1.5.0 -- /Library/Frameworks/Python.framework/Versions/3.13/bin/python3.13
cachedir: .pytest_cache
rootdir: /Users/Downloads/fix_logic/accelerated-data-science
configfile: pytest.ini
plugins: anyio-4.9.0, langsmith-0.3.15, mock-3.14.0, xdist-3.6.1
collected 88 items                                                                                            

tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_fine_tuned_model PASSED [  1%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_foundation_model PASSED [  2%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_gguf_model PASSED [  3%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_multi_model PASSED [  4%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_stack_model PASSED [  5%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_tei_byoc_embedding_model PASSED [  6%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment PASSED       [  7%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_config PASSED [  9%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_0_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 10%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_1_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 11%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_2_TGI_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 12%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_3_CUSTOM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 13%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_missing_tags PASSED [ 14%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_status_failed PASSED [ 15%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_status_success PASSED [ 17%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_multi_model_deployment PASSED [ 18%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_multimodel_deployment_config_hybrid PASSED [ 19%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_multimodel_deployment_config_single PASSED [ 20%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_list_deployments PASSED     [ 21%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 22%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_1_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 23%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_2_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 25%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_3_custom_container_key <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 26%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_4_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 27%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_5_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 28%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_for_unverified_models_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 29%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_for_unverified_models_1_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 30%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_for_unverified_models_2_ <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 31%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_0 PASSED [ 32%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_1 PASSED [ 34%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_2 PASSED [ 35%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_3 PASSED [ 36%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_4 PASSED [ 37%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_5 PASSED [ 38%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_single_0 PASSED [ 39%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_single_1 PASSED [ 40%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_0 PASSED [ 42%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_1 PASSED [ 43%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_2 PASSED [ 44%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_single_0 PASSED [ 45%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_single_1 PASSED [ 46%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_verify_compatibility PASSED [ 47%]
tests/unitary/with_extras/aqua/test_deployment.py::TestBaseModelSpec::test_invalid_from_aqua_multi_model_ref[oci://test_location_3-ft_weights0-True-False] PASSED [ 48%]
tests/unitary/with_extras/aqua/test_deployment.py::TestBaseModelSpec::test_invalid_from_aqua_multi_model_ref[oci://test_location_3-ft_weights1-False-False] PASSED [ 50%]
tests/unitary/with_extras/aqua/test_deployment.py::TestBaseModelSpec::test_invalid_from_aqua_multi_model_ref[not-a-valid-uri-ft_weights2-False-True] PASSED [ 51%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_fine_tuned_model PASSED [ 52%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_foundation_model PASSED [ 53%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_gguf_model PASSED [ 54%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_multi_model PASSED [ 55%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_stack_model PASSED [ 56%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_tei_byoc_embedding_model PASSED [ 57%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_from_create_model_deployment_details PASSED [ 59%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment PASSED     [ 60%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_config PASSED [ 61%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_0_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 62%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_1_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 63%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_2_TGI_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 64%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_3_CUSTOM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 65%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_missing_tags PASSED [ 67%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_status_failed PASSED [ 68%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_status_success PASSED [ 69%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_multi_model_deployment PASSED [ 70%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_multimodel_deployment_config_hybrid PASSED [ 71%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_multimodel_deployment_config_single PASSED [ 72%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_list_deployments PASSED   [ 73%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 75%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_1_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 76%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_2_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 77%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_3_custom_container_key <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 78%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_4_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 79%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_5_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 80%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_for_unverified_models_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 81%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_for_unverified_models_1_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 82%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_for_unverified_models_2_ <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 84%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_0 PASSED [ 85%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_1 PASSED [ 86%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_2 PASSED [ 87%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_3 PASSED [ 88%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_4 PASSED [ 89%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_5 PASSED [ 90%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_single_0 PASSED [ 92%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_single_1 PASSED [ 93%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_0 PASSED [ 94%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_1 PASSED [ 95%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_2 PASSED [ 96%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_single_0 PASSED [ 97%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_single_1 PASSED [ 98%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_verify_compatibility PASSED [100%]

============================================= 88 passed in 24.80s =============================================
```