### PR TITLE
[AQUA][STMD] Added support to edit stacked model deployment

### DIFF
--- a/ads/aqua/extension/deployment_handler.py
+++ b/ads/aqua/extension/deployment_handler.py
@@ -119,7 +119,15 @@ class AquaDeploymentHandler(AquaAPIhandler):
         if not input_data:
             raise HTTPError(400, Errors.NO_INPUT_DATA)
 
-        self.finish(AquaDeploymentApp().create(**input_data))
+        model_deployment_id = input_data.pop("model_deployment_id", None)
+        if model_deployment_id:
+            self.finish(
+                AquaDeploymentApp().update(
+                    model_deployment_id=model_deployment_id, **input_data
+                )
+            )
+        else:
+            self.finish(AquaDeploymentApp().create(**input_data))
 
     def read(self, id):
         """Read the information of an Aqua model deployment."""

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -1294,6 +1294,8 @@ class AquaDeploymentApp(AquaApp):
                     f"Invalid parameters for updating a model group deployment. Error details: {custom_errors}."
                 ) from ex
 
+        self._validate_input_models(update_model_deployment_details)
+
         model_deployment = ModelDeployment.from_id(model_deployment_id)
 
         infrastructure = model_deployment.infrastructure

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -1294,8 +1294,6 @@ class AquaDeploymentApp(AquaApp):
                     f"Invalid parameters for updating a model group deployment. Error details: {custom_errors}."
                 ) from ex
 
-        self._validate_input_models(update_model_deployment_details)
-
         model_deployment = ModelDeployment.from_id(model_deployment_id)
 
         infrastructure = model_deployment.infrastructure
@@ -1421,6 +1419,8 @@ class AquaDeploymentApp(AquaApp):
                 raise AquaValueError(
                     "Invalid 'models' provided. Only one base model is required for updating model stack deployment."
                 )
+            # validates input base and fine tune models
+            self._validate_input_models(update_model_deployment_details)
             target_stacked_model = update_model_deployment_details.models[0]
             target_base_model_id = target_stacked_model.model_id
             if model_group.base_model_id != target_base_model_id:

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -1305,7 +1305,7 @@ class AquaDeploymentApp(AquaApp):
 
         if not runtime.model_group_id:
             raise AquaValueError(
-                "Invalid `model_deployment_id`. Only model group deployment is supported to update."
+                "Invalid 'model_deployment_id'. Only model group deployment is supported to update."
             )
 
         model = self._update_model_group(
@@ -1402,7 +1402,7 @@ class AquaDeploymentApp(AquaApp):
         model_group_id: str,
         update_model_deployment_details: UpdateModelGroupDeploymentDetails,
     ) -> DataScienceModelGroup:
-        """Creates a new model group if fine tuned weights changes.
+        """Creates a new model group if fine tuned weights changed.
 
         Parameters
         ----------
@@ -1420,11 +1420,15 @@ class AquaDeploymentApp(AquaApp):
         model_group = DataScienceModelGroup.from_id(model_group_id)
         # create a new model group if fine tune weights changed as member models in ds model group is inmutable
         if update_model_deployment_details.models:
+            if len(update_model_deployment_details.models) != 1:
+                raise AquaValueError(
+                    "Invalid 'models' provided. Only one base model is required for updating model stack deployment."
+                )
             target_stacked_model = update_model_deployment_details.models[0]
             target_base_model_id = target_stacked_model.model_id
             if model_group.base_model_id != target_base_model_id:
                 raise AquaValueError(
-                    "Invalid parameter `models`. Base model id can't be changed for stacked model deployment."
+                    "Invalid parameter 'models'. Base model id can't be changed for stacked model deployment."
                 )
 
             # add member models

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -82,6 +82,7 @@ from ads.aqua.modeldeployment.entities import (
     AquaDeploymentDetail,
     ConfigValidationError,
     CreateModelDeploymentDetails,
+    UpdateModelGroupDeploymentDetails,
 )
 from ads.aqua.modeldeployment.model_group_config import ModelGroupConfig
 from ads.aqua.shaperecommend.recommend import AquaShapeRecommend
@@ -109,6 +110,9 @@ from ads.model.deployment import (
     ModelDeploymentContainerRuntime,
     ModelDeploymentInfrastructure,
     ModelDeploymentMode,
+)
+from ads.model.deployment.model_deployment import (
+    ModelDeploymentUpdateType,
 )
 from ads.model.model_metadata import ModelCustomMetadata, ModelCustomMetadataItem
 from ads.telemetry import telemetry
@@ -1246,6 +1250,215 @@ class AquaDeploymentApp(AquaApp):
                 ) from err
 
         return container_type_key
+
+    @telemetry(entry_point="plugin=deployment&action=update", name="aqua")
+    def update(
+        self,
+        model_deployment_id: str,
+        update_model_deployment_details: Optional[
+            UpdateModelGroupDeploymentDetails
+        ] = None,
+        **kwargs,
+    ) -> AquaDeployment:
+        """Updates a AQUA model group deployment.
+
+        Args:
+            update_model_deployment_details : UpdateModelGroupDeploymentDetails, optional
+                An instance of UpdateModelGroupDeploymentDetails containing all optional
+                fields for updating a model deployment via Aqua.
+            kwargs:
+                display_name (str): The name of the model deployment.
+                description (Optional[str]): The description of the deployment.
+                models (Optional[List[AquaMultiModelRef]]): List of models for deployment.
+                instance_count (int): Number of instances used for deployment.
+                log_group_id (Optional[str]): OCI logging group ID for logs.
+                access_log_id (Optional[str]): OCID for access logs.
+                predict_log_id (Optional[str]): OCID for prediction logs.
+                bandwidth_mbps (Optional[int]): Bandwidth limit on the load balancer in Mbps.
+                web_concurrency (Optional[int]): Number of worker processes/threads for handling requests.
+                memory_in_gbs (Optional[float]): Memory (in GB) for the selected shape.
+                ocpus (Optional[float]): OCPU count for the selected shape.
+                private_endpoint_id (Optional[str]): Private endpoint ID for model deployment.
+                freeform_tags (Optional[Dict]): Freeform tags for model deployment.
+                defined_tags (Optional[Dict]): Defined tags for model deployment.
+
+        Returns
+        -------
+        AquaDeployment
+            An Aqua deployment instance.
+        """
+        if not update_model_deployment_details:
+            try:
+                update_model_deployment_details = UpdateModelGroupDeploymentDetails(
+                    **kwargs
+                )
+            except ValidationError as ex:
+                custom_errors = build_pydantic_error_message(ex)
+                raise AquaValueError(
+                    f"Invalid parameters for updating a model group deployment. Error details: {custom_errors}."
+                ) from ex
+
+        model_deployment = ModelDeployment.from_id(model_deployment_id)
+
+        infrastructure = model_deployment.infrastructure
+        runtime = model_deployment.runtime
+
+        if not runtime.model_group_id:
+            raise AquaValueError(
+                "Invalid `model_deployment_id`. Only model group deployment is supported to update."
+            )
+
+        model = self._update_model_group(
+            runtime.model_group_id, update_model_deployment_details
+        )
+
+        (
+            infrastructure.with_bandwidth_mbps(
+                update_model_deployment_details.bandwidth_mbps
+                or infrastructure.bandwidth_mbps
+            )
+            .with_replica(
+                update_model_deployment_details.instance_count or infrastructure.replica
+            )
+            .with_web_concurrency(
+                update_model_deployment_details.web_concurrency
+                or infrastructure.web_concurrency
+            )
+            .with_private_endpoint_id(
+                update_model_deployment_details.private_endpoint_id
+                or infrastructure.private_endpoint_id
+            )
+        )
+
+        if (
+            update_model_deployment_details.log_group_id
+            and update_model_deployment_details.access_log_id
+        ):
+            infrastructure.with_access_log(
+                log_group_id=update_model_deployment_details.log_group_id,
+                log_id=update_model_deployment_details.access_log_id,
+            )
+
+        if (
+            update_model_deployment_details.log_group_id
+            and update_model_deployment_details.predict_log_id
+        ):
+            infrastructure.with_predict_log(
+                log_group_id=update_model_deployment_details.log_group_id,
+                log_id=update_model_deployment_details.predict_log_id,
+            )
+
+        if (
+            update_model_deployment_details.memory_in_gbs
+            and update_model_deployment_details.ocpus
+            and infrastructure.shape_name.endswith("Flex")
+        ):
+            infrastructure.with_shape_config_details(
+                ocpus=update_model_deployment_details.ocpus,
+                memory_in_gbs=update_model_deployment_details.memory_in_gbs,
+            )
+
+        update_type = ModelDeploymentUpdateType.ZDT
+        # applies LIVE update if model group id has been changed
+        if runtime.model_group_id != model.id:
+            runtime.with_model_group_id(model.id)
+            update_type = ModelDeploymentUpdateType.LIVE
+
+        freeform_tags = (
+            update_model_deployment_details.freeform_tags
+            or model_deployment.freeform_tags
+        )
+        defined_tags = (
+            update_model_deployment_details.defined_tags
+            or model_deployment.defined_tags
+        )
+
+        # configure model deployment and deploy model on container runtime
+        (
+            model_deployment.with_display_name(
+                update_model_deployment_details.display_name
+                or model_deployment.display_name
+            )
+            .with_description(
+                update_model_deployment_details.description
+                or model_deployment.description
+            )
+            .with_freeform_tags(**(freeform_tags or {}))
+            .with_defined_tags(**(defined_tags or {}))
+            .with_infrastructure(infrastructure)
+            .with_runtime(runtime)
+        )
+
+        model_deployment.update(wait_for_completion=False, update_type=update_type)
+
+        logger.info(f"Updating Aqua Model Deployment {model_deployment.id}.")
+
+        return AquaDeployment.from_oci_model_deployment(
+            model_deployment.dsc_model_deployment, self.region
+        )
+
+    def _update_model_group(
+        self,
+        model_group_id: str,
+        update_model_deployment_details: UpdateModelGroupDeploymentDetails,
+    ) -> DataScienceModelGroup:
+        """Creates a new model group if fine tuned weights changes.
+
+        Parameters
+        ----------
+        model_group_id: str
+            The model group id.
+        update_model_deployment_details: UpdateModelGroupDeploymentDetails
+            An instance of UpdateModelGroupDeploymentDetails containing all optional
+            fields for updating a model deployment via Aqua.
+
+        Returns
+        -------
+        DataScienceModelGroup
+            The instance of DataScienceModelGroup.
+        """
+        model_group = DataScienceModelGroup.from_id(model_group_id)
+        # create a new model group if fine tune weights changed as member models in ds model group is inmutable
+        if update_model_deployment_details.models:
+            target_stacked_model = update_model_deployment_details.models[0]
+            target_base_model_id = target_stacked_model.model_id
+            if model_group.base_model_id != target_base_model_id:
+                raise AquaValueError(
+                    "Invalid parameter `models`. Base model id can't be changed for stacked model deployment."
+                )
+
+            # add member models
+            member_models = [
+                {
+                    "inference_key": fine_tune_weight.model_name,
+                    "model_id": fine_tune_weight.model_id,
+                }
+                for fine_tune_weight in target_stacked_model.fine_tune_weights
+            ]
+            # add base model
+            member_models.append(
+                {
+                    "inference_key": target_stacked_model.model_name,
+                    "model_id": target_base_model_id,
+                }
+            )
+
+            # creates a model group with the same configurations from original model group except member models
+            model_group = (
+                DataScienceModelGroup()
+                .with_compartment_id(model_group.compartment_id)
+                .with_project_id(model_group.project_id)
+                .with_display_name(model_group.display_name)
+                .with_description(model_group.description)
+                .with_freeform_tags(**(model_group.freeform_tags or {}))
+                .with_defined_tags(**(model_group.defined_tags or {}))
+                .with_custom_metadata_list(model_group.custom_metadata_list)
+                .with_base_model_id(target_base_model_id)
+                .with_member_models(member_models)
+                .create()
+            )
+
+        return model_group
 
     @telemetry(entry_point="plugin=deployment&action=list", name="aqua")
     def list(self, **kwargs) -> List["AquaDeployment"]:

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -1294,8 +1294,6 @@ class AquaDeploymentApp(AquaApp):
                     f"Invalid parameters for updating a model group deployment. Error details: {custom_errors}."
                 ) from ex
 
-        self._validate_input_models(update_model_deployment_details)
-
         model_deployment = ModelDeployment.from_id(model_deployment_id)
 
         infrastructure = model_deployment.infrastructure

--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -1277,7 +1277,6 @@ class AquaDeploymentApp(AquaApp):
                 web_concurrency (Optional[int]): Number of worker processes/threads for handling requests.
                 memory_in_gbs (Optional[float]): Memory (in GB) for the selected shape.
                 ocpus (Optional[float]): OCPU count for the selected shape.
-                private_endpoint_id (Optional[str]): Private endpoint ID for model deployment.
                 freeform_tags (Optional[Dict]): Freeform tags for model deployment.
                 defined_tags (Optional[Dict]): Defined tags for model deployment.
 
@@ -1312,6 +1311,7 @@ class AquaDeploymentApp(AquaApp):
             runtime.model_group_id, update_model_deployment_details
         )
 
+        # updates model group deployment infrastructure
         (
             infrastructure.with_bandwidth_mbps(
                 update_model_deployment_details.bandwidth_mbps
@@ -1370,7 +1370,7 @@ class AquaDeploymentApp(AquaApp):
             or model_deployment.defined_tags
         )
 
-        # configure model deployment and deploy model on container runtime
+        # updates model group deployment
         (
             model_deployment.with_display_name(
                 update_model_deployment_details.display_name

--- a/ads/aqua/modeldeployment/entities.py
+++ b/ads/aqua/modeldeployment/entities.py
@@ -749,3 +749,54 @@ class CreateModelDeploymentDetails(BaseModel):
     class Config:
         extra = "allow"
         protected_namespaces = ()
+
+
+class UpdateModelGroupDeploymentDetails(BaseModel):
+    """Class for updating Aqua model deployments."""
+
+    display_name: Optional[str] = Field(
+        None, description="The name of the model deployment."
+    )
+    description: Optional[str] = Field(
+        None, description="The description of the deployment."
+    )
+    models: Optional[List[AquaMultiModelRef]] = Field(
+        None, description="List of models for multimodel deployment."
+    )
+    instance_count: Optional[int] = Field(
+        None, description="Number of instances used for deployment."
+    )
+    log_group_id: Optional[str] = Field(
+        None, description="OCI logging group ID for logs."
+    )
+    access_log_id: Optional[str] = Field(
+        None,
+        description="OCID for access logs. "
+        "https://docs.oracle.com/en-us/iaas/data-science/using/model_dep_using_logging.htm",
+    )
+    predict_log_id: Optional[str] = Field(
+        None,
+        description="OCID for prediction logs."
+        "https://docs.oracle.com/en-us/iaas/data-science/using/model_dep_using_logging.htm",
+    )
+    bandwidth_mbps: Optional[int] = Field(
+        None, description="Bandwidth limit on the load balancer in Mbps."
+    )
+    web_concurrency: Optional[int] = Field(
+        None, description="Number of worker processes/threads for handling requests."
+    )
+    memory_in_gbs: Optional[float] = Field(
+        None, description="Memory (in GB) for the selected shape."
+    )
+    ocpus: Optional[float] = Field(
+        None, description="OCPU count for the selected shape."
+    )
+    private_endpoint_id: Optional[str] = Field(
+        None, description="Private endpoint ID for model deployment."
+    )
+    freeform_tags: Optional[Dict] = Field(
+        None, description="Freeform tags for model deployment."
+    )
+    defined_tags: Optional[Dict] = Field(
+        None, description="Defined tags for model deployment."
+    )

--- a/ads/aqua/modeldeployment/entities.py
+++ b/ads/aqua/modeldeployment/entities.py
@@ -800,3 +800,7 @@ class UpdateModelGroupDeploymentDetails(BaseModel):
     defined_tags: Optional[Dict] = Field(
         None, description="Defined tags for model deployment."
     )
+
+    class Config:
+        extra = "allow"
+        protected_namespaces = ()

--- a/ads/aqua/modeldeployment/entities.py
+++ b/ads/aqua/modeldeployment/entities.py
@@ -251,27 +251,19 @@ class AquaDeploymentDetail(AquaDeployment, DataClassSerializable):
         extra = "allow"
 
 
-class CreateModelDeploymentDetails(BaseModel):
-    """Class for creating Aqua model deployments."""
+class ModelDeploymentDetails(BaseModel):
+    """Class for the base details of creating and updating Aqua model deployments."""
 
-    instance_shape: str = Field(
-        ..., description="The instance shape used for deployment."
+    display_name: Optional[str] = Field(
+        None, description="The name of the model deployment."
     )
-    display_name: str = Field(..., description="The name of the model deployment.")
-    compartment_id: Optional[str] = Field(None, description="The compartment OCID.")
-    project_id: Optional[str] = Field(None, description="The project OCID.")
     description: Optional[str] = Field(
         None, description="The description of the deployment."
     )
-    model_id: Optional[str] = Field(None, description="The model OCID to deploy.")
-    model_name: Optional[str] = Field(
-        None, description="The model name specified by user to deploy."
-    )
-
     models: Optional[List[AquaMultiModelRef]] = Field(
-        None, description="List of models for multimodel deployment."
+        None, description="List of models for multimodel or stacked deployment."
     )
-    instance_count: int = Field(
+    instance_count: Optional[int] = Field(
         None, description="Number of instances used for deployment."
     )
     log_group_id: Optional[str] = Field(
@@ -293,39 +285,11 @@ class CreateModelDeploymentDetails(BaseModel):
     web_concurrency: Optional[int] = Field(
         None, description="Number of worker processes/threads for handling requests."
     )
-    server_port: Optional[int] = Field(
-        None, description="Server port for the Docker container image."
-    )
-    health_check_port: Optional[int] = Field(
-        None, description="Health check port for the Docker container image."
-    )
-    env_var: Optional[Dict[str, str]] = Field(
-        default_factory=dict, description="Environment variables for deployment."
-    )
-    container_family: Optional[str] = Field(
-        None, description="Image family of the model deployment container runtime."
-    )
     memory_in_gbs: Optional[float] = Field(
         None, description="Memory (in GB) for the selected shape."
     )
     ocpus: Optional[float] = Field(
         None, description="OCPU count for the selected shape."
-    )
-    model_file: Optional[str] = Field(
-        None, description="File used for model deployment."
-    )
-    private_endpoint_id: Optional[str] = Field(
-        None, description="Private endpoint ID for model deployment."
-    )
-    container_image_uri: Optional[str] = Field(
-        None,
-        description="Image URI for model deployment container runtime "
-        "(ignored for service-managed containers). "
-        "Required parameter for BYOC based deployments if this parameter was not set during "
-        "model registration.",
-    )
-    cmd_var: Optional[List[str]] = Field(
-        None, description="Command variables for the container runtime."
     )
     freeform_tags: Optional[Dict] = Field(
         None, description="Freeform tags for model deployment."
@@ -333,187 +297,6 @@ class CreateModelDeploymentDetails(BaseModel):
     defined_tags: Optional[Dict] = Field(
         None, description="Defined tags for model deployment."
     )
-    deployment_type: Optional[str] = Field(
-        None, description="The type of model deployment."
-    )
-
-    @model_validator(mode="before")
-    @classmethod
-    def validate(cls, values: Any) -> Any:
-        """Ensures exactly one of `model_id` or `models` is provided."""
-        model_id = values.get("model_id")
-        models = values.get("models")
-        if bool(model_id) == bool(models):  # Both set or both unset
-            raise ValueError(
-                "Exactly one of `model_id` or `models` must be provided to create a model deployment."
-            )
-        return values
-
-    def validate_multimodel_deployment_feasibility(
-        self, models_config_summary: ModelDeploymentConfigSummary
-    ) -> None:
-        """
-        Validates whether the selected model group is feasible for a multi-model deployment
-        on the chosen instance shape.
-
-        Validation Criteria:
-        - Ensures that the model group is not empty.
-        - Verifies that the selected instance shape is supported by the GPU allocation.
-        - Confirms that each model in the group has a corresponding deployment configuration.
-        - Ensures that each model's user-specified GPU allocation is allowed by its deployment configuration.
-        - Checks that the total GPUs requested by the model group does not exceed the available GPU capacity
-            for the selected instance shape.
-
-        Parameters
-        ----------
-        models_config_summary : ModelDeploymentConfigSummary
-            Contains GPU allocations and deployment configuration for models.
-
-        Raises
-        ------
-        ConfigValidationError:
-        - If the model group is empty.
-        - If the selected instance shape is not supported.
-        - If any model is missing from the deployment configuration.
-        - If a model's GPU allocation does not match any valid configuration.
-        - If the total requested GPUs exceed the instance shape’s capacity.
-        """
-        # Ensure that at least one model is provided.
-        if not self.models:
-            logger.error("No models provided in the model group.")
-            raise ConfigValidationError(
-                "Multi-model deployment requires at least one model. Please provide one or more models."
-            )
-
-        selected_shape = self.instance_shape
-
-        if models_config_summary.error_message:
-            logger.error(models_config_summary.error_message)
-            raise ConfigValidationError(models_config_summary.error_message)
-
-        # Verify that the selected shape is supported by the GPU allocation.
-        if selected_shape not in models_config_summary.gpu_allocation:
-            supported_shapes = list(models_config_summary.gpu_allocation.keys())
-            error_message = (
-                f"The model group is not compatible with the selected instance shape `{selected_shape}`. "
-                f"Supported shapes: {supported_shapes}."
-            )
-            logger.error(error_message)
-            raise ConfigValidationError(error_message)
-
-        total_available_gpus: int = models_config_summary.gpu_allocation[
-            selected_shape
-        ].total_gpus_available
-        model_deployment_config = models_config_summary.deployment_config
-
-        # Verify that every model in the group has a corresponding deployment configuration.
-        required_model_ids = {model.model_id for model in self.models}
-        missing_model_ids = required_model_ids - set(model_deployment_config.keys())
-        if missing_model_ids:
-            error_message = (
-                f"Missing deployment configuration for models: {list(missing_model_ids)}. "
-                "Ensure all selected models are properly configured. If you are deploying custom "
-                "models that lack AQUA service configuration, refer to the deployment guidelines here: "
-                "https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/multimodel-deployment-tips.md#custom_models"
-            )
-            logger.error(error_message)
-            raise ConfigValidationError(error_message)
-
-        sum_model_gpus = 0
-        is_single_model = len(self.models) == 1
-
-        # Validate each model's GPU allocation against its deployment configuration.
-        for model in self.models:
-            sum_model_gpus += model.gpu_count
-            aqua_deployment_config = model_deployment_config[model.model_id]
-
-            # Skip validation for models without deployment configuration details.
-            if not aqua_deployment_config.configuration:
-                error_message = (
-                    f"Missing deployment configuration for model `{model.model_id}`. "
-                    "Please verify that the model is correctly configured. If you are deploying custom models without AQUA service configuration, "
-                    "refer to the guidelines at: "
-                    "https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/multimodel-deployment-tips.md#custom_models"
-                )
-
-                logger.error(error_message)
-                raise ConfigValidationError(error_message)
-
-            allowed_shapes = (
-                list(
-                    set(aqua_deployment_config.configuration.keys()).union(
-                        set(aqua_deployment_config.shape or [])
-                    )
-                )
-                if is_single_model
-                else list(aqua_deployment_config.configuration.keys())
-            )
-
-            if selected_shape not in allowed_shapes:
-                error_message = (
-                    f"Model `{model.model_id}` is not compatible with the selected instance shape `{selected_shape}`. "
-                    f"Select a different instance shape from allowed shapes {allowed_shapes}."
-                )
-                logger.error(error_message)
-                raise ConfigValidationError(error_message)
-
-            # Retrieve valid GPU counts for the selected shape.
-            multi_model_configs = aqua_deployment_config.configuration.get(
-                selected_shape, ConfigurationItem()
-            ).multi_model_deployment
-
-            valid_gpu_configurations = [cfg.gpu_count for cfg in multi_model_configs]
-
-            if model.gpu_count not in valid_gpu_configurations:
-                valid_gpu_str = valid_gpu_configurations or []
-
-                if is_single_model:
-                    # If total GPU allocation is not supported by selected model
-                    if selected_shape not in aqua_deployment_config.shape:
-                        error_message = (
-                            f"Model `{model.model_id}` is configured with {model.gpu_count} GPU(s), "
-                            f"which is invalid. The allowed GPU configurations are: {valid_gpu_str}."
-                        )
-                        logger.error(error_message)
-                        raise ConfigValidationError(error_message)
-
-                    if model.gpu_count != total_available_gpus:
-                        error_message = (
-                            f"Model '{model.model_id}' is configured to use {model.gpu_count} GPU(s), "
-                            f"which not fully utilize the selected instance shape with {total_available_gpus} available GPU(s). "
-                            "Consider adjusting the GPU allocation to better utilize the available resources and maximize performance."
-                        )
-                        logger.error(error_message)
-                        raise ConfigValidationError(error_message)
-
-                else:
-                    error_message = (
-                        f"Model `{model.model_id}` is configured with {model.gpu_count} GPU(s), which is invalid. "
-                        f"Valid GPU configurations are: {valid_gpu_str}. Please adjust the GPU allocation "
-                        f"or choose an instance shape that supports a higher GPU count."
-                    )
-                    logger.error(error_message)
-                    raise ConfigValidationError(error_message)
-
-        if sum_model_gpus < total_available_gpus:
-            error_message = (
-                f"Selected models are configured to use {sum_model_gpus} GPU(s), "
-                f"which not fully utilize the selected instance shape with {total_available_gpus} available GPU(s). "
-                "This configuration may lead to suboptimal performance for a multi-model deployment. "
-                "Consider adjusting the GPU allocation to better utilize the available resources and maximize performance."
-            )
-            logger.warning(error_message)
-            # raise ConfigValidationError(error_message)
-
-        # Check that the total GPU count for the model group does not exceed the instance capacity.
-        if sum_model_gpus > total_available_gpus:
-            error_message = (
-                f"The selected instance shape `{selected_shape}` provides `{total_available_gpus}` GPU(s), "
-                f"but the total GPU allocation required by the model group is `{sum_model_gpus}` GPU(s). "
-                "Please adjust the GPU allocation per model or choose an instance shape with greater GPU capacity."
-            )
-            logger.error(error_message)
-            raise ConfigValidationError(error_message)
 
     def validate_input_models(self, model_details: Dict[str, DataScienceModel]) -> None:
         """
@@ -750,57 +533,237 @@ class CreateModelDeploymentDetails(BaseModel):
         extra = "allow"
         protected_namespaces = ()
 
+class CreateModelDeploymentDetails(ModelDeploymentDetails):
+    """Class for creating Aqua model deployments."""
 
-class UpdateModelGroupDeploymentDetails(BaseModel):
-    """Class for updating Aqua model deployments."""
-
-    display_name: Optional[str] = Field(
-        None, description="The name of the model deployment."
+    instance_shape: str = Field(
+        ..., description="The instance shape used for deployment."
     )
-    description: Optional[str] = Field(
-        None, description="The description of the deployment."
+    compartment_id: Optional[str] = Field(None, description="The compartment OCID.")
+    project_id: Optional[str] = Field(None, description="The project OCID.")
+    model_id: Optional[str] = Field(None, description="The model OCID to deploy.")
+    model_name: Optional[str] = Field(
+        None, description="The model name specified by user to deploy."
     )
-    models: Optional[List[AquaMultiModelRef]] = Field(
-        None, description="List of models for multimodel deployment."
+    server_port: Optional[int] = Field(
+        None, description="Server port for the Docker container image."
     )
-    instance_count: Optional[int] = Field(
-        None, description="Number of instances used for deployment."
+    health_check_port: Optional[int] = Field(
+        None, description="Health check port for the Docker container image."
     )
-    log_group_id: Optional[str] = Field(
-        None, description="OCI logging group ID for logs."
+    env_var: Optional[Dict[str, str]] = Field(
+        default_factory=dict, description="Environment variables for deployment."
     )
-    access_log_id: Optional[str] = Field(
+    container_family: Optional[str] = Field(
+        None, description="Image family of the model deployment container runtime."
+    )
+    model_file: Optional[str] = Field(
+        None, description="File used for model deployment."
+    )
+    container_image_uri: Optional[str] = Field(
         None,
-        description="OCID for access logs. "
-        "https://docs.oracle.com/en-us/iaas/data-science/using/model_dep_using_logging.htm",
-    )
-    predict_log_id: Optional[str] = Field(
-        None,
-        description="OCID for prediction logs."
-        "https://docs.oracle.com/en-us/iaas/data-science/using/model_dep_using_logging.htm",
-    )
-    bandwidth_mbps: Optional[int] = Field(
-        None, description="Bandwidth limit on the load balancer in Mbps."
-    )
-    web_concurrency: Optional[int] = Field(
-        None, description="Number of worker processes/threads for handling requests."
-    )
-    memory_in_gbs: Optional[float] = Field(
-        None, description="Memory (in GB) for the selected shape."
-    )
-    ocpus: Optional[float] = Field(
-        None, description="OCPU count for the selected shape."
+        description="Image URI for model deployment container runtime "
+        "(ignored for service-managed containers). "
+        "Required parameter for BYOC based deployments if this parameter was not set during "
+        "model registration.",
     )
     private_endpoint_id: Optional[str] = Field(
         None, description="Private endpoint ID for model deployment."
     )
-    freeform_tags: Optional[Dict] = Field(
-        None, description="Freeform tags for model deployment."
+    cmd_var: Optional[List[str]] = Field(
+        None, description="Command variables for the container runtime."
     )
-    defined_tags: Optional[Dict] = Field(
-        None, description="Defined tags for model deployment."
+    deployment_type: Optional[str] = Field(
+        None, description="The type of model deployment."
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate(cls, values: Any) -> Any:
+        """Ensures exactly one of `model_id` or `models` is provided."""
+        model_id = values.get("model_id")
+        models = values.get("models")
+        if bool(model_id) == bool(models):  # Both set or both unset
+            raise ValueError(
+                "Exactly one of `model_id` or `models` must be provided to create a model deployment."
+            )
+        return values
+
+    def validate_multimodel_deployment_feasibility(
+        self, models_config_summary: ModelDeploymentConfigSummary
+    ) -> None:
+        """
+        Validates whether the selected model group is feasible for a multi-model deployment
+        on the chosen instance shape.
+
+        Validation Criteria:
+        - Ensures that the model group is not empty.
+        - Verifies that the selected instance shape is supported by the GPU allocation.
+        - Confirms that each model in the group has a corresponding deployment configuration.
+        - Ensures that each model's user-specified GPU allocation is allowed by its deployment configuration.
+        - Checks that the total GPUs requested by the model group does not exceed the available GPU capacity
+            for the selected instance shape.
+
+        Parameters
+        ----------
+        models_config_summary : ModelDeploymentConfigSummary
+            Contains GPU allocations and deployment configuration for models.
+
+        Raises
+        ------
+        ConfigValidationError:
+        - If the model group is empty.
+        - If the selected instance shape is not supported.
+        - If any model is missing from the deployment configuration.
+        - If a model's GPU allocation does not match any valid configuration.
+        - If the total requested GPUs exceed the instance shape’s capacity.
+        """
+        # Ensure that at least one model is provided.
+        if not self.models:
+            logger.error("No models provided in the model group.")
+            raise ConfigValidationError(
+                "Multi-model deployment requires at least one model. Please provide one or more models."
+            )
+
+        selected_shape = self.instance_shape
+
+        if models_config_summary.error_message:
+            logger.error(models_config_summary.error_message)
+            raise ConfigValidationError(models_config_summary.error_message)
+
+        # Verify that the selected shape is supported by the GPU allocation.
+        if selected_shape not in models_config_summary.gpu_allocation:
+            supported_shapes = list(models_config_summary.gpu_allocation.keys())
+            error_message = (
+                f"The model group is not compatible with the selected instance shape `{selected_shape}`. "
+                f"Supported shapes: {supported_shapes}."
+            )
+            logger.error(error_message)
+            raise ConfigValidationError(error_message)
+
+        total_available_gpus: int = models_config_summary.gpu_allocation[
+            selected_shape
+        ].total_gpus_available
+        model_deployment_config = models_config_summary.deployment_config
+
+        # Verify that every model in the group has a corresponding deployment configuration.
+        required_model_ids = {model.model_id for model in self.models}
+        missing_model_ids = required_model_ids - set(model_deployment_config.keys())
+        if missing_model_ids:
+            error_message = (
+                f"Missing deployment configuration for models: {list(missing_model_ids)}. "
+                "Ensure all selected models are properly configured. If you are deploying custom "
+                "models that lack AQUA service configuration, refer to the deployment guidelines here: "
+                "https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/multimodel-deployment-tips.md#custom_models"
+            )
+            logger.error(error_message)
+            raise ConfigValidationError(error_message)
+
+        sum_model_gpus = 0
+        is_single_model = len(self.models) == 1
+
+        # Validate each model's GPU allocation against its deployment configuration.
+        for model in self.models:
+            sum_model_gpus += model.gpu_count
+            aqua_deployment_config = model_deployment_config[model.model_id]
+
+            # Skip validation for models without deployment configuration details.
+            if not aqua_deployment_config.configuration:
+                error_message = (
+                    f"Missing deployment configuration for model `{model.model_id}`. "
+                    "Please verify that the model is correctly configured. If you are deploying custom models without AQUA service configuration, "
+                    "refer to the guidelines at: "
+                    "https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/multimodel-deployment-tips.md#custom_models"
+                )
+
+                logger.error(error_message)
+                raise ConfigValidationError(error_message)
+
+            allowed_shapes = (
+                list(
+                    set(aqua_deployment_config.configuration.keys()).union(
+                        set(aqua_deployment_config.shape or [])
+                    )
+                )
+                if is_single_model
+                else list(aqua_deployment_config.configuration.keys())
+            )
+
+            if selected_shape not in allowed_shapes:
+                error_message = (
+                    f"Model `{model.model_id}` is not compatible with the selected instance shape `{selected_shape}`. "
+                    f"Select a different instance shape from allowed shapes {allowed_shapes}."
+                )
+                logger.error(error_message)
+                raise ConfigValidationError(error_message)
+
+            # Retrieve valid GPU counts for the selected shape.
+            multi_model_configs = aqua_deployment_config.configuration.get(
+                selected_shape, ConfigurationItem()
+            ).multi_model_deployment
+
+            valid_gpu_configurations = [cfg.gpu_count for cfg in multi_model_configs]
+
+            if model.gpu_count not in valid_gpu_configurations:
+                valid_gpu_str = valid_gpu_configurations or []
+
+                if is_single_model:
+                    # If total GPU allocation is not supported by selected model
+                    if selected_shape not in aqua_deployment_config.shape:
+                        error_message = (
+                            f"Model `{model.model_id}` is configured with {model.gpu_count} GPU(s), "
+                            f"which is invalid. The allowed GPU configurations are: {valid_gpu_str}."
+                        )
+                        logger.error(error_message)
+                        raise ConfigValidationError(error_message)
+
+                    if model.gpu_count != total_available_gpus:
+                        error_message = (
+                            f"Model '{model.model_id}' is configured to use {model.gpu_count} GPU(s), "
+                            f"which not fully utilize the selected instance shape with {total_available_gpus} available GPU(s). "
+                            "Consider adjusting the GPU allocation to better utilize the available resources and maximize performance."
+                        )
+                        logger.error(error_message)
+                        raise ConfigValidationError(error_message)
+
+                else:
+                    error_message = (
+                        f"Model `{model.model_id}` is configured with {model.gpu_count} GPU(s), which is invalid. "
+                        f"Valid GPU configurations are: {valid_gpu_str}. Please adjust the GPU allocation "
+                        f"or choose an instance shape that supports a higher GPU count."
+                    )
+                    logger.error(error_message)
+                    raise ConfigValidationError(error_message)
+
+        if sum_model_gpus < total_available_gpus:
+            error_message = (
+                f"Selected models are configured to use {sum_model_gpus} GPU(s), "
+                f"which not fully utilize the selected instance shape with {total_available_gpus} available GPU(s). "
+                "This configuration may lead to suboptimal performance for a multi-model deployment. "
+                "Consider adjusting the GPU allocation to better utilize the available resources and maximize performance."
+            )
+            logger.warning(error_message)
+            # raise ConfigValidationError(error_message)
+
+        # Check that the total GPU count for the model group does not exceed the instance capacity.
+        if sum_model_gpus > total_available_gpus:
+            error_message = (
+                f"The selected instance shape `{selected_shape}` provides `{total_available_gpus}` GPU(s), "
+                f"but the total GPU allocation required by the model group is `{sum_model_gpus}` GPU(s). "
+                "Please adjust the GPU allocation per model or choose an instance shape with greater GPU capacity."
+            )
+            logger.error(error_message)
+            raise ConfigValidationError(error_message)
 
     class Config:
         extra = "allow"
+        protected_namespaces = ()
+
+
+class UpdateModelDeploymentDetails(ModelDeploymentDetails):
+    """Class for updating Aqua model deployments."""
+
+    class Config:
+        # forbid any other parameter for updating model group deployment
+        extra = "forbid"
         protected_namespaces = ()

--- a/ads/model/deployment/model_deployment.py
+++ b/ads/model/deployment/model_deployment.py
@@ -1580,12 +1580,15 @@ class ModelDeployment(Builder):
             self.infrastructure.CONST_CATEGORY_LOG_DETAILS: self._build_category_log_details(),
         }
 
-        update_model_deployment_details[
-            self.infrastructure.CONST_MODEL_DEPLOYMENT_CONFIG_DETAILS
-        ][self.CONST_UPDATE_TYPE] = update_type
-        return UpdateModelDeploymentDetails(
-            **ads_utils.batch_convert_case(update_model_deployment_details, "snake")
+        dsc_update_model_deployment_details: UpdateModelDeploymentDetails = (
+            OCIDataScienceModelDeployment(
+                **update_model_deployment_details
+            ).to_oci_model(UpdateModelDeploymentDetails)
         )
+
+        dsc_update_model_deployment_details.model_deployment_configuration_details.update_type = update_type
+
+        return dsc_update_model_deployment_details
 
     def _update_spec(self, **kwargs) -> "ModelDeployment":
         """Updates model deployment specs from kwargs.

--- a/ads/model/deployment/model_deployment_infrastructure.py
+++ b/ads/model/deployment/model_deployment_infrastructure.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
-# -*- coding: utf-8; -*-
 
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2025 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/from typing import Dict
 
 
@@ -187,19 +186,44 @@ class ModelDeploymentInfrastructure(Builder):
         "model_deployment_configuration_details.model_configuration_details"
     )
 
+    MODEL_INFRA_CONFIG_DETAILS_PATH = (
+        "model_deployment_configuration_details.infrastructure_configuration_details"
+    )
+
     payload_attribute_map = {
         CONST_PROJECT_ID: "project_id",
         CONST_COMPARTMENT_ID: "compartment_id",
-        CONST_SHAPE_NAME: f"{MODEL_CONFIG_DETAILS_PATH}.instance_configuration.instance_shape_name",
-        CONST_SHAPE_CONFIG_DETAILS: f"{MODEL_CONFIG_DETAILS_PATH}.instance_configuration.model_deployment_instance_shape_config_details",
-        CONST_SUBNET_ID: f"{MODEL_CONFIG_DETAILS_PATH}.instance_configuration.subnet_id",
-        CONST_PRIVATE_ENDPOINT_ID: f"{MODEL_CONFIG_DETAILS_PATH}.instance_configuration.private_endpoint_id",
-        CONST_REPLICA: f"{MODEL_CONFIG_DETAILS_PATH}.scaling_policy.instance_count",
-        CONST_BANDWIDTH_MBPS: f"{MODEL_CONFIG_DETAILS_PATH}.bandwidth_mbps",
+        CONST_SHAPE_NAME: [
+            f"{MODEL_CONFIG_DETAILS_PATH}.instance_configuration.instance_shape_name",
+            f"{MODEL_INFRA_CONFIG_DETAILS_PATH}.instance_configuration.instance_shape_name",
+        ],
+        CONST_SHAPE_CONFIG_DETAILS: [
+            f"{MODEL_CONFIG_DETAILS_PATH}.instance_configuration.model_deployment_instance_shape_config_details",
+            f"{MODEL_INFRA_CONFIG_DETAILS_PATH}.instance_configuration.model_deployment_instance_shape_config_details",
+        ],
+        CONST_SUBNET_ID: [
+            f"{MODEL_CONFIG_DETAILS_PATH}.instance_configuration.subnet_id",
+            f"{MODEL_INFRA_CONFIG_DETAILS_PATH}.instance_configuration.subnet_id",
+        ],
+        CONST_PRIVATE_ENDPOINT_ID: [
+            f"{MODEL_CONFIG_DETAILS_PATH}.instance_configuration.private_endpoint_id",
+            f"{MODEL_INFRA_CONFIG_DETAILS_PATH}.instance_configuration.private_endpoint_id",
+        ],
+        CONST_REPLICA: [
+            f"{MODEL_CONFIG_DETAILS_PATH}.scaling_policy.instance_count",
+            f"{MODEL_INFRA_CONFIG_DETAILS_PATH}.scaling_policy.instance_count",
+        ],
+        CONST_BANDWIDTH_MBPS: [
+            f"{MODEL_CONFIG_DETAILS_PATH}.bandwidth_mbps",
+            f"{MODEL_INFRA_CONFIG_DETAILS_PATH}.bandwidth_mbps",
+        ],
         CONST_ACCESS_LOG: "category_log_details.access",
         CONST_PREDICT_LOG: "category_log_details.predict",
         CONST_DEPLOYMENT_TYPE: "model_deployment_configuration_details.deployment_type",
-        CONST_POLICY_TYPE: f"{MODEL_CONFIG_DETAILS_PATH}.scaling_policy.policy_type",
+        CONST_POLICY_TYPE: [
+            f"{MODEL_CONFIG_DETAILS_PATH}.scaling_policy.policy_type",
+            f"{MODEL_INFRA_CONFIG_DETAILS_PATH}.scaling_policy.policy_type",
+        ],
     }
 
     sub_level_attribute_maps = {
@@ -621,7 +645,9 @@ class ModelDeploymentInfrastructure(Builder):
         """
         return self.get_spec(self.CONST_SUBNET_ID, None)
 
-    def with_private_endpoint_id(self, private_endpoint_id: str) -> "ModelDeploymentInfrastructure":
+    def with_private_endpoint_id(
+        self, private_endpoint_id: str
+    ) -> "ModelDeploymentInfrastructure":
         """Sets the private endpoint id of model deployment.
 
         Parameters

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -246,6 +246,74 @@ class TestDataset:
         }
     ]
 
+    stack_model_deployment_object = {
+        "category_log_details": oci.data_science.models.CategoryLogDetails(
+            **{
+                "access": oci.data_science.models.LogDetails(
+                    **{
+                        "log_group_id": "ocid1.loggroup.oc1.<region>.<OCID>",
+                        "log_id": "ocid1.log.oc1.<region>.<OCID>",
+                    }
+                ),
+                "predict": oci.data_science.models.LogDetails(
+                    **{
+                        "log_group_id": "ocid1.loggroup.oc1.<region>.<OCID>",
+                        "log_id": "ocid1.log.oc1.<region>.<OCID>",
+                    }
+                ),
+            }
+        ),
+        "compartment_id": "ocid1.compartment.oc1..<OCID>",
+        "created_by": "ocid1.user.oc1..<OCID>",
+        "defined_tags": {},
+        "description": "Mock description",
+        "display_name": "model-deployment-name",
+        "freeform_tags": {"OCI_AQUA": "active", "aqua_model_name": "model-name"},
+        "id": "ocid1.datasciencemodeldeployment.oc1.<region>.<MD_OCID>",
+        "lifecycle_state": "ACTIVE",
+        "model_deployment_configuration_details": oci.data_science.models.ModelGroupDeploymentConfigurationDetails(
+            **{
+                "deployment_type": "MODEL_GROUP",
+                "environment_configuration_details": oci.data_science.models.OcirModelDeploymentEnvironmentConfigurationDetails(
+                    **{
+                        "cmd": [],
+                        "entrypoint": [],
+                        "environment_configuration_type": "OCIR_CONTAINER",
+                        "environment_variables": {
+                            "BASE_MODEL": "service_models/model-name/artifact",
+                            "MODEL_DEPLOY_PREDICT_ENDPOINT": "/v1/completions",
+                            "PARAMS": "--served-model-name custom_base_name odsc-llm --seed 42 --max-lora-rank 32 --enable_lora",
+                        },
+                        "health_check_port": 8080,
+                        "image": "dsmc://image-name:1.0.0.0",
+                        "image_digest": "sha256:mock22373c16f2015f6f33c5c8553923cf8520217da0bd9504471c5e53cbc9d",
+                        "server_port": 8080,
+                    }
+                ),
+                "infrastructure_configuration_details": oci.data_science.models.InstancePoolInfrastructureConfigurationDetails(
+                    **{
+                        "bandwidth_mbps": 10,
+                        "instance_configuration": oci.data_science.models.InstanceConfiguration(
+                            **{
+                                "instance_shape_name": DEPLOYMENT_SHAPE_NAME,
+                                "model_deployment_instance_shape_config_details": null,
+                            }
+                        ),
+                        "scaling_policy": oci.data_science.models.FixedSizeScalingPolicy(
+                            **{"instance_count": 1, "policy_type": "FIXED_SIZE"}
+                        ),
+                    }
+                ),
+                "model_group_configuration_details": oci.data_science.models.ModelGroupConfigurationDetails(
+                    model_group_id="ocid1.datasciencemodelgroupint.oc1.<region>.<OCID>"
+                ),
+            }
+        ),
+        "model_deployment_url": MODEL_DEPLOYMENT_URL,
+        "project_id": USER_PROJECT_ID,
+        "time_created": "2024-01-01T00:00:00.000000+00:00",
+    }
+
     multi_model_deployment_object = {
         "category_log_details": oci.data_science.models.CategoryLogDetails(
             **{
@@ -1117,9 +1185,13 @@ class TestDataset:
         ),
         "memberModels": [
             {
+                "inference_key": "custom_base_key",
+                "model_id": "ocid1.datasciencemodel.oc1.iad.<OCID>",
+            },
+            {
                 "inference_key": "custom_inference_key",
                 "model_id": "ocid1.datasciencemodel.oc1.iad.<OCID>",
-            }
+            },
         ],
     }
 
@@ -2141,6 +2213,81 @@ class TestAquaDeployment(unittest.TestCase):
         expected_result = copy.deepcopy(TestDataset.aqua_multi_deployment_object)
         expected_result["state"] = "CREATING"
         assert actual_attributes == expected_result
+
+    @patch("ads.model.deployment.ModelDeployment.update")
+    @patch.object(DataScienceModelGroup, "create")
+    @patch.object(DataScienceModelGroup, "from_id")
+    @patch("ads.model.deployment.ModelDeployment.from_id")
+    @patch("ads.aqua.modeldeployment.AquaDeploymentApp._validate_input_models")
+    def test_update_model_group_deployment(
+        self,
+        mock_validate_input_models,
+        mock_deployment_from_id,
+        mock_model_group_from_id,
+        mock_model_group_create,
+        mock_update,
+    ):
+        model_deployment_dsc_obj = copy.deepcopy(
+            TestDataset.stack_model_deployment_object
+        )
+        model_deployment_dsc_obj["lifecycle_state"] = "UPDATING"
+
+        aqua_deployment = os.path.join(
+            self.curr_dir, "test_data/deployment/aqua_create_deployment.yaml"
+        )
+        model_deployment_obj = ModelDeployment.from_yaml(uri=aqua_deployment)
+        model_deployment_obj.runtime.set_spec(
+            model_deployment_obj.runtime.CONST_MODEL_GROUP_ID,
+            "ocid1.datasciencemodelgroup.oc1.iad.<OCID>",
+        )
+        model_deployment_obj.dsc_model_deployment = (
+            oci.data_science.models.ModelDeploymentSummary(**model_deployment_dsc_obj)
+        )
+        model_deployment_obj.dsc_model_deployment.workflow_req_id = "workflow_req_id"
+        mock_deployment_from_id.return_value = model_deployment_obj
+
+        aqua_model_group = DataScienceModelGroup(
+            spec=TestDataset.aqua_deployment_stack_model
+        )
+        aqua_model_group.set_spec(
+            aqua_model_group.CONST_BASE_MODEL_ID,
+            "ocid1.datasciencemodel.oc1.iad.<OCID>",
+        )
+        mock_model_group_from_id.return_value = aqua_model_group
+
+        updated_aqua_model_group = copy.deepcopy(aqua_model_group)
+        updated_aqua_model_group.set_spec(
+            updated_aqua_model_group.CONST_ID,
+            "ocid1.datasciencemodelgroup.oc1.iad.<UPDATED_OCID>",
+        )
+        mock_model_group_create.return_value = updated_aqua_model_group
+
+        mock_update.return_value = model_deployment_obj
+
+        ft_weights = [
+            LoraModuleSpec(
+                model_id="ocid1.datasciencemodel.oc1..<FT_OCID>",
+                model_name="ft_model",
+            )
+        ]
+        model_info = AquaMultiModelRef(
+            model_id="ocid1.datasciencemodel.oc1.iad.<OCID>",
+            model_name="test_model",
+            model_task="code_synthesis",
+            gpu_count=2,
+            fine_tune_weights=ft_weights,
+        )
+
+        self.app.update(
+            model_deployment_id="ocid1.datasciencemodeldeployment.oc1.<region>.<MD_OCID>",
+            display_name="updated display name",
+            description="updated description",
+            models=[model_info],
+        )
+
+        mock_validate_input_models.assert_called()
+        mock_model_group_create.assert_called()
+        mock_update.assert_called_with(wait_for_completion=False, update_type="LIVE")
 
     @parameterized.expand(
         [


### PR DESCRIPTION
### Added support to edit stacked model deployment

- Added `update` method in `AquaDeploymentApp` to support updating model group deployment.

```
ads aqua deployment update --model_deployment_id <model_deployment_id> \
--display_name <display_name> \
--description <description> \
--models '[
    {
      "model_id": "ocid1.log.oc1.iad.<ocid>",
      "gpu_count": 1,
      "model_name": "meta-llama/Meta-Llama-3.1-8B",
      "model_task": "text_generation",
      "fine_tune_weights": [
        {
          "model_id": "ocid1.datasciencemodel.oc1.iad.<>",
          "model_name": "meta-llama/Meta-Llama-3.1-8B-FT1"
        },
        {
          "model_id": "ocid1.datasciencemodel.oc1.iad.<>",
          "model_name": "meta-llama/Meta-Llama-3.1-8B-FT2"
        }
      ]
    }]' \
...
```

### Unit tests
```
================================================= test session starts =================================================
platform darwin -- Python 3.13.0, pytest-8.3.4, pluggy-1.5.0 -- /usr/local/opt/python@3.13/bin/python3.13
cachedir: .pytest_cache
rootdir: /Users/Downloads/fix_logic/accelerated-data-science
configfile: pytest.ini
plugins: anyio-4.7.0
collected 90 items                                                                                                    

tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_fine_tuned_model PASSED [  1%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_foundation_model PASSED [  2%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_gguf_model PASSED [  3%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_multi_model PASSED [  4%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_stack_model PASSED [  5%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_tei_byoc_embedding_model PASSED [  6%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment PASSED               [  7%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_config PASSED        [  8%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_0_VLLM_PARAMS <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 10%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_1_VLLM_PARAMS <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 11%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_2_TGI_PARAMS <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 12%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_3_CUSTOM_PARAMS <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 13%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_missing_tags PASSED  [ 14%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_status_failed PASSED [ 15%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_status_success PASSED [ 16%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_multi_model_deployment PASSED   [ 17%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_multimodel_deployment_config_hybrid PASSED [ 18%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_multimodel_deployment_config_single PASSED [ 20%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_list_deployments PASSED             [ 21%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_update_model_group_deployment PASSED [ 22%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_0_odsc_vllm_serving <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 23%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_1_odsc_vllm_serving <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 24%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_2_odsc_tgi_serving <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 25%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_3_custom_container_key <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 26%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_4_odsc_vllm_serving <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 27%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_5_odsc_tgi_serving <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 28%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_for_unverified_models_0_odsc_vllm_serving <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 30%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_for_unverified_models_1_odsc_tgi_serving <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 31%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_for_unverified_models_2_ <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 32%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_0 PASSED [ 33%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_1 PASSED [ 34%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_2 PASSED [ 35%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_3 PASSED [ 36%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_4 PASSED [ 37%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_5 PASSED [ 38%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_single_0 PASSED [ 40%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_single_1 PASSED [ 41%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_0 PASSED [ 42%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_1 PASSED [ 43%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_2 PASSED [ 44%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_single_0 PASSED [ 45%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_single_1 PASSED [ 46%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_verify_compatibility PASSED         [ 47%]
tests/unitary/with_extras/aqua/test_deployment.py::TestBaseModelSpec::test_invalid_from_aqua_multi_model_ref[oci://test_location_3-ft_weights0-True-False] PASSED [ 48%]
tests/unitary/with_extras/aqua/test_deployment.py::TestBaseModelSpec::test_invalid_from_aqua_multi_model_ref[oci://test_location_3-ft_weights1-False-False] PASSED [ 50%]
tests/unitary/with_extras/aqua/test_deployment.py::TestBaseModelSpec::test_invalid_from_aqua_multi_model_ref[not-a-valid-uri-ft_weights2-False-True] PASSED [ 51%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_fine_tuned_model PASSED [ 52%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_foundation_model PASSED [ 53%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_gguf_model PASSED [ 54%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_multi_model PASSED [ 55%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_stack_model PASSED [ 56%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_tei_byoc_embedding_model PASSED [ 57%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_from_create_model_deployment_details PASSED [ 58%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment PASSED             [ 60%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_config PASSED      [ 61%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_0_VLLM_PARAMS <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 62%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_1_VLLM_PARAMS <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 63%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_2_TGI_PARAMS <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 64%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_3_CUSTOM_PARAMS <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 65%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_missing_tags PASSED [ 66%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_status_failed PASSED [ 67%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_status_success PASSED [ 68%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_multi_model_deployment PASSED [ 70%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_multimodel_deployment_config_hybrid PASSED [ 71%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_multimodel_deployment_config_single PASSED [ 72%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_list_deployments PASSED           [ 73%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_update_model_group_deployment PASSED [ 74%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_0_odsc_vllm_serving <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 75%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_1_odsc_vllm_serving <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 76%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_2_odsc_tgi_serving <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 77%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_3_custom_container_key <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 78%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_4_odsc_vllm_serving <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 80%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_5_odsc_tgi_serving <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 81%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_for_unverified_models_0_odsc_vllm_serving <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 82%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_for_unverified_models_1_odsc_tgi_serving <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 83%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_for_unverified_models_2_ <- ../../../../../usr/local/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 84%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_0 PASSED [ 85%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_1 PASSED [ 86%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_2 PASSED [ 87%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_3 PASSED [ 88%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_4 PASSED [ 90%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_5 PASSED [ 91%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_single_0 PASSED [ 92%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_single_1 PASSED [ 93%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_0 PASSED [ 94%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_1 PASSED [ 95%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_2 PASSED [ 96%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_single_0 PASSED [ 97%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_single_1 PASSED [ 98%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_verify_compatibility PASSED       [100%]

================================================= 90 passed in 24.24s =================================================
```


### Integration tests

- Update `display_name` and `description`
<img width="1015" height="291" alt="Screenshot 2025-08-20 at 4 55 27 PM" src="https://github.com/user-attachments/assets/ad478f3c-08e6-4905-86d9-1c2eb7e0e96c" />
<img width="1435" height="630" alt="Screenshot 2025-08-20 at 4 55 49 PM" src="https://github.com/user-attachments/assets/8bb062a8-0403-4dc7-aa96-0f82aabf8b41" />

- Update fine tuned weights
<img width="1015" height="306" alt="Screenshot 2025-08-20 at 5 03 24 PM" src="https://github.com/user-attachments/assets/b11617bb-b446-4a47-87f4-0a0e23846583" />
<img width="1429" height="582" alt="Screenshot 2025-08-20 at 5 03 02 PM" src="https://github.com/user-attachments/assets/2bfebd5c-29cc-4364-b475-9afe72251021" />
<img width="1431" height="565" alt="Screenshot 2025-08-20 at 5 12 10 PM" src="https://github.com/user-attachments/assets/2f0e0203-e781-45ee-aa84-0f01dd115b00" />

- Update model group deployment using non fine tuned ft weight

<img width="1034" height="157" alt="Screenshot 2025-08-26 at 3 29 31 PM" src="https://github.com/user-attachments/assets/4110d9ba-5277-4b02-a7a2-9f33aac87baa" />

- Update model group deployment using ft weight from different base model

<img width="1026" height="223" alt="Screenshot 2025-08-26 at 3 27 26 PM" src="https://github.com/user-attachments/assets/d0adcb18-47d2-43d2-a608-a3936add3ef8" />

- Update model group deployment using invalid parameter `name`

<img width="1037" height="191" alt="Screenshot 2025-08-26 at 3 10 20 PM" src="https://github.com/user-attachments/assets/e55c0210-f6d0-482d-95a8-141893f17be4" />

