### PR TITLE
Modify docker image builds

### DIFF
--- a/ads/opctl/docker/Dockerfile.job
+++ b/ads/opctl/docker/Dockerfile.job
@@ -30,7 +30,6 @@ RUN \
     openssl \
     openssl-devel \
     patch \
-    sudo \
     unzip \
     zip \
     gcc-c++ \
@@ -45,7 +44,6 @@ RUN \
   useradd -m -s /bin/bash -N -u $DATASCIENCE_UID $DATASCIENCE_USER && \
   chown -R $DATASCIENCE_USER /home/$DATASCIENCE_USER && \
   chown -R $DATASCIENCE_USER:users /usr/local/ && \
-  touch /etc/sudoers.d/$DATASCIENCE_USER && echo "$DATASCIENCE_USER ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers.d/$DATASCIENCE_USER && \
   mkdir -p $DATASCIENCE_INSTALL_DIR && chown $DATASCIENCE_USER $DATASCIENCE_INSTALL_DIR
 
 RUN mkdir -p /etc/datascience/build

--- a/ads/opctl/docker/Dockerfile.job
+++ b/ads/opctl/docker/Dockerfile.job
@@ -62,8 +62,11 @@ RUN chown -R $DATASCIENCE_USER /opt
 
 USER $DATASCIENCE_USER
 WORKDIR /home/datascience
-ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
-RUN wget -nv ${MINIFORGE_URL} -O /home/datascience/Miniforge3.sh \
+ARG MINIFORGE_VERSION=26.1.1-3
+ARG MINIFORGE_SHA256=b25b828b702df4dd2a6d24d4eb56cfa912471dd8e3342cde2c3d86fe3dc2d870
+ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-Linux-x86_64.sh
+RUN curl -fsSL ${MINIFORGE_URL} -o /home/datascience/Miniforge3.sh \
+    && echo "${MINIFORGE_SHA256}  /home/datascience/Miniforge3.sh" | sha256sum -c - \
     && /bin/bash /home/datascience/Miniforge3.sh -f -b -p /opt/conda \
     && rm /home/datascience/Miniforge3.sh \
     && /opt/conda/bin/conda clean -yaf

--- a/ads/opctl/docker/Dockerfile.job.arm
+++ b/ads/opctl/docker/Dockerfile.job.arm
@@ -33,7 +33,6 @@ RUN \
     openssl \
     openssl-devel \
     patch \
-    sudo \
     unzip \
     zip \
     gcc-c++ \
@@ -48,7 +47,6 @@ RUN \
   useradd -m -s /bin/bash -N -u $DATASCIENCE_UID $DATASCIENCE_USER && \
   chown -R $DATASCIENCE_USER /home/$DATASCIENCE_USER && \
   chown -R $DATASCIENCE_USER:users /usr/local/ && \
-  touch /etc/sudoers.d/$DATASCIENCE_USER && echo "$DATASCIENCE_USER ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers.d/$DATASCIENCE_USER && \
   mkdir -p $DATASCIENCE_INSTALL_DIR && chown $DATASCIENCE_USER $DATASCIENCE_INSTALL_DIR
 
 RUN mkdir -p /etc/datascience/build
@@ -65,7 +63,6 @@ RUN chown -R $DATASCIENCE_USER /opt
 
 USER $DATASCIENCE_USER
 WORKDIR /home/datascience
-# Note in order to run sudo commands as a non root user, you must specify --credential yes if using qemu static to build the image
 ARG MINIFORGE_VERSION=26.1.1-3
 ARG MINIFORGE_SHA256=83280e4ee71a5bd547d6b318f96e9ababe1054911ff6cc2b8801ce5493fe67e5
 ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-Linux-aarch64.sh

--- a/ads/opctl/docker/Dockerfile.job.arm
+++ b/ads/opctl/docker/Dockerfile.job.arm
@@ -66,8 +66,11 @@ RUN chown -R $DATASCIENCE_USER /opt
 USER $DATASCIENCE_USER
 WORKDIR /home/datascience
 # Note in order to run sudo commands as a non root user, you must specify --credential yes if using qemu static to build the image
-ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh
-RUN wget -nv ${MINIFORGE_URL} -O /home/datascience/Miniforge3.sh \
+ARG MINIFORGE_VERSION=26.1.1-3
+ARG MINIFORGE_SHA256=83280e4ee71a5bd547d6b318f96e9ababe1054911ff6cc2b8801ce5493fe67e5
+ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-Linux-aarch64.sh
+RUN curl -fsSL ${MINIFORGE_URL} -o /home/datascience/Miniforge3.sh \
+    && echo "${MINIFORGE_SHA256}  /home/datascience/Miniforge3.sh" | sha256sum -c - \
     && /bin/bash /home/datascience/Miniforge3.sh -f -b -p /opt/conda \
     && rm /home/datascience/Miniforge3.sh \
     && /opt/conda/bin/conda clean -yaf

--- a/ads/opctl/docker/Dockerfile.job.gpu
+++ b/ads/opctl/docker/Dockerfile.job.gpu
@@ -107,8 +107,11 @@ RUN chown -R $DATASCIENCE_USER /opt
 
 USER $DATASCIENCE_USER
 WORKDIR /home/datascience
-ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
-RUN wget -nv ${MINIFORGE_URL} -O /home/datascience/Miniforge3.sh \
+ARG MINIFORGE_VERSION=26.1.1-3
+ARG MINIFORGE_SHA256=b25b828b702df4dd2a6d24d4eb56cfa912471dd8e3342cde2c3d86fe3dc2d870
+ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-Linux-x86_64.sh
+RUN curl -fsSL ${MINIFORGE_URL} -o /home/datascience/Miniforge3.sh \
+    && echo "${MINIFORGE_SHA256}  /home/datascience/Miniforge3.sh" | sha256sum -c - \
     && /bin/bash /home/datascience/Miniforge3.sh -f -b -p /opt/conda \
     && rm /home/datascience/Miniforge3.sh \
     && /opt/conda/bin/conda clean -yaf

--- a/ads/opctl/docker/Dockerfile.job.gpu
+++ b/ads/opctl/docker/Dockerfile.job.gpu
@@ -30,7 +30,6 @@ RUN \
     openssl \
     openssl-devel \
     patch \
-    sudo \
     unzip \
     zip \
     gcc-c++ \
@@ -90,7 +89,6 @@ RUN \
   useradd -m -s /bin/bash -N -u $DATASCIENCE_UID $DATASCIENCE_USER && \
   chown -R $DATASCIENCE_USER /home/$DATASCIENCE_USER && \
   chown -R $DATASCIENCE_USER:users /usr/local/ && \
-  touch /etc/sudoers.d/$DATASCIENCE_USER && echo "$DATASCIENCE_USER ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers.d/$DATASCIENCE_USER && \
   mkdir -p $DATASCIENCE_INSTALL_DIR && chown $DATASCIENCE_USER $DATASCIENCE_INSTALL_DIR
 
 RUN mkdir -p /etc/datascience/build

--- a/ads/opctl/docker/operator/Dockerfile
+++ b/ads/opctl/docker/operator/Dockerfile
@@ -10,8 +10,13 @@ RUN \
     rm -rf /var/cache/yum/*
 
 ########################### CONDA INSTALLATION ########################################
-RUN curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh >> miniforge.sh
-RUN bash ./miniforge.sh -b -p /miniforge; rm ./miniforge.sh;
+ARG MINIFORGE_VERSION=26.1.1-3
+ARG MINIFORGE_SHA256=b25b828b702df4dd2a6d24d4eb56cfa912471dd8e3342cde2c3d86fe3dc2d870
+ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-Linux-x86_64.sh
+RUN curl -fsSL ${MINIFORGE_URL} -o miniforge.sh \
+    && echo "${MINIFORGE_SHA256}  miniforge.sh" | sha256sum -c - \
+    && bash ./miniforge.sh -b -p /miniforge \
+    && rm ./miniforge.sh
 ENV PATH="/miniforge/bin:$PATH"
 
 USER root

--- a/ads/opctl/docker/operator/Dockerfile.gpu
+++ b/ads/opctl/docker/operator/Dockerfile.gpu
@@ -54,8 +54,13 @@ RUN CUDNN_DOWNLOAD_SUM=7eaec8039a2c30ab0bc758d303588767693def6bf49b22485a2c00bf2
     ldconfig
 
 ########################### CONDA INSTALLATION ########################################
-RUN curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh >> miniforge.sh
-RUN bash ./miniforge.sh -b -p /miniforge; rm ./miniforge.sh;
+ARG MINIFORGE_VERSION=26.1.1-3
+ARG MINIFORGE_SHA256=b25b828b702df4dd2a6d24d4eb56cfa912471dd8e3342cde2c3d86fe3dc2d870
+ARG MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-Linux-x86_64.sh
+RUN curl -fsSL ${MINIFORGE_URL} -o miniforge.sh \
+    && echo "${MINIFORGE_SHA256}  miniforge.sh" | sha256sum -c - \
+    && bash ./miniforge.sh -b -p /miniforge \
+    && rm ./miniforge.sh
 ENV PATH="/miniforge/bin:$PATH"
 
 USER root


### PR DESCRIPTION
  ## Summary
  - Pin Miniforge installer downloads in ADS Dockerfiles to a fixed release and verify SHA-256 before execution.
  - Remove unrestricted passwordless sudo from ADS job images.
  - Include the ARM job Dockerfile because it had the same Dockerfile patterns as the x86 job images.

  ## Validation
  - Verified no remaining `releases/latest/download`, `NOPASSWD: ALL`, `sudoers`, or `sudo` references under `ads/opctl/docker`.
  - Ran targeted operator utility tests:
    - `tests/unitary/with_extras/operator/test_common_utils.py` - 9 passed
  - Built ARM job image with Colima:
    - `docker build -t ads-job-arm-smoke -f ads/opctl/docker/Dockerfile.job.arm ads/opctl`
  - Verified ARM Miniforge checksum during build:
    - `/home/datascience/Miniforge3.sh: OK`
  - Verified runtime user and absence of sudo:
    - `docker run --rm ads-job-arm-smoke bash -lc 'whoami && command -v sudo || true'`
    - Output: `datascience`
  - Attempted amd64 operator image build and verified the x86_64 Miniforge checksum step:
    - `miniforge.sh: OK`