### PR TITLE
Add post-processing step for forecast clipping

### DIFF
--- a/ads/opctl/operator/lowcode/forecast/model/arima.py
+++ b/ads/opctl/operator/lowcode/forecast/model/arima.py
@@ -151,6 +151,7 @@ class ArimaOperatorModel(ForecastOperatorBaseModel):
             horizon=self.spec.horizon,
             target_column=self.original_target_column,
             dt_column=self.spec.datetime_column.name,
+            postprocessing=self.spec.postprocessing,
         )
 
         Parallel(n_jobs=-1, require="sharedmem")(

--- a/ads/opctl/operator/lowcode/forecast/model/automlx.py
+++ b/ads/opctl/operator/lowcode/forecast/model/automlx.py
@@ -100,6 +100,7 @@ class AutoMLXOperatorModel(ForecastOperatorBaseModel):
             horizon=self.spec.horizon,
             target_column=self.original_target_column,
             dt_column=self.spec.datetime_column.name,
+            postprocessing=self.spec.postprocessing,
         )
 
         # Clean up kwargs for pass through

--- a/ads/opctl/operator/lowcode/forecast/model/autots.py
+++ b/ads/opctl/operator/lowcode/forecast/model/autots.py
@@ -54,6 +54,7 @@ class AutoTSOperatorModel(ForecastOperatorBaseModel):
             horizon=self.spec.horizon,
             target_column=self.original_target_column,
             dt_column=self.spec.datetime_column.name,
+            postprocessing=self.spec.postprocessing,
         )
         try:
             model = self.loaded_models if self.loaded_models is not None else None

--- a/ads/opctl/operator/lowcode/forecast/model/ml_forecast.py
+++ b/ads/opctl/operator/lowcode/forecast/model/ml_forecast.py
@@ -182,6 +182,7 @@ class MLForecastOperatorModel(ForecastOperatorBaseModel):
             horizon=self.spec.horizon,
             target_column=self.original_target_column,
             dt_column=self.date_col,
+            postprocessing=self.spec.postprocessing,
         )
         self._train_model(data_train, data_test, model_kwargs)
         return self.forecast_output.get_forecast_long()

--- a/ads/opctl/operator/lowcode/forecast/model/neuralprophet.py
+++ b/ads/opctl/operator/lowcode/forecast/model/neuralprophet.py
@@ -234,6 +234,7 @@ class NeuralProphetOperatorModel(ForecastOperatorBaseModel):
             horizon=self.spec.horizon,
             target_column=self.original_target_column,
             dt_column=self.spec.datetime_column.name,
+            postprocessing=self.spec.postprocessing,
         )
 
         for i, (s_id, df) in enumerate(full_data_dict.items()):

--- a/ads/opctl/operator/lowcode/forecast/model/prophet.py
+++ b/ads/opctl/operator/lowcode/forecast/model/prophet.py
@@ -198,6 +198,7 @@ class ProphetOperatorModel(ForecastOperatorBaseModel):
             horizon=self.spec.horizon,
             target_column=self.original_target_column,
             dt_column=self.spec.datetime_column.name,
+            postprocessing=self.spec.postprocessing,
         )
 
         Parallel(n_jobs=-1, require="sharedmem")(

--- a/ads/opctl/operator/lowcode/forecast/operator_config.py
+++ b/ads/opctl/operator/lowcode/forecast/operator_config.py
@@ -77,6 +77,14 @@ class PreprocessingSteps(DataClassSerializable):
 
 
 @dataclass(repr=True)
+class PostprocessingSteps(DataClassSerializable):
+    """Class representing postprocessing steps for operator."""
+
+    set_min_forecast: int = None
+    set_max_forecast: int = None
+
+
+@dataclass(repr=True)
 class DataPreprocessor(DataClassSerializable):
     """Class representing operator specification preprocessing details."""
 
@@ -110,6 +118,7 @@ class ForecastOperatorSpec(DataClassSerializable):
     local_explanation_filename: str = None
     target_column: str = None
     preprocessing: DataPreprocessor = field(default_factory=DataPreprocessor)
+    postprocessing: PostprocessingSteps = field(default_factory=PostprocessingSteps)
     datetime_column: DateTimeColumn = field(default_factory=DateTimeColumn)
     target_category_columns: List[str] = field(default_factory=list)
     generate_report: bool = None
@@ -145,6 +154,11 @@ class ForecastOperatorSpec(DataClassSerializable):
             self.preprocessing
             if self.preprocessing is not None
             else DataPreprocessor(enabled=True)
+        )
+        self.postprocessing = (
+            self.postprocessing
+            if self.postprocessing is not None
+            else PostprocessingSteps()
         )
         # For Report Generation. When user doesn't specify defaults to True
         self.generate_report = (

--- a/ads/opctl/operator/lowcode/forecast/schema.yaml
+++ b/ads/opctl/operator/lowcode/forecast/schema.yaml
@@ -329,6 +329,21 @@ spec:
               required: false
               default: false
 
+    postprocessing:
+      type: dict
+      required: false
+      schema:
+        set_min_forecast:
+          type: integer
+          required: false
+          meta:
+            description: "This can be used to define the minimum forecast in the output."
+        set_max_forecast:
+          type: integer
+          required: false
+          meta:
+            description: "This can be used to define the maximum forecast in the output."
+
     generate_explanations:
       type: boolean
       required: false


### PR DESCRIPTION
Add post-processing step for forecast clipping

This change introduces a new post-processing step for the forecast operator that allows users to clip the forecast output to a specified minimum and maximum value. This is useful for ensuring that the forecast values remain within a realistic or desirable range.

  This change includes:
   - A new `PostprocessingSteps` configuration to define the min/max clipping values.
   - Updates to the operator schema to expose the new configuration.
   - Implementation of the clipping logic using `numpy.clip`.
   - A new test case to verify the clipping functionality.