### PR TITLE
[AQUA] Block deploying ft model as single model deployment.

### DIFF
--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -232,7 +232,7 @@ class AquaDeploymentApp(AquaApp):
                 model = create_deployment_details.models[0]
             else:
                 try:
-                    create_deployment_details.validate_ft_model_v2(model_id=model)
+                    create_deployment_details.validate_base_model(model_id=model)
                 except ConfigValidationError as err:
                     raise AquaValueError(f"{err}") from err
 

--- a/ads/aqua/modeldeployment/entities.py
+++ b/ads/aqua/modeldeployment/entities.py
@@ -713,6 +713,35 @@ class CreateModelDeploymentDetails(BaseModel):
                     f"Invalid fine-tuned model ID '{base_model.id}': for fine tuned models like Phi4, the deployment is not supported. "
                 )
 
+    def validate_base_model(self, model_id: str) -> None:
+        """
+        Validates the input base model for single model deployment configuration.
+
+        Validation Criteria:
+        - Fine-tuned models are not supported in single model deployment.
+
+        Parameters
+        ----------
+        model_id : str
+            The OCID of DataScienceModel instance.
+
+        Raises
+        ------
+        ConfigValidationError
+            If any of the above conditions are violated.
+        """
+        base_model = DataScienceModel.from_id(model_id)
+        if Tags.AQUA_FINE_TUNED_MODEL_TAG in base_model.freeform_tags:
+            logger.error(
+                "Validation failed: Fine-tuned model ID '%s' is not supported for single-model deployment.",
+                base_model.id,
+            )
+            raise ConfigValidationError(
+                f"Invalid base model ID '{base_model.id}': "
+                "single-model deployment does not support fine-tuned models. "
+                f"Please deploy the fine-tuned model '{base_model.id}' as a stacked model deployment instead."
+            )
+
     class Config:
         extra = "allow"
         protected_namespaces = ()

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -1438,11 +1438,11 @@ class TestAquaDeployment(unittest.TestCase):
     @patch("ads.model.deployment.model_deployment.ModelDeployment.deploy")
     @patch.object(AquaApp, "get_container_config")
     @patch(
-        "ads.aqua.modeldeployment.entities.CreateModelDeploymentDetails.validate_ft_model_v2"
+        "ads.aqua.modeldeployment.entities.CreateModelDeploymentDetails.validate_base_model"
     )
     def test_create_deployment_for_foundation_model(
         self,
-        mock_validate_ft_model_v2,
+        mock_validate_base_model,
         mock_get_container_config,
         mock_deploy,
         mock_get_container_image,
@@ -1518,7 +1518,7 @@ class TestAquaDeployment(unittest.TestCase):
             defined_tags=defined_tags,
         )
 
-        mock_validate_ft_model_v2.assert_called()
+        mock_validate_base_model.assert_called()
         mock_create.assert_called_with(
             model=TestDataset.MODEL_ID,
             compartment_id=TestDataset.USER_COMPARTMENT_ID,
@@ -1544,11 +1544,11 @@ class TestAquaDeployment(unittest.TestCase):
     @patch("ads.model.deployment.model_deployment.ModelDeployment.deploy")
     @patch.object(AquaApp, "get_container_config")
     @patch(
-        "ads.aqua.modeldeployment.entities.CreateModelDeploymentDetails.validate_ft_model_v2"
+        "ads.aqua.modeldeployment.entities.CreateModelDeploymentDetails.validate_base_model"
     )
     def test_create_deployment_for_fine_tuned_model(
         self,
-        mock_validate_ft_model_v2,
+        mock_validate_base_model,
         mock_get_container_config,
         mock_deploy,
         mock_get_container_image,
@@ -1619,7 +1619,7 @@ class TestAquaDeployment(unittest.TestCase):
             predict_log_id="ocid1.log.oc1.<region>.<OCID>",
         )
 
-        mock_validate_ft_model_v2.assert_called()
+        mock_validate_base_model.assert_called()
         mock_create.assert_called_with(
             model=TestDataset.MODEL_ID,
             compartment_id=TestDataset.USER_COMPARTMENT_ID,
@@ -1643,11 +1643,11 @@ class TestAquaDeployment(unittest.TestCase):
     @patch("ads.model.deployment.model_deployment.ModelDeployment.deploy")
     @patch.object(AquaApp, "get_container_config")
     @patch(
-        "ads.aqua.modeldeployment.entities.CreateModelDeploymentDetails.validate_ft_model_v2"
+        "ads.aqua.modeldeployment.entities.CreateModelDeploymentDetails.validate_base_model"
     )
     def test_create_deployment_for_gguf_model(
         self,
-        mock_validate_ft_model_v2,
+        mock_validate_base_model,
         mock_get_container_config,
         mock_deploy,
         mock_get_container_image,
@@ -1720,7 +1720,7 @@ class TestAquaDeployment(unittest.TestCase):
             memory_in_gbs=60.0,
         )
 
-        mock_validate_ft_model_v2.assert_called()
+        mock_validate_base_model.assert_called()
         mock_create.assert_called_with(
             model=TestDataset.MODEL_ID,
             compartment_id=TestDataset.USER_COMPARTMENT_ID,
@@ -1748,11 +1748,11 @@ class TestAquaDeployment(unittest.TestCase):
     @patch("ads.model.deployment.model_deployment.ModelDeployment.deploy")
     @patch.object(AquaApp, "get_container_config")
     @patch(
-        "ads.aqua.modeldeployment.entities.CreateModelDeploymentDetails.validate_ft_model_v2"
+        "ads.aqua.modeldeployment.entities.CreateModelDeploymentDetails.validate_base_model"
     )
     def test_create_deployment_for_tei_byoc_embedding_model(
         self,
-        mock_validate_ft_model_v2,
+        mock_validate_base_model,
         mock_get_container_config,
         mock_deploy,
         mock_get_container_image,
@@ -1828,7 +1828,7 @@ class TestAquaDeployment(unittest.TestCase):
             cmd_var=[],
         )
 
-        mock_validate_ft_model_v2.assert_called()
+        mock_validate_base_model.assert_called()
         mock_create.assert_called_with(
             model=TestDataset.MODEL_ID,
             compartment_id=TestDataset.USER_COMPARTMENT_ID,


### PR DESCRIPTION
### Block deploying ft model as single model deployment.

### Integration
- Block deploying legacy ft model as single model deployment.
<img width="1019" height="190" alt="Screenshot 2025-08-29 at 3 01 16 PM" src="https://github.com/user-attachments/assets/0cd49126-ef55-4107-8f6a-5aa945b2c6ac" />

- Block deploying ft model v2 as single model deployment.
<img width="1023" height="189" alt="Screenshot 2025-08-29 at 3 02 36 PM" src="https://github.com/user-attachments/assets/b6d0c54b-eacb-4da4-af8f-77a5e75787d4" />
