### PR TITLE
Added cli to convert legacy fine tuned model to v2.

### DIFF
--- a/ads/aqua/constants.py
+++ b/ads/aqua/constants.py
@@ -45,6 +45,7 @@ MODEL_NAME_DELIMITER = ";"
 AQUA_TROUBLESHOOTING_LINK = "https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md"
 MODEL_FILE_DESCRIPTION_VERSION = "1.0"
 MODEL_FILE_DESCRIPTION_TYPE = "modelOSSReferenceDescription"
+AQUA_FINE_TUNE_MODEL_VERSION = "v2"
 
 TRAINING_METRICS_FINAL = "training_metrics_final"
 VALIDATION_METRICS_FINAL = "validation_metrics_final"

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -710,6 +710,11 @@ class AquaModelApp(AquaApp):
             .create(model_by_reference=True)
         )
 
+        logger.info(
+            f"Successfully converted legacy AQUA fine tuned model '{model_id}' to version '{AQUA_FINE_TUNE_MODEL_VERSION}'. "
+            f"Use new AQUA fine tuned model '{fine_tune_model_v2.id}' for future deployment."
+        )
+
         if delete_model:
             legacy_fine_tuned_model.delete()
 

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -675,12 +675,14 @@ class AquaModelApp(AquaApp):
             == AQUA_FINE_TUNE_MODEL_VERSION
         ):
             raise AquaValueError(
-                f"Invalid model id {model_id}. Only legacy AQUA fine tuned model is supported to convert to version {AQUA_FINE_TUNE_MODEL_VERSION}."
+                f"Model '{model_id}' is not eligible for conversion. Only legacy AQUA fine-tuned models "
+                f"without the 'fine_tune_model_version={AQUA_FINE_TUNE_MODEL_VERSION}' tag are supported."
             )
 
         if not legacy_fine_tuned_model.model_file_description:
             raise AquaValueError(
-                f"Invalid model id {model_id}. Only legacy AQUA fine tuned model created by model by reference is supported to convert to version {AQUA_FINE_TUNE_MODEL_VERSION}."
+                f"Model '{model_id}' is missing required metadata and cannot be converted. "
+                "This may indicate the model was not created properly or is not a supported legacy AQUA fine-tuned model."
             )
 
         # add 'fine_tune_model_version' tag as 'v2'
@@ -711,8 +713,8 @@ class AquaModelApp(AquaApp):
         )
 
         logger.info(
-            f"Successfully converted legacy AQUA fine tuned model '{model_id}' to version '{AQUA_FINE_TUNE_MODEL_VERSION}'. "
-            f"Use new AQUA fine tuned model '{fine_tune_model_v2.id}' for future deployment."
+            f"Successfully created version '{AQUA_FINE_TUNE_MODEL_VERSION}' fine-tuned model: '{fine_tune_model_v2.id}' "
+            f"based on legacy model '{model_id}'. This new model is now ready for deployment."
         )
 
         if delete_model:

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -671,12 +671,19 @@ class AquaModelApp(AquaApp):
         if (
             Tags.AQUA_TAG not in legacy_tags
             or Tags.AQUA_FINE_TUNED_MODEL_TAG not in legacy_tags
-            or legacy_tags.get(Tags.AQUA_FINE_TUNE_MODEL_VERSION, UNKNOWN).lower()
-            == AQUA_FINE_TUNE_MODEL_VERSION
         ):
             raise AquaValueError(
                 f"Model '{model_id}' is not eligible for conversion. Only legacy AQUA fine-tuned models "
                 f"without the 'fine_tune_model_version={AQUA_FINE_TUNE_MODEL_VERSION}' tag are supported."
+            )
+
+        if (
+            legacy_tags.get(Tags.AQUA_FINE_TUNE_MODEL_VERSION, UNKNOWN).lower()
+            == AQUA_FINE_TUNE_MODEL_VERSION
+        ):
+            raise AquaValueError(
+                f"Model '{model_id}' is already a fine-tuned model in version '{AQUA_FINE_TUNE_MODEL_VERSION}'. "
+                "No conversion is necessary."
             )
 
         if not legacy_fine_tuned_model.model_file_description:

--- a/ads/aqua/model/model.py
+++ b/ads/aqua/model/model.py
@@ -43,6 +43,7 @@ from ads.aqua.common.utils import (
 )
 from ads.aqua.config.container_config import AquaContainerConfig
 from ads.aqua.constants import (
+    AQUA_FINE_TUNE_MODEL_VERSION,
     AQUA_MODEL_ARTIFACT_CONFIG,
     AQUA_MODEL_ARTIFACT_CONFIG_MODEL_NAME,
     AQUA_MODEL_ARTIFACT_CONFIG_MODEL_TYPE,
@@ -644,6 +645,75 @@ class AquaModelApp(AquaApp):
                 logger.info(f"Updated model details for the model {id}.")
         else:
             raise AquaRuntimeError("Only registered unverified models can be edited.")
+
+    def convert_fine_tune(
+        self, model_id: str, delete_model: Optional[bool] = False
+    ) -> DataScienceModel:
+        """Converts legacy fine tuned model to fine tuned model v2.
+        1. 'fine_tune_model_version' tag will be added as 'v2' to new fine tuned model.
+        2. 'model_file_description' json will only contain fine tuned artifacts for new fine tuned model.
+
+        Parameters
+        ----------
+        model_id: str
+            The legacy fine tuned model OCID.
+        delete_model: bool
+            Flag whether to delete the legacy model or not. Defaults to False.
+
+        Returns
+        -------
+        DataScienceModel:
+            The instance of DataScienceModel.
+        """
+        legacy_fine_tuned_model = DataScienceModel.from_id(model_id)
+        legacy_tags = legacy_fine_tuned_model.freeform_tags or {}
+
+        if (
+            Tags.AQUA_TAG not in legacy_tags
+            or Tags.AQUA_FINE_TUNED_MODEL_TAG not in legacy_tags
+            or legacy_tags.get(Tags.AQUA_FINE_TUNE_MODEL_VERSION, UNKNOWN).lower()
+            == AQUA_FINE_TUNE_MODEL_VERSION
+        ):
+            raise AquaValueError(
+                f"Invalid model id {model_id}. Only legacy AQUA fine tuned model is supported to convert to version {AQUA_FINE_TUNE_MODEL_VERSION}."
+            )
+
+        if not legacy_fine_tuned_model.model_file_description:
+            raise AquaValueError(
+                f"Invalid model id {model_id}. Only legacy AQUA fine tuned model created by model by reference is supported to convert to version {AQUA_FINE_TUNE_MODEL_VERSION}."
+            )
+
+        # add 'fine_tune_model_version' tag as 'v2'
+        fine_tune_model_v2_tags = {
+            **legacy_tags,
+            Tags.AQUA_FINE_TUNE_MODEL_VERSION: AQUA_FINE_TUNE_MODEL_VERSION,
+        }
+
+        # remove base model artifacts in 'model_file_description' json file
+        # base model artifacts are placed as the first entry in 'models' list
+        legacy_fine_tuned_model.model_file_description["models"].pop(0)
+
+        fine_tune_model_v2 = (
+            DataScienceModel()
+            .with_compartment_id(legacy_fine_tuned_model.compartment_id)
+            .with_project_id(legacy_fine_tuned_model.project_id)
+            .with_model_file_description(
+                json_dict=legacy_fine_tuned_model.model_file_description
+            )
+            .with_display_name(legacy_fine_tuned_model.display_name)
+            .with_description(legacy_fine_tuned_model.description)
+            .with_freeform_tags(**fine_tune_model_v2_tags)
+            .with_defined_tags(**(legacy_fine_tuned_model.defined_tags or {}))
+            .with_custom_metadata_list(legacy_fine_tuned_model.custom_metadata_list)
+            .with_defined_metadata_list(legacy_fine_tuned_model.defined_metadata_list)
+            .with_provenance_metadata(legacy_fine_tuned_model.provenance_metadata)
+            .create(model_by_reference=True)
+        )
+
+        if delete_model:
+            legacy_fine_tuned_model.delete()
+
+        return fine_tune_model_v2
 
     def _fetch_metric_from_metadata(
         self,

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -825,6 +825,125 @@ class TestAquaModel:
             "evaluation_container": "odsc-llm-evaluate",
         }
 
+    @patch.object(DataScienceModel, "create")
+    @patch.object(DataScienceModel, "from_id")
+    def test_convert_fine_tune(self, mock_from_id, mock_create):
+        ds_model = MagicMock()
+        ds_model.id = "test_id"
+        ds_model.compartment_id = "test_model_compartment_id"
+        ds_model.project_id = "test_project_id"
+        ds_model.display_name = "test_display_name"
+        ds_model.description = "test_description"
+        ds_model.model_version_set_id = "test_model_version_set_id"
+        ds_model.model_version_set_name = "test_model_version_set_name"
+        ds_model.freeform_tags = {
+            "license": "test_license",
+            "organization": "test_organization",
+            "task": "test_task",
+            "aqua_fine_tuned_model": "test_finetuned_model",
+        }
+        ds_model.time_created = "2024-01-19T17:57:39.158000+00:00"
+        ds_model.lifecycle_state = "ACTIVE"
+        custom_metadata_list = ModelCustomMetadata()
+        custom_metadata_list.add(
+            **{"key": "artifact_location", "value": "oci://bucket@namespace/prefix/"}
+        )
+        custom_metadata_list.add(
+            **{"key": "fine_tune_source", "value": "test_fine_tuned_source_id"}
+        )
+        custom_metadata_list.add(
+            **{"key": "fine_tune_source_name", "value": "test_fine_tuned_source_name"}
+        )
+        custom_metadata_list.add(
+            **{
+                "key": "deployment-container",
+                "value": "odsc-vllm-serving",
+            }
+        )
+        custom_metadata_list.add(
+            **{
+                "key": "evaluation-container",
+                "value": "odsc-llm-evaluate",
+            }
+        )
+        custom_metadata_list.add(
+            **{
+                "key": "finetune-container",
+                "value": "odsc-llm-fine-tuning",
+            }
+        )
+        ds_model.custom_metadata_list = custom_metadata_list
+        defined_metadata_list = ModelTaxonomyMetadata()
+        defined_metadata_list["Hyperparameters"].value = {
+            "training_data": "test_training_data",
+            "val_set_size": "test_val_set_size",
+        }
+        ds_model.defined_metadata_list = defined_metadata_list
+        ds_model.provenance_metadata = ModelProvenanceMetadata(
+            training_id="test_training_job_run_id"
+        )
+        ds_model.model_file_description = {
+            "version": "1.0",
+            "type": "modelOSSReferenceDescription",
+            "models": [
+                {
+                    "namespace": "test_namespace_one",
+                    "bucketName": "test_bucket_name_one",
+                    "prefix": "test_prefix_one",
+                    "objects": [
+                        {
+                            "name": "artifact/.gitattributes",
+                            "version": "123",
+                            "sizeInBytes": 1519,
+                        }
+                    ],
+                },
+                {
+                    "namespace": "test_namespace_two",
+                    "bucketName": "test_bucket_name_two",
+                    "prefix": "test_prefix_two",
+                    "objects": [
+                        {
+                            "name": "/README.md",
+                            "version": "b52c2608-009f-4774-8325-60ec226ae003",
+                            "sizeInBytes": 5189,
+                        }
+                    ],
+                },
+            ],
+        }
+
+        mock_from_id.return_value = ds_model
+
+        # missing 'OCI_AQUA' tag
+        with pytest.raises(
+            AquaValueError,
+            match="Invalid model id mock_model_id. Only legacy AQUA fine tuned model is supported to convert to version v2.",
+        ):
+            self.app.convert_fine_tune(model_id="mock_model_id")
+
+        # add 'OCI_AQUA' tag
+        mock_from_id.return_value.freeform_tags["OCI_AQUA"] = "ACTIVE"
+
+        self.app.convert_fine_tune(model_id="mock_model_id")
+
+        mock_create.assert_called_with(model_by_reference=True)
+
+        assert mock_from_id.return_value.model_file_description["models"] == [
+            {
+                "namespace": "test_namespace_two",
+                "bucketName": "test_bucket_name_two",
+                "prefix": "test_prefix_two",
+                "objects": [
+                    {
+                        "name": "/README.md",
+                        "version": "b52c2608-009f-4774-8325-60ec226ae003",
+                        "sizeInBytes": 5189,
+                    }
+                ],
+            }
+        ]
+
     @pytest.mark.parametrize(
         ("artifact_location_set", "download_from_hf", "cleanup_model_cache"),
         [

--- a/tests/unitary/with_extras/aqua/test_model.py
+++ b/tests/unitary/with_extras/aqua/test_model.py
@@ -918,7 +918,7 @@ class TestAquaModel:
         # missing 'OCI_AQUA' tag
         with pytest.raises(
             AquaValueError,
-            match="Invalid model id mock_model_id. Only legacy AQUA fine tuned model is supported to convert to version v2.",
+            match="Model 'mock_model_id' is not eligible for conversion. Only legacy AQUA fine-tuned models without the 'fine_tune_model_version=v2' tag are supported.",
         ):
             self.app.convert_fine_tune(model_id="mock_model_id")
 


### PR DESCRIPTION
### Added cli to convert legacy fine tuned model to v2.

- Added `convert_fine_tune` to convert legacy fine tuned model to v2.

### Integration
- Convert legacy fine tuned model to v2 via cli

<img width="966" height="564" alt="Screenshot 2025-08-04 at 3 31 23 PM" src="https://github.com/user-attachments/assets/83533403-fdd3-4f63-9802-3386df8a62a4" />

- Fine tuned model v2 will have tag `fine_tune_model_version` and only fine tune artifacts in `model_file_description.json`
<img width="965" height="516" alt="Screenshot 2025-08-04 at 3 08 38 PM" src="https://github.com/user-attachments/assets/c7068601-0738-464a-aa91-bd902a237e92" />

### Unit
```
============================================= test session starts =============================================
platform darwin -- Python 3.13.2, pytest-8.3.5, pluggy-1.5.0 -- /Library/Frameworks/Python.framework/Versions/3.13/bin/python3.13
cachedir: .pytest_cache
rootdir: /Users/Downloads/fix_logic/accelerated-data-science
configfile: pytest.ini
plugins: anyio-4.9.0, langsmith-0.3.15, mock-3.14.0, xdist-3.6.1
collected 35 items                                                                                            

tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_create_model PASSED                   [  2%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_create_multimodel PASSED              [  5%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_get_foundation_models[service] PASSED [  8%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_get_foundation_models[verified] PASSED [ 11%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_get_model_fine_tuned PASSED           [ 14%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_convert_fine_tune PASSED              [ 17%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_verified_model[True-True-True] PASSED [ 20%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_verified_model[True-False-True] PASSED [ 22%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_verified_model[False-True-False] PASSED [ 25%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_verified_model[False-False-True] PASSED [ 28%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_any_model_no_containers_specified PASSED [ 31%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_project_compartment_override[True] PASSED [ 34%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_project_compartment_override[False] PASSED [ 37%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_missing_config[True-True] PASSED [ 40%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_missing_config[True-False] PASSED [ 42%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_missing_config[False-True] PASSED [ 45%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_missing_config[False-False] PASSED [ 48%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_missing_config[None-False] PASSED [ 51%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_missing_config[None-True] PASSED [ 54%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_any_model_smc_container PASSED [ 57%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_tei_model_byoc[True] PASSED    [ 60%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_tei_model_byoc[False] PASSED   [ 62%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_model_with_input_tags PASSED   [ 65%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_cli[data0-ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf True --cleanup_model_cache False --inference_container odsc-vllm-serving] PASSED [ 68%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_cli[data1-ads aqua model register --model ocid1.datasciencemodel.oc1.iad.<OCID> --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf True --cleanup_model_cache False] PASSED [ 71%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_cli[data2-ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf False --cleanup_model_cache False] PASSED [ 74%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_cli[data3-ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf True --cleanup_model_cache False --model_file test_model_file] PASSED [ 77%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_cli[data4-ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf True --cleanup_model_cache False --inference_container odsc-tei-serving --inference_container_uri <region>.ocir.io/<your_tenancy>/<your_image>] PASSED [ 80%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_cli[data5-ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf True --cleanup_model_cache False --inference_container odsc-vllm-serving --freeform_tags {"ftag1": "fvalue1", "ftag2": "fvalue2"} --defined_tags {"dtag1": "dvalue1", "dtag2": "dvalue2"}] PASSED [ 82%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_import_cli[data6-ads aqua model register --model oracle/oracle-1it --os_path oci://aqua-bkt@aqua-ns/path --download_from_hf True --cleanup_model_cache True --inference_container odsc-vllm-serving --ignore_model_artifact_check True] PASSED [ 85%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_load_license PASSED                   [ 88%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_list_service_models PASSED            [ 91%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_list_custom_models PASSED             [ 94%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_build_search_text_0 PASSED            [ 97%]
tests/unitary/with_extras/aqua/test_model.py::TestAquaModel::test_build_search_text_1_This_is_a_description_ PASSED [100%]

============================================= 35 passed in 20.12s =============================================
```