### PR TITLE
Fixed custom model name for single deployment.

### DIFF
--- a/ads/aqua/modeldeployment/deployment.py
+++ b/ads/aqua/modeldeployment/deployment.py
@@ -965,8 +965,7 @@ class AquaDeploymentApp(AquaApp):
             # adds `--enable_lora` to parameters
             params_dict.update({"--enable_lora": UNKNOWN})
             params = build_params_string(params_dict)
-
-        if create_deployment_details.model_name and "--served-model-name" in params:
+        elif create_deployment_details.model_name and "--served-model-name" in params:
             # Replace existing --served-model-name argument with custom name provided by user
             params = re.sub(
                 r"--served-model-name\s+\S+",

--- a/tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py
+++ b/tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py
@@ -922,7 +922,7 @@ spec:
         model_deployment = self.initialize_model_deployment()
         model_deployment.dsc_model_deployment.id = "test_model_deployment_id"
         update_model_deployment_details = (
-            model_deployment._update_model_deployment_details()
+            model_deployment._update_model_deployment_details(update_type="ZDT")
         )
         model_deployment.update(wait_for_completion=True)
         mock_create.assert_called()


### PR DESCRIPTION
### Fixed custom model_name only for single deployment.

- Fixed custom `model_name` only for single deployment.
- Fixed unit tests

### Unit
```
================================================= test session starts =================================================
platform darwin -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0 -- /Library/Frameworks/Python.framework/Versions/3.13/bin/python3.13
cachedir: .pytest_cache
rootdir: /Users/Downloads/fix_logic/accelerated-data-science
configfile: pytest.ini
plugins: anyio-4.10.0
collected 90 items                                                                                                    

tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_fine_tuned_model PASSED [  1%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_foundation_model PASSED [  2%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_gguf_model PASSED [  3%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_multi_model PASSED [  4%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_stack_model PASSED [  5%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_tei_byoc_embedding_model PASSED [  6%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment PASSED               [  7%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_config PASSED        [  8%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_0_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 10%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_1_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 11%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_2_TGI_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 12%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_3_CUSTOM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 13%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_missing_tags PASSED  [ 14%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_status_failed PASSED [ 15%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_status_success PASSED [ 16%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_multi_model_deployment PASSED   [ 17%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_multimodel_deployment_config_hybrid PASSED [ 18%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_multimodel_deployment_config_single PASSED [ 20%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_list_deployments PASSED             [ 21%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_update_model_group_deployment PASSED [ 22%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 23%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_1_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 24%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_2_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 25%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_3_custom_container_key <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 26%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_4_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 27%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_5_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 28%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_for_unverified_models_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 30%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_for_unverified_models_1_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 31%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_for_unverified_models_2_ <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 32%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_0 PASSED [ 33%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_1 PASSED [ 34%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_2 PASSED [ 35%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_3 PASSED [ 36%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_4 PASSED [ 37%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_5 PASSED [ 38%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_single_0 PASSED [ 40%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_single_1 PASSED [ 41%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_0 PASSED [ 42%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_1 PASSED [ 43%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_2 PASSED [ 44%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_single_0 PASSED [ 45%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_single_1 PASSED [ 46%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_verify_compatibility PASSED         [ 47%]
tests/unitary/with_extras/aqua/test_deployment.py::TestBaseModelSpec::test_invalid_from_aqua_multi_model_ref[oci://test_location_3-ft_weights0-True-False] PASSED [ 48%]
tests/unitary/with_extras/aqua/test_deployment.py::TestBaseModelSpec::test_invalid_from_aqua_multi_model_ref[oci://test_location_3-ft_weights1-False-False] PASSED [ 50%]
tests/unitary/with_extras/aqua/test_deployment.py::TestBaseModelSpec::test_invalid_from_aqua_multi_model_ref[not-a-valid-uri-ft_weights2-False-True] PASSED [ 51%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_fine_tuned_model PASSED [ 52%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_foundation_model PASSED [ 53%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_gguf_model PASSED [ 54%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_multi_model PASSED [ 55%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_stack_model PASSED [ 56%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_tei_byoc_embedding_model PASSED [ 57%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_from_create_model_deployment_details PASSED [ 58%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment PASSED             [ 60%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_config PASSED      [ 61%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_0_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 62%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_1_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 63%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_2_TGI_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 64%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_3_CUSTOM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 65%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_missing_tags PASSED [ 66%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_status_failed PASSED [ 67%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_status_success PASSED [ 68%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_multi_model_deployment PASSED [ 70%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_multimodel_deployment_config_hybrid PASSED [ 71%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_multimodel_deployment_config_single PASSED [ 72%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_list_deployments PASSED           [ 73%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_update_model_group_deployment PASSED [ 74%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 75%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_1_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 76%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_2_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 77%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_3_custom_container_key <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 78%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_4_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 80%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_5_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 81%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_for_unverified_models_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 82%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_for_unverified_models_1_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 83%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_for_unverified_models_2_ <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 84%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_0 PASSED [ 85%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_1 PASSED [ 86%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_2 PASSED [ 87%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_3 PASSED [ 88%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_4 PASSED [ 90%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_5 PASSED [ 91%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_single_0 PASSED [ 92%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_single_1 PASSED [ 93%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_0 PASSED [ 94%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_1 PASSED [ 95%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_2 PASSED [ 96%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_single_0 PASSED [ 97%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_single_1 PASSED [ 98%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_verify_compatibility PASSED       [100%]

================================================= 90 passed in 28.18s =================================================
```
```
================================================= test session starts =================================================
platform darwin -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0 -- /Library/Frameworks/Python.framework/Versions/3.13/bin/python3.13
cachedir: .pytest_cache
rootdir: /Users/Downloads/fix_logic/accelerated-data-science
configfile: pytest.ini
plugins: anyio-4.10.0
collected 33 items                                                                                                    

tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test__load_default_properties PASSED [  3%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_activate PASSED [  6%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_build_category_log_details PASSED [  9%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_build_model_deployment_configuration_details PASSED [ 12%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_check_and_print_status PASSED [ 15%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_deactivate PASSED [ 18%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_delete PASSED [ 21%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_deploy PASSED [ 24%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_extract_from_oci_model PASSED [ 27%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_extract_spec_kwargs PASSED [ 30%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_from_ocid PASSED [ 33%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_initialize_model_deployment PASSED [ 36%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_initialize_model_deployment_from_spec PASSED [ 39%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_initialize_model_deployment_triton_builder PASSED [ 42%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_initialize_model_deployment_triton_yaml PASSED [ 45%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_initialize_model_deployment_with_error PASSED [ 48%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_initialize_model_deployment_with_spec_kwargs PASSED [ 51%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_list PASSED [ 54%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_list_df PASSED [ 57%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_model_deployment_from_dict PASSED [ 60%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_model_deployment_from_yaml PASSED [ 63%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_model_deployment_status_text PASSED [ 66%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_model_deployment_to_dict PASSED [ 69%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_model_deployment_with_large_size_artifact PASSED [ 72%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_model_deployment_with_subnet_id PASSED [ 75%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_random_display_name PASSED [ 78%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_state PASSED [ 81%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_status PASSED [ 84%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_sync PASSED [ 87%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_update PASSED [ 90%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_update_from_oci_model PASSED [ 93%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_update_spec PASSED [ 96%]
tests/unitary/default_setup/model_deployment/test_model_deployment_v2.py::ModelDeploymentBYOCTestCase::test_watch PASSED [100%]

================================================= 33 passed in 9.24s ==================================================
```