### PR TITLE
[AQUA][MMD] Added support to edit multi deployment.

### DIFF
--- a/ads/aqua/modeldeployment/entities.py
+++ b/ads/aqua/modeldeployment/entities.py
@@ -255,6 +255,9 @@ class AquaDeploymentDetail(AquaDeployment, DataClassSerializable):
 class ModelDeploymentDetails(BaseModel):
     """Class for the base details of creating and updating Aqua model deployments."""
 
+    instance_shape: str = Field(
+        None, description="The instance shape used for deployment."
+    )
     display_name: Optional[str] = Field(
         None, description="The name of the model deployment."
     )
@@ -266,6 +269,9 @@ class ModelDeploymentDetails(BaseModel):
     )
     instance_count: Optional[int] = Field(
         None, description="Number of instances used for deployment."
+    )
+    container_family: Optional[str] = Field(
+        None, description="Image family of the model deployment container runtime."
     )
     log_group_id: Optional[str] = Field(
         None, description="OCI logging group ID for logs."
@@ -298,6 +304,172 @@ class ModelDeploymentDetails(BaseModel):
     defined_tags: Optional[Dict] = Field(
         None, description="Defined tags for model deployment."
     )
+
+    def validate_multimodel_deployment_feasibility(
+        self, models_config_summary: ModelDeploymentConfigSummary
+    ) -> None:
+        """
+        Validates whether the selected model group is feasible for a multi-model deployment
+        on the chosen instance shape.
+
+        Validation Criteria:
+        - Ensures that the model group is not empty.
+        - Verifies that the selected instance shape is supported by the GPU allocation.
+        - Confirms that each model in the group has a corresponding deployment configuration.
+        - Ensures that each model's user-specified GPU allocation is allowed by its deployment configuration.
+        - Checks that the total GPUs requested by the model group does not exceed the available GPU capacity
+            for the selected instance shape.
+
+        Parameters
+        ----------
+        models_config_summary : ModelDeploymentConfigSummary
+            Contains GPU allocations and deployment configuration for models.
+
+        Raises
+        ------
+        ConfigValidationError:
+        - If the model group is empty.
+        - If the selected instance shape is not supported.
+        - If any model is missing from the deployment configuration.
+        - If a model's GPU allocation does not match any valid configuration.
+        - If the total requested GPUs exceed the instance shape’s capacity.
+        """
+        # Ensure that at least one model is provided.
+        if not self.models:
+            logger.error("No models provided in the model group.")
+            raise ConfigValidationError(
+                "Multi-model deployment requires at least one model. Please provide one or more models."
+            )
+
+        selected_shape = self.instance_shape
+
+        if models_config_summary.error_message:
+            logger.error(models_config_summary.error_message)
+            raise ConfigValidationError(models_config_summary.error_message)
+
+        # Verify that the selected shape is supported by the GPU allocation.
+        if selected_shape not in models_config_summary.gpu_allocation:
+            supported_shapes = list(models_config_summary.gpu_allocation.keys())
+            error_message = (
+                f"The model group is not compatible with the selected instance shape `{selected_shape}`. "
+                f"Supported shapes: {supported_shapes}."
+            )
+            logger.error(error_message)
+            raise ConfigValidationError(error_message)
+
+        total_available_gpus: int = models_config_summary.gpu_allocation[
+            selected_shape
+        ].total_gpus_available
+        model_deployment_config = models_config_summary.deployment_config
+
+        # Verify that every model in the group has a corresponding deployment configuration.
+        required_model_ids = {model.model_id for model in self.models}
+        missing_model_ids = required_model_ids - set(model_deployment_config.keys())
+        if missing_model_ids:
+            error_message = (
+                f"Missing deployment configuration for models: {list(missing_model_ids)}. "
+                "Ensure all selected models are properly configured. If you are deploying custom "
+                "models that lack AQUA service configuration, refer to the deployment guidelines here: "
+                "https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/multimodel-deployment-tips.md#custom_models"
+            )
+            logger.error(error_message)
+            raise ConfigValidationError(error_message)
+
+        sum_model_gpus = 0
+        is_single_model = len(self.models) == 1
+
+        # Validate each model's GPU allocation against its deployment configuration.
+        for model in self.models:
+            sum_model_gpus += model.gpu_count
+            aqua_deployment_config = model_deployment_config[model.model_id]
+
+            # Skip validation for models without deployment configuration details.
+            if not aqua_deployment_config.configuration:
+                error_message = (
+                    f"Missing deployment configuration for model `{model.model_id}`. "
+                    "Please verify that the model is correctly configured. If you are deploying custom models without AQUA service configuration, "
+                    "refer to the guidelines at: "
+                    "https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/multimodel-deployment-tips.md#custom_models"
+                )
+
+                logger.error(error_message)
+                raise ConfigValidationError(error_message)
+
+            allowed_shapes = (
+                list(
+                    set(aqua_deployment_config.configuration.keys()).union(
+                        set(aqua_deployment_config.shape or [])
+                    )
+                )
+                if is_single_model
+                else list(aqua_deployment_config.configuration.keys())
+            )
+
+            if selected_shape not in allowed_shapes:
+                error_message = (
+                    f"Model `{model.model_id}` is not compatible with the selected instance shape `{selected_shape}`. "
+                    f"Select a different instance shape from allowed shapes {allowed_shapes}."
+                )
+                logger.error(error_message)
+                raise ConfigValidationError(error_message)
+
+            # Retrieve valid GPU counts for the selected shape.
+            multi_model_configs = aqua_deployment_config.configuration.get(
+                selected_shape, ConfigurationItem()
+            ).multi_model_deployment
+
+            valid_gpu_configurations = [cfg.gpu_count for cfg in multi_model_configs]
+
+            if model.gpu_count not in valid_gpu_configurations:
+                valid_gpu_str = valid_gpu_configurations or []
+
+                if is_single_model:
+                    # If total GPU allocation is not supported by selected model
+                    if selected_shape not in aqua_deployment_config.shape:
+                        error_message = (
+                            f"Model `{model.model_id}` is configured with {model.gpu_count} GPU(s), "
+                            f"which is invalid. The allowed GPU configurations are: {valid_gpu_str}."
+                        )
+                        logger.error(error_message)
+                        raise ConfigValidationError(error_message)
+
+                    if model.gpu_count != total_available_gpus:
+                        error_message = (
+                            f"Model '{model.model_id}' is configured to use {model.gpu_count} GPU(s), "
+                            f"which not fully utilize the selected instance shape with {total_available_gpus} available GPU(s). "
+                            "Consider adjusting the GPU allocation to better utilize the available resources and maximize performance."
+                        )
+                        logger.error(error_message)
+                        raise ConfigValidationError(error_message)
+
+                else:
+                    error_message = (
+                        f"Model `{model.model_id}` is configured with {model.gpu_count} GPU(s), which is invalid. "
+                        f"Valid GPU configurations are: {valid_gpu_str}. Please adjust the GPU allocation "
+                        f"or choose an instance shape that supports a higher GPU count."
+                    )
+                    logger.error(error_message)
+                    raise ConfigValidationError(error_message)
+
+        if sum_model_gpus < total_available_gpus:
+            error_message = (
+                f"Selected models are configured to use {sum_model_gpus} GPU(s), "
+                f"which not fully utilize the selected instance shape with {total_available_gpus} available GPU(s). "
+                "This configuration may lead to suboptimal performance for a multi-model deployment. "
+                "Consider adjusting the GPU allocation to better utilize the available resources and maximize performance."
+            )
+            logger.warning(error_message)
+            # raise ConfigValidationError(error_message)
+
+        # Check that the total GPU count for the model group does not exceed the instance capacity.
+        if sum_model_gpus > total_available_gpus:
+            error_message = (
+                f"The selected instance shape `{selected_shape}` provides `{total_available_gpus}` GPU(s), "
+                f"but the total GPU allocation required by the model group is `{sum_model_gpus}` GPU(s). "
+                "Please adjust the GPU allocation per model or choose an instance shape with greater GPU capacity."
+            )
+            logger.error(error_message)
+            raise ConfigValidationError(error_message)
 
     def validate_input_models(self, model_details: Dict[str, DataScienceModel]) -> None:
         """
@@ -565,6 +737,7 @@ class ModelDeploymentDetails(BaseModel):
         extra = "allow"
         protected_namespaces = ()
 
+
 class CreateModelDeploymentDetails(ModelDeploymentDetails):
     """Class for creating Aqua model deployments."""
 
@@ -620,172 +793,6 @@ class CreateModelDeploymentDetails(ModelDeploymentDetails):
                 "Exactly one of `model_id` or `models` must be provided to create a model deployment."
             )
         return values
-
-    def validate_multimodel_deployment_feasibility(
-        self, models_config_summary: ModelDeploymentConfigSummary
-    ) -> None:
-        """
-        Validates whether the selected model group is feasible for a multi-model deployment
-        on the chosen instance shape.
-
-        Validation Criteria:
-        - Ensures that the model group is not empty.
-        - Verifies that the selected instance shape is supported by the GPU allocation.
-        - Confirms that each model in the group has a corresponding deployment configuration.
-        - Ensures that each model's user-specified GPU allocation is allowed by its deployment configuration.
-        - Checks that the total GPUs requested by the model group does not exceed the available GPU capacity
-            for the selected instance shape.
-
-        Parameters
-        ----------
-        models_config_summary : ModelDeploymentConfigSummary
-            Contains GPU allocations and deployment configuration for models.
-
-        Raises
-        ------
-        ConfigValidationError:
-        - If the model group is empty.
-        - If the selected instance shape is not supported.
-        - If any model is missing from the deployment configuration.
-        - If a model's GPU allocation does not match any valid configuration.
-        - If the total requested GPUs exceed the instance shape’s capacity.
-        """
-        # Ensure that at least one model is provided.
-        if not self.models:
-            logger.error("No models provided in the model group.")
-            raise ConfigValidationError(
-                "Multi-model deployment requires at least one model. Please provide one or more models."
-            )
-
-        selected_shape = self.instance_shape
-
-        if models_config_summary.error_message:
-            logger.error(models_config_summary.error_message)
-            raise ConfigValidationError(models_config_summary.error_message)
-
-        # Verify that the selected shape is supported by the GPU allocation.
-        if selected_shape not in models_config_summary.gpu_allocation:
-            supported_shapes = list(models_config_summary.gpu_allocation.keys())
-            error_message = (
-                f"The model group is not compatible with the selected instance shape `{selected_shape}`. "
-                f"Supported shapes: {supported_shapes}."
-            )
-            logger.error(error_message)
-            raise ConfigValidationError(error_message)
-
-        total_available_gpus: int = models_config_summary.gpu_allocation[
-            selected_shape
-        ].total_gpus_available
-        model_deployment_config = models_config_summary.deployment_config
-
-        # Verify that every model in the group has a corresponding deployment configuration.
-        required_model_ids = {model.model_id for model in self.models}
-        missing_model_ids = required_model_ids - set(model_deployment_config.keys())
-        if missing_model_ids:
-            error_message = (
-                f"Missing deployment configuration for models: {list(missing_model_ids)}. "
-                "Ensure all selected models are properly configured. If you are deploying custom "
-                "models that lack AQUA service configuration, refer to the deployment guidelines here: "
-                "https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/multimodel-deployment-tips.md#custom_models"
-            )
-            logger.error(error_message)
-            raise ConfigValidationError(error_message)
-
-        sum_model_gpus = 0
-        is_single_model = len(self.models) == 1
-
-        # Validate each model's GPU allocation against its deployment configuration.
-        for model in self.models:
-            sum_model_gpus += model.gpu_count
-            aqua_deployment_config = model_deployment_config[model.model_id]
-
-            # Skip validation for models without deployment configuration details.
-            if not aqua_deployment_config.configuration:
-                error_message = (
-                    f"Missing deployment configuration for model `{model.model_id}`. "
-                    "Please verify that the model is correctly configured. If you are deploying custom models without AQUA service configuration, "
-                    "refer to the guidelines at: "
-                    "https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/multimodel-deployment-tips.md#custom_models"
-                )
-
-                logger.error(error_message)
-                raise ConfigValidationError(error_message)
-
-            allowed_shapes = (
-                list(
-                    set(aqua_deployment_config.configuration.keys()).union(
-                        set(aqua_deployment_config.shape or [])
-                    )
-                )
-                if is_single_model
-                else list(aqua_deployment_config.configuration.keys())
-            )
-
-            if selected_shape not in allowed_shapes:
-                error_message = (
-                    f"Model `{model.model_id}` is not compatible with the selected instance shape `{selected_shape}`. "
-                    f"Select a different instance shape from allowed shapes {allowed_shapes}."
-                )
-                logger.error(error_message)
-                raise ConfigValidationError(error_message)
-
-            # Retrieve valid GPU counts for the selected shape.
-            multi_model_configs = aqua_deployment_config.configuration.get(
-                selected_shape, ConfigurationItem()
-            ).multi_model_deployment
-
-            valid_gpu_configurations = [cfg.gpu_count for cfg in multi_model_configs]
-
-            if model.gpu_count not in valid_gpu_configurations:
-                valid_gpu_str = valid_gpu_configurations or []
-
-                if is_single_model:
-                    # If total GPU allocation is not supported by selected model
-                    if selected_shape not in aqua_deployment_config.shape:
-                        error_message = (
-                            f"Model `{model.model_id}` is configured with {model.gpu_count} GPU(s), "
-                            f"which is invalid. The allowed GPU configurations are: {valid_gpu_str}."
-                        )
-                        logger.error(error_message)
-                        raise ConfigValidationError(error_message)
-
-                    if model.gpu_count != total_available_gpus:
-                        error_message = (
-                            f"Model '{model.model_id}' is configured to use {model.gpu_count} GPU(s), "
-                            f"which not fully utilize the selected instance shape with {total_available_gpus} available GPU(s). "
-                            "Consider adjusting the GPU allocation to better utilize the available resources and maximize performance."
-                        )
-                        logger.error(error_message)
-                        raise ConfigValidationError(error_message)
-
-                else:
-                    error_message = (
-                        f"Model `{model.model_id}` is configured with {model.gpu_count} GPU(s), which is invalid. "
-                        f"Valid GPU configurations are: {valid_gpu_str}. Please adjust the GPU allocation "
-                        f"or choose an instance shape that supports a higher GPU count."
-                    )
-                    logger.error(error_message)
-                    raise ConfigValidationError(error_message)
-
-        if sum_model_gpus < total_available_gpus:
-            error_message = (
-                f"Selected models are configured to use {sum_model_gpus} GPU(s), "
-                f"which not fully utilize the selected instance shape with {total_available_gpus} available GPU(s). "
-                "This configuration may lead to suboptimal performance for a multi-model deployment. "
-                "Consider adjusting the GPU allocation to better utilize the available resources and maximize performance."
-            )
-            logger.warning(error_message)
-            # raise ConfigValidationError(error_message)
-
-        # Check that the total GPU count for the model group does not exceed the instance capacity.
-        if sum_model_gpus > total_available_gpus:
-            error_message = (
-                f"The selected instance shape `{selected_shape}` provides `{total_available_gpus}` GPU(s), "
-                f"but the total GPU allocation required by the model group is `{sum_model_gpus}` GPU(s). "
-                "Please adjust the GPU allocation per model or choose an instance shape with greater GPU capacity."
-            )
-            logger.error(error_message)
-            raise ConfigValidationError(error_message)
 
     class Config:
         extra = "allow"

--- a/ads/aqua/modeldeployment/model_group_config.py
+++ b/ads/aqua/modeldeployment/model_group_config.py
@@ -23,7 +23,10 @@ from ads.aqua.modeldeployment.config_loader import (
     ConfigurationItem,
     ModelDeploymentConfigSummary,
 )
-from ads.aqua.modeldeployment.entities import CreateModelDeploymentDetails
+from ads.aqua.modeldeployment.entities import (
+    CreateModelDeploymentDetails,
+    UpdateModelDeploymentDetails,
+)
 from ads.common.object_storage_details import ObjectStorageDetails
 from ads.common.utils import UNKNOWN
 
@@ -157,7 +160,9 @@ class ModelGroupConfig(Serializable):
     def _merge_gpu_count_params(
         model: AquaMultiModelRef,
         model_config_summary: ModelDeploymentConfigSummary,
-        create_deployment_details: CreateModelDeploymentDetails,
+        deployment_details: Union[
+            CreateModelDeploymentDetails, UpdateModelDeploymentDetails
+        ],
         container_type_key: str,
         container_params,
     ):
@@ -170,9 +175,7 @@ class ModelGroupConfig(Serializable):
 
         deployment_config = model_config_summary.deployment_config.get(
             model.model_id, AquaDeploymentConfig()
-        ).configuration.get(
-            create_deployment_details.instance_shape, ConfigurationItem()
-        )
+        ).configuration.get(deployment_details.instance_shape, ConfigurationItem())
 
         params_found = False
         for item in deployment_config.multi_model_deployment:
@@ -198,9 +201,11 @@ class ModelGroupConfig(Serializable):
         return params
 
     @classmethod
-    def from_create_model_deployment_details(
+    def from_model_deployment_details(
         cls,
-        create_deployment_details: CreateModelDeploymentDetails,
+        deployment_details: Union[
+            CreateModelDeploymentDetails, UpdateModelDeploymentDetails
+        ],
         model_config_summary: ModelDeploymentConfigSummary,
         container_type_key,
         container_params,
@@ -212,11 +217,11 @@ class ModelGroupConfig(Serializable):
         """
         models = []
         seen_models = set()
-        for model in create_deployment_details.models:
+        for model in deployment_details.models:
             params = ModelGroupConfig._merge_gpu_count_params(
                 model,
                 model_config_summary,
-                create_deployment_details,
+                deployment_details,
                 container_type_key,
                 container_params,
             )

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -2268,6 +2268,8 @@ class TestAquaDeployment(unittest.TestCase):
 
         mock_update.return_value = model_deployment_obj
 
+        mock_validate_input_models.return_value = (MagicMock(), MagicMock())
+
         ft_weights = [
             LoraModuleSpec(
                 model_id="ocid1.datasciencemodel.oc1..<FT_OCID>",
@@ -2922,8 +2924,8 @@ class TestModelGroupConfig(TestAquaDeployment):
             )
         )
 
-        model_group_config = ModelGroupConfig.from_create_model_deployment_details(
-            create_deployment_details=create_deployment_details,
+        model_group_config = ModelGroupConfig.from_model_deployment_details(
+            deployment_details=create_deployment_details,
             model_config_summary=model_config_summary,
             container_type_key="odsc-vllm-serving",
             container_params="--example-container-params test",
@@ -2945,13 +2947,11 @@ class TestModelGroupConfig(TestAquaDeployment):
                 predict_log_id="ocid1.log.oc1.<region>.<OCID>",
             )
         )
-        model_group_config_no_ft = (
-            ModelGroupConfig.from_create_model_deployment_details(
-                create_deployment_details=create_deployment_details_no_ft,
-                model_config_summary=model_config_summary,
-                container_type_key="odsc-vllm-serving",
-                container_params="--example-container-params test",
-            )
+        model_group_config_no_ft = ModelGroupConfig.from_model_deployment_details(
+            deployment_details=create_deployment_details_no_ft,
+            model_config_summary=model_config_summary,
+            container_type_key="odsc-vllm-serving",
+            container_params="--example-container-params test",
         )
 
         assert (


### PR DESCRIPTION
### Added support to edit multi deployment.

- Updated `update` api in `AquaDeploymentApp` class to add support to edit multi model deployment
- Multi model deployment can only apply `ZDT` update

### Unit
```
=================================================== test session starts ===================================================
platform darwin -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0 -- /Library/Frameworks/Python.framework/Versions/3.13/bin/python3.13
cachedir: .pytest_cache
rootdir: /Users/Downloads/fix_logic/accelerated-data-science
configfile: pytest.ini
plugins: anyio-4.10.0
collected 90 items                                                                                                        

tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_fine_tuned_model PASSED [  1%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_foundation_model PASSED [  2%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_gguf_model PASSED [  3%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_multi_model PASSED [  4%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_stack_model PASSED [  5%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_create_deployment_for_tei_byoc_embedding_model PASSED [  6%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment PASSED                   [  7%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_config PASSED            [  8%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_0_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 10%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_1_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 11%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_2_TGI_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 12%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_default_params_3_CUSTOM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 13%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_missing_tags PASSED      [ 14%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_status_failed PASSED     [ 15%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_deployment_status_success PASSED    [ 16%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_multi_model_deployment PASSED       [ 17%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_multimodel_deployment_config_hybrid PASSED [ 18%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_get_multimodel_deployment_config_single PASSED [ 20%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_list_deployments PASSED                 [ 21%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_update_model_group_deployment PASSED    [ 22%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 23%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_1_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 24%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_2_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 25%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_3_custom_container_key <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 26%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_4_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 27%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_5_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 28%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_for_unverified_models_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 30%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_for_unverified_models_1_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 31%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_deployment_params_for_unverified_models_2_ <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 32%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_0 PASSED [ 33%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_1 PASSED [ 34%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_2 PASSED [ 35%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_3 PASSED [ 36%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_4 PASSED [ 37%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_5 PASSED [ 38%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_single_0 PASSED [ 40%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_negative_single_1 PASSED [ 41%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_0 PASSED [ 42%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_1 PASSED [ 43%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_2 PASSED [ 44%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_single_0 PASSED [ 45%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_validate_multimodel_deployment_feasibility_positive_single_1 PASSED [ 46%]
tests/unitary/with_extras/aqua/test_deployment.py::TestAquaDeployment::test_verify_compatibility PASSED             [ 47%]
tests/unitary/with_extras/aqua/test_deployment.py::TestBaseModelSpec::test_invalid_from_aqua_multi_model_ref[oci://test_location_3-ft_weights0-True-False] PASSED [ 48%]
tests/unitary/with_extras/aqua/test_deployment.py::TestBaseModelSpec::test_invalid_from_aqua_multi_model_ref[oci://test_location_3-ft_weights1-False-False] PASSED [ 50%]
tests/unitary/with_extras/aqua/test_deployment.py::TestBaseModelSpec::test_invalid_from_aqua_multi_model_ref[not-a-valid-uri-ft_weights2-False-True] PASSED [ 51%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_fine_tuned_model PASSED [ 52%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_foundation_model PASSED [ 53%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_gguf_model PASSED [ 54%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_multi_model PASSED [ 55%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_stack_model PASSED [ 56%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_create_deployment_for_tei_byoc_embedding_model PASSED [ 57%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_from_create_model_deployment_details PASSED [ 58%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment PASSED                 [ 60%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_config PASSED          [ 61%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_0_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 62%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_1_VLLM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 63%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_2_TGI_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 64%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_default_params_3_CUSTOM_PARAMS <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 65%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_missing_tags PASSED    [ 66%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_status_failed PASSED   [ 67%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_deployment_status_success PASSED  [ 68%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_multi_model_deployment PASSED     [ 70%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_multimodel_deployment_config_hybrid PASSED [ 71%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_get_multimodel_deployment_config_single PASSED [ 72%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_list_deployments PASSED               [ 73%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_update_model_group_deployment PASSED  [ 74%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 75%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_1_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 76%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_2_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 77%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_3_custom_container_key <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 78%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_4_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 80%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_5_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 81%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_for_unverified_models_0_odsc_vllm_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 82%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_for_unverified_models_1_odsc_tgi_serving <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 83%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_deployment_params_for_unverified_models_2_ <- ../../../../../Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py PASSED [ 84%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_0 PASSED [ 85%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_1 PASSED [ 86%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_2 PASSED [ 87%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_3 PASSED [ 88%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_4 PASSED [ 90%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_5 PASSED [ 91%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_single_0 PASSED [ 92%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_negative_single_1 PASSED [ 93%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_0 PASSED [ 94%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_1 PASSED [ 95%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_2 PASSED [ 96%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_single_0 PASSED [ 97%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_validate_multimodel_deployment_feasibility_positive_single_1 PASSED [ 98%]
tests/unitary/with_extras/aqua/test_deployment.py::TestModelGroupConfig::test_verify_compatibility PASSED           [100%]

=================================================== 90 passed in 30.17s ===================================================
```

### Integration
- Update model group
<img width="1439" height="646" alt="Screenshot 2025-10-02 at 3 51 05 PM" src="https://github.com/user-attachments/assets/8e5502e3-57cc-4eea-a277-f9065f910732" />
<img width="1440" height="571" alt="Screenshot 2025-10-02 at 3 51 25 PM" src="https://github.com/user-attachments/assets/0c75b13a-b8c1-4551-ad35-3dcf64753a57" />

- Update name and description
<img width="1434" height="628" alt="Screenshot 2025-10-02 at 4 05 16 PM" src="https://github.com/user-attachments/assets/95a051a5-eb82-4bcc-8561-f82626d3e1bd" />

