### PR TITLE
[AQUA][GPT-OSS] Add Shape-Specific Env Config for GPT-OSS Models in AQUA Deployment Config Reader

### DIFF
--- a/ads/aqua/common/utils.py
+++ b/ads/aqua/common/utils.py
@@ -14,7 +14,7 @@ import shlex
 import shutil
 import subprocess
 from datetime import datetime, timedelta
-from functools import lru_cache, wraps
+from functools import wraps
 from pathlib import Path
 from string import Template
 from typing import Any, Dict, List, Optional, Union
@@ -997,7 +997,6 @@ def get_container_params_type(container_type_name: str) -> str:
         return UNKNOWN
 
 
-@lru_cache(maxsize=None)
 def get_container_env_type(container_type_name: Optional[str]) -> str:
     """
     Determine the container environment type based on the container type name.

--- a/ads/aqua/common/utils.py
+++ b/ads/aqua/common/utils.py
@@ -14,7 +14,7 @@ import shlex
 import shutil
 import subprocess
 from datetime import datetime, timedelta
-from functools import wraps
+from functools import lru_cache, wraps
 from pathlib import Path
 from string import Template
 from typing import Any, Dict, List, Optional, Union
@@ -995,6 +995,45 @@ def get_container_params_type(container_type_name: str) -> str:
         return InferenceContainerParamType.PARAM_TYPE_LLAMA_CPP
     else:
         return UNKNOWN
+
+
+@lru_cache(maxsize=None)
+def get_container_env_type(container_type_name: Optional[str]) -> str:
+    """
+    Determine the container environment type based on the container type name.
+
+    This function matches the provided container type name against the known
+    values of `InferenceContainerType`. The check is case-insensitive and
+    allows for partial matches so that changes in container naming conventions
+    (e.g., prefixes or suffixes) will still be matched correctly.
+
+    Examples:
+        >>> get_container_env_type("odsc-vllm-serving")
+        'vllm'
+        >>> get_container_env_type("ODSC-TGI-Serving")
+        'tgi'
+        >>> get_container_env_type("custom-unknown-container")
+        'UNKNOWN'
+
+    Args:
+        container_type_name (Optional[str]):
+            The deployment container type name (e.g., "odsc-vllm-serving").
+
+    Returns:
+        str:
+            - A matching `InferenceContainerType` value string (e.g., "VLLM", "TGI", "LLAMA-CPP").
+            - `"UNKNOWN"` if no match is found or the input is empty/None.
+    """
+    if not container_type_name:
+        return UNKNOWN
+
+    needle = container_type_name.strip().casefold()
+
+    for container_type in InferenceContainerType.values():
+        if container_type and container_type.casefold() in needle:
+            return container_type.upper()
+
+    return UNKNOWN
 
 
 def get_restricted_params_by_container(container_type_name: str) -> set:

--- a/ads/aqua/modeldeployment/config_loader.py
+++ b/ads/aqua/modeldeployment/config_loader.py
@@ -88,6 +88,7 @@ class MultiModelConfig(Serializable):
         gpu_count (int, optional): Number of GPUs count to this model of this shape.
         parameters (Dict[str, str], optional): A dictionary of parameters (e.g., VLLM_PARAMS) to
             configure the behavior of a particular GPU shape.
+        env (Dict[str, Dict[str, str]]): Environment variables grouped by namespace (e.g., "VLLM": {"VAR": "VAL"}).
     """
 
     gpu_count: Optional[int] = Field(
@@ -96,6 +97,10 @@ class MultiModelConfig(Serializable):
     parameters: Optional[Dict[str, str]] = Field(
         default_factory=dict,
         description="Key-value pairs for GPU shape parameters (e.g., VLLM_PARAMS).",
+    )
+    env: Optional[Dict[str, Dict[str, str]]] = Field(
+        default_factory=dict,
+        description="Environment variables grouped by namespace",
     )
 
     class Config:
@@ -130,6 +135,7 @@ class ConfigurationItem(Serializable):
             configure the behavior of a particular GPU shape.
         multi_model_deployment (List[MultiModelConfig], optional): A list of multi model configuration details.
         shape_info (DeploymentShapeInfo, optional): The shape information to this model for specific CPU shape.
+        env (Dict[str, Dict[str, str]]): Environment variables grouped by namespace (e.g., "VLLM": {"VAR": "VAL"}).
     """
 
     parameters: Optional[Dict[str, str]] = Field(
@@ -142,6 +148,10 @@ class ConfigurationItem(Serializable):
     shape_info: Optional[DeploymentShapeInfo] = Field(
         default_factory=DeploymentShapeInfo,
         description="The shape information to this model for specific shape",
+    )
+    env: Optional[Dict[str, Dict[str, str]]] = Field(
+        default_factory=dict,
+        description="Environment variables grouped by namespace",
     )
 
     class Config:

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -27,6 +27,7 @@ from ads.aqua.common.utils import (
     build_pydantic_error_message,
     find_restricted_params,
     get_combined_params,
+    get_container_env_type,
     get_container_params_type,
     get_ocid_substring,
     get_params_list,
@@ -1042,6 +1043,7 @@ class AquaDeploymentApp(AquaApp):
         config = self.get_config_from_metadata(
             model_id, AquaModelMetadataKeys.DEPLOYMENT_CONFIGURATION
         ).config
+
         if config:
             logger.info(
                 f"Fetched {AquaModelMetadataKeys.DEPLOYMENT_CONFIGURATION} from defined metadata for model: {model_id}."
@@ -1126,7 +1128,7 @@ class AquaDeploymentApp(AquaApp):
         model_id: str,
         instance_shape: str,
         gpu_count: int = None,
-    ) -> List[str]:
+    ) -> Dict:
         """Gets the default params set in the deployment configs for the given model and instance shape.
 
         Parameters
@@ -1148,6 +1150,7 @@ class AquaDeploymentApp(AquaApp):
 
         """
         default_params = []
+        default_envs = {}
         config_params = {}
         model = DataScienceModel.from_id(model_id)
         try:
@@ -1157,19 +1160,15 @@ class AquaDeploymentApp(AquaApp):
         except ValueError:
             container_type_key = UNKNOWN
             logger.debug(
-                f"{AQUA_DEPLOYMENT_CONTAINER_METADATA_NAME} key is not available in the custom metadata field for model {model_id}."
+                f"{AQUA_DEPLOYMENT_CONTAINER_METADATA_NAME} key is not available in the "
+                f"custom metadata field for model {model_id}."
             )
 
-        if (
-            container_type_key
-            and container_type_key in InferenceContainerTypeFamily.values()
-        ):
+        if container_type_key:
             deployment_config = self.get_deployment_config(model_id)
-
             instance_shape_config = deployment_config.configuration.get(
                 instance_shape, ConfigurationItem()
             )
-
             if instance_shape_config.multi_model_deployment and gpu_count:
                 gpu_params = instance_shape_config.multi_model_deployment
 
@@ -1178,11 +1177,17 @@ class AquaDeploymentApp(AquaApp):
                         config_params = gpu_config.parameters.get(
                             get_container_params_type(container_type_key), UNKNOWN
                         )
+                        default_envs = instance_shape_config.env.get(
+                            get_container_env_type(container_type_key), {}
+                        )
                         break
 
             else:
                 config_params = instance_shape_config.parameters.get(
                     get_container_params_type(container_type_key), UNKNOWN
+                )
+                default_envs = instance_shape_config.env.get(
+                    get_container_env_type(container_type_key), {}
                 )
 
             if config_params:
@@ -1196,7 +1201,7 @@ class AquaDeploymentApp(AquaApp):
                     if params.split()[0] not in restricted_params_set:
                         default_params.append(params)
 
-        return default_params
+        return {"data": default_params, "env": default_envs}
 
     def validate_deployment_params(
         self,

--- a/tests/unitary/with_extras/aqua/test_data/deployment/aqua_multi_model_deployment_config.json
+++ b/tests/unitary/with_extras/aqua/test_data/deployment/aqua_multi_model_deployment_config.json
@@ -1,20 +1,24 @@
 {
   "configuration": {
     "BM.GPU.A100-v2.8": {
+      "env": {},
       "multi_model_deployment": [
         {
+          "env": {},
           "gpu_count": 1,
           "parameters": {
             "VLLM_PARAMS": "--trust-remote-code --max-model-len 32000"
           }
         },
         {
+          "env": {},
           "gpu_count": 2,
           "parameters": {
             "VLLM_PARAMS": "--trust-remote-code --max-model-len 32000"
           }
         },
         {
+          "env": {},
           "gpu_count": 8,
           "parameters": {
             "VLLM_PARAMS": "--trust-remote-code --max-model-len 32000"
@@ -26,6 +30,7 @@
       }
     },
     "BM.GPU.H100.8": {
+      "env": {},
       "multi_model_deployment": [
         {
           "gpu_count": 1
@@ -44,6 +49,7 @@
     "VM.GPU.A10.2": {
       "multi_model_deployment": [
         {
+          "env": {},
           "gpu_count": 2,
           "parameters": {
             "VLLM_PARAMS": "--trust-remote-code --max-model-len 32000"
@@ -52,8 +58,10 @@
       ]
     },
     "VM.GPU.A10.4": {
+      "env": {},
       "multi_model_deployment": [
         {
+          "env": {},
           "gpu_count": 2,
           "parameters": {
             "VLLM_PARAMS": "--trust-remote-code --max-model-len 32000"

--- a/tests/unitary/with_extras/aqua/test_data/deployment/deployment_config.json
+++ b/tests/unitary/with_extras/aqua/test_data/deployment/deployment_config.json
@@ -1,6 +1,11 @@
 {
   "configuration": {
     "VM.GPU.A10.4": {
+      "env": {
+        "VLLM": {
+          "VLLM_ATTENTION_BACKEND": "TRITON_ATTN_VLLM_V1"
+        }
+      },
       "parameters": {
         "TGI_PARAMS": "--max-stop-sequences 6",
         "VLLM_PARAMS": "--max-model-len 4096"

--- a/tests/unitary/with_extras/aqua/test_data/deployment/deployment_gpu_config.json
+++ b/tests/unitary/with_extras/aqua/test_data/deployment/deployment_gpu_config.json
@@ -1,43 +1,58 @@
 {
-    "shape": [
-        "VM.GPU.A10.1",
-        "VM.GPU.A10.2",
-        "BM.GPU.A10.4",
-        "BM.GPU.L40S-NC.4"
-    ],
-    "configuration": {
-        "VM.GPU.A10.2": {
-            "parameters": {
-                "VLLM_PARAMS": "--trust-remote-code --max-model-len 60000"
-            },
-            "multi_model_deployment": [
-                {
-                    "gpu_count": 1
-                }
-            ]
-        },
-        "BM.GPU.A10.4": {
-            "parameters": {
-                "VLLM_PARAMS": "--trust-remote-code --max-model-len 60000"
-            },
-            "multi_model_deployment": [
-                {
-                    "gpu_count": 1
-                },
-                {
-                    "gpu_count": 2
-                }
-            ]
-        },
-        "BM.GPU.L40S-NC.4": {
-            "parameters": {
-                "VLLM_PARAMS": "--trust-remote-code --max-model-len 60000"
-            },
-            "multi_model_deployment": [
-                {
-                    "gpu_count": 2
-                }
-            ]
+  "configuration": {
+    "BM.GPU.A10.4": {
+      "env": {
+        "VLLM": {
+          "VLLM_ATTENTION_BACKEND": "TRITON_ATTN_VLLM_V1"
         }
+      },
+      "multi_model_deployment": [
+        {
+          "gpu_count": 1
+        },
+        {
+          "gpu_count": 2
+        }
+      ],
+      "parameters": {
+        "VLLM_PARAMS": "--trust-remote-code --max-model-len 60000"
+      }
+    },
+    "BM.GPU.L40S-NC.4": {
+      "env": {
+        "VLLM": {
+          "VLLM_ATTENTION_BACKEND": "TRITON_ATTN_VLLM_V1"
+        }
+      },
+      "multi_model_deployment": [
+        {
+          "gpu_count": 2
+        }
+      ],
+      "parameters": {
+        "VLLM_PARAMS": "--trust-remote-code --max-model-len 60000"
+      }
+    },
+    "VM.GPU.A10.2": {
+      "env": {
+        "VLLM": {
+          "VLLM_ATTENTION_BACKEND": "TRITON_ATTN_VLLM_V1"
+        }
+      },
+      "multi_model_deployment": [
+        {
+          "gpu_count": 1
+        }
+      ],
+      "parameters": {
+        "VLLM_PARAMS": "--trust-remote-code --max-model-len 60000"
+      }
     }
+  },
+  "shape": [
+    "VM.GPU.A10.1",
+    "VM.GPU.A10.2",
+    "BM.GPU.A10.4",
+    "BM.GPU.L40S-NC.4"
+  ]
 }


### PR DESCRIPTION
# Description:

**Summary**
This PR updates the AQUA deployment config reader to support **shape-specific environment variables** for GPT-OSS model deployments. The change introduces an `env` section in the deployment configuration for A-series GPU shapes, allowing AQUA handlers to return custom environment variables alongside existing parameter sets.

**Example**
A request to:

```
/aqua/deployments/{model_ocid}/params?instance_shape=BM.GPU4.8
```

will now return:

```json
{
  "data": [
    "--trust-remote-code",
    "--gpu-memory-utilization 0.98",
    "--enforce-eager",
    "--max-num-seqs 32",
    "--max_model_len 130000",
    "--dtype bfloat16"
  ],
  "env": {
    "VLLM_ATTENTION_BACKEND": "TRITON_ATTN_VLLM_V1"
  }
}
```

This change is required to ensure GPT-OSS model deployments on A-series shapes use the correct VLLM attention backend (`TRITON_ATTN_VLLM_V1`), which improves compatibility and performance for these hardware configurations.