### PR TITLE
ODSC-85044: Improve AQUA shape recommender fallback for nested text_config model configs

### DIFF
--- a/ads/aqua/shaperecommend/llm_config.py
+++ b/ads/aqua/shaperecommend/llm_config.py
@@ -22,6 +22,28 @@ from ads.aqua.shaperecommend.constants import (
 from ads.common.utils import parse_bool
 
 
+def _get_nested_text_section(raw: dict[str, Any]) -> Optional[dict[str, Any]]:
+    return (
+        raw.get("text_config")
+        or raw.get("llm_config")
+        or raw.get("language_model")
+        or raw.get("language_model_config")
+        or raw.get("decoder_config")
+        or raw.get("model_config")
+        or raw.get("base_model")
+        or raw.get("gpt_config")
+        or next(
+            (
+                value
+                for key, value in raw.items()
+                if ("text" in key or "llm" in key or "gpt" in key)
+                and isinstance(value, dict)
+            ),
+            None,
+        )
+    )
+
+
 class GeneralConfig(BaseModel):
     num_hidden_layers: int = Field(
         ...,
@@ -372,7 +394,22 @@ class LLMConfig(GeneralConfig):
         Instantiates an LLMConfig from a raw Hugging Face config.json file,
         using robust key detection and fallback for architecture.
         """
+        required_field_aliases = (
+            ["num_hidden_layers", "n_layer", "num_layers"],
+            ["hidden_size", "n_embd", "d_model"],
+            ["num_attention_heads", "n_head", "num_heads"],
+            ["vocab_size"],
+        )
+        text_section = _get_nested_text_section(raw)
+        requires_nested_fallback = text_section and any(
+            all(raw.get(key) is None for key in field_aliases)
+            for field_aliases in required_field_aliases
+        )
+
         cls.validate_model_support(raw)
+        if requires_nested_fallback:
+            cls.validate_model_support(text_section)
+            raw = {**text_section, **raw}
 
         # Field mappings with fallback using safe extraction
         num_hidden_layers = cls._get_required_int(
@@ -517,22 +554,7 @@ class ModelConfig(BaseModel):
         """
         # Sectioned/nested search for text
         text_section = (
-            raw.get("text_config")
-            or raw.get("llm_config")
-            or raw.get("language_model")
-            or raw.get("language_model_config")
-            or raw.get("decoder_config")
-            or raw.get("model_config")
-            or raw.get("base_model")
-            or raw.get("gpt_config")
-            or next(
-                (
-                    v
-                    for k, v in raw.items()
-                    if ("text" in k or "llm" in k or "gpt" in k) and isinstance(v, dict)
-                ),
-                None,
-            )
+            _get_nested_text_section(raw)
         )
 
         # Sectioned/nested search for vision

--- a/tests/unitary/with_extras/aqua/test_recommend.py
+++ b/tests/unitary/with_extras/aqua/test_recommend.py
@@ -153,6 +153,47 @@ class TestLLMConfig:
         assert config.weight_dtype.lower() == "float16"
         assert config.quantization is None
 
+    def test_llm_config_from_nested_text_config(self):
+        raw = {
+            "model_type": "llama-nemotron-vl",
+            "text_config": {
+                "model_type": "llama",
+                "num_hidden_layers": 2,
+                "hidden_size": 64,
+                "vocab_size": 1000,
+                "num_attention_heads": 4,
+                "head_dim": 16,
+                "max_position_embeddings": 2048,
+            },
+        }
+
+        config = LLMConfig.from_raw_config(raw)
+
+        assert config.num_hidden_layers == 2
+        assert config.hidden_size == 64
+        assert config.vocab_size == 1000
+        assert config.num_attention_heads == 4
+        assert config.head_dim == 16
+        assert config.max_seq_len == 2048
+
+    def test_llm_config_nested_text_config_unsupported_decoder(self):
+        raw = {
+            "model_type": "multimodal-wrapper",
+            "text_config": {
+                "model_type": "t5",
+                "is_encoder_decoder": True,
+                "num_hidden_layers": 2,
+                "hidden_size": 64,
+                "vocab_size": 1000,
+                "num_attention_heads": 4,
+            },
+        }
+
+        with pytest.raises(
+            AquaRecommendationError, match="decoder-only text-generation model"
+        ):
+            LLMConfig.from_raw_config(raw)
+
     @pytest.mark.parametrize(
         "config_file, expected_hidden_size, expected_max_seq_len, expected_dtype, exp_num_key_value_heads, exp_num_local_experts, expected_head_dim, expected_quant",
         [
@@ -214,9 +255,6 @@ class TestLLMConfig:
         [
             # CASE 1: Whisper (Audio model) -> Should trigger "model type not supported"
             ("config-json-files/whisper-large-v3.json", "model type.*not supported"),
-            
-            # CASE 2: Nemotron (VLM) -> Should trigger "Could not determine 'num_hidden_layers'"
-            ("config-json-files/nemotron-vl-8b.json", "Could not determine.*num_hidden_layers"),
         ],
     )
     def test_llm_config_unsupported_models(self, config_file, error_match):
@@ -368,17 +406,36 @@ class TestAquaShapeRecommend:
                 # Matches the full error string from llm_config.py
                 "The model type 'whisper' is not supported. Please provide a decoder-only text-generation model (ex. Llama, Falcon, etc). Encoder-decoder models (ex. T5, Gemma), encoder-only (BERT), and audio models (Whisper) are not supported at this time.", 
             ),
-            (  # 4. Nemotron (VLM) - Fails because keys are nested in 'text_config'
+            (  # 4. Nested text decoder config - supported through fallback
                 {
                     "model_type": "llama-3.1-nemotron-nano-vl",
-                    "vocab_size": 128256,
-                    "text_config": { # Parser doesn't look here yet, so it fails finding layers at top level
-                        "num_hidden_layers": 32 
-                    }
+                    "text_config": {
+                        "model_type": "llama",
+                        "num_hidden_layers": 2,
+                        "hidden_size": 64,
+                        "vocab_size": 1000,
+                        "num_attention_heads": 4,
+                        "head_dim": 16,
+                        "max_position_embeddings": 2048,
+                    },
                 },
                 [],
-                # Matches the 'missing key' error from llm_config.py
-                "Could not determine 'num_hidden_layers' from the model configuration. Checked keys: ['num_hidden_layers', 'n_layer', 'num_layers']. This indicates the model architecture might not be supported or uses a non-standard config structure."
+                "",
+            ),
+            (  # 5. Nested text decoder config - unsupported decoder surfaces clear validation error
+                {
+                    "model_type": "multimodal-wrapper",
+                    "text_config": {
+                        "model_type": "t5",
+                        "is_encoder_decoder": True,
+                        "num_hidden_layers": 2,
+                        "hidden_size": 64,
+                        "vocab_size": 1000,
+                        "num_attention_heads": 4,
+                    },
+                },
+                [],
+                "The model type 't5' is not supported. Please provide a decoder-only text-generation model (ex. Llama, Falcon, etc). Encoder-decoder models (ex. T5, Gemma), encoder-only (BERT), and audio models (Whisper) are not supported at this time.",
             ),
         ],
     )


### PR DESCRIPTION
## Jira
- Ticket: ODSC-85044

## What Changed
- Added a nested decoder fallback in `LLMConfig.from_raw_config()` so recommender parsing can use `text_config` or similar nested text sections when top-level decoder fields are missing.
- Kept top-level config values authoritative while validating nested decoder sections so unsupported nested decoders still return descriptive `AquaRecommendationError` messages.
- Updated focused AQUA recommender unit coverage for supported nested `text_config` parsing and unsupported nested decoder validation.

## Validation
- `python3 -m pytest tests/unitary/with_extras/aqua/test_recommend.py -k text_config`
- `python3 -m pytest tests/unitary/with_extras/aqua/test_recommend.py -k valid`

## Risks / Follow-Ups
- The fallback only fills missing decoder fields; broader nested config handling remains unchanged.

## Checklist
- [x] PR title follows `<JIRA-KEY>: <summary>`
- [x] Changes are scoped to the ticket
- [x] Relevant tests were added or updated
- [x] Validation steps are documented above
- [x] Commits are signed off
