### PR TITLE
Use validated tar extraction for conda installs

### DIFF
--- a/ads/opctl/conda/cmds.py
+++ b/ads/opctl/conda/cmds.py
@@ -11,6 +11,7 @@ import subprocess
 import shlex
 import json
 import glob
+import tarfile
 from typing import Dict
 
 import click
@@ -47,6 +48,74 @@ from ads.opctl.config.base import ConfigProcessor
 from ads.opctl.config.merger import ConfigMerger
 from ads.opctl.conda.multipart_uploader import MultiPartUploader
 import tempfile
+
+
+def _is_path_inside_directory(directory: str, path: str) -> bool:
+    directory_path = os.path.realpath(directory)
+    target_path = os.path.realpath(path)
+    return os.path.commonpath([directory_path, target_path]) == directory_path
+
+
+def _validate_tar_member_path(member_name: str, target_dir: str) -> None:
+    if not member_name:
+        raise ValueError("Tar archive contains an empty member name.")
+    if os.path.isabs(member_name):
+        raise ValueError(f"Tar archive member uses an absolute path: {member_name}")
+    if ".." in member_name.split("/"):
+        raise ValueError(f"Tar archive member contains path traversal: {member_name}")
+
+    destination = os.path.join(target_dir, member_name)
+    if not _is_path_inside_directory(target_dir, destination):
+        raise ValueError(f"Tar archive member escapes target directory: {member_name}")
+
+
+def _validate_tar_link_target(member: tarfile.TarInfo, target_dir: str) -> None:
+    if not member.issym() and not member.islnk():
+        return
+    if not member.linkname:
+        raise ValueError(f"Tar archive link member is missing a target: {member.name}")
+
+    member_destination = os.path.join(target_dir, member.name)
+    if member.issym():
+        if os.path.isabs(member.linkname):
+            link_target = member.linkname
+        else:
+            link_target = os.path.join(
+                os.path.dirname(member_destination), member.linkname
+            )
+    else:
+        if os.path.isabs(member.linkname):
+            raise ValueError(
+                f"Tar archive hard link uses an absolute target: {member.name}"
+            )
+        link_target = os.path.join(target_dir, member.linkname)
+
+    if not _is_path_inside_directory(target_dir, link_target):
+        raise ValueError(
+            f"Tar archive link target escapes target directory: {member.name}"
+        )
+
+
+def _validate_tar_member(member: tarfile.TarInfo, target_dir: str) -> None:
+    _validate_tar_member_path(member.name, target_dir)
+    if member.isdev() or member.isfifo():
+        raise ValueError(
+            f"Tar archive member has an unsupported file type: {member.name}"
+        )
+    _validate_tar_link_target(member, target_dir)
+
+
+def _safe_extract_tar(pack_path: str, target_dir: str) -> None:
+    """Extracts a tar archive after validating every member path."""
+    target_path = os.path.realpath(target_dir)
+    with tarfile.open(pack_path) as tar:
+        members = tar.getmembers()
+        for member in members:
+            _validate_tar_member(member, target_path)
+
+        for member in members:
+            _validate_tar_member_path(member.name, target_path)
+            tar.extract(member, target_path)
 
 
 def _fetch_manifest_template() -> Dict:
@@ -469,13 +538,13 @@ def _install(
     print(f"Start unpacking {pack_path}")
     os.makedirs(pack_folder_path, exist_ok=True)
 
-    process = subprocess.Popen(["tar", "-xf", pack_path, "-C", pack_folder_path])
-    process.communicate()
-    if process.returncode != 0:
+    try:
+        _safe_extract_tar(pack_path, pack_folder_path)
+    except (OSError, tarfile.TarError, ValueError) as ex:
         shutil.rmtree(pack_folder_path)
         raise Exception(
             f"Error extracting {pack_path} to {pack_folder_path}. Please try again."
-        )
+        ) from ex
 
     # Run the conda-unpack script to clean up prefixes
     # This will fix problems related to repeated "placehold" paths.

--- a/tests/unitary/with_extras/opctl/test_opctl_conda.py
+++ b/tests/unitary/with_extras/opctl/test_opctl_conda.py
@@ -3,16 +3,18 @@
 # Copyright (c) 2021, 2023 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-import pytest
-from unittest.mock import patch, MagicMock, PropertyMock
-import tempfile
+from io import BytesIO
 import os
+import tarfile
+import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock, PropertyMock, patch
 
+import pytest
 import yaml
 
 from ads.common.auth import AuthType
-from ads.opctl.conda.cmds import create, install, publish
+from ads.opctl.conda.cmds import _safe_extract_tar, create, install, publish
 from ads.opctl.conda.multipart_uploader import MultiPartUploader
 from ads.opctl.constants import ML_JOB_IMAGE
 
@@ -196,10 +198,18 @@ manifest:
     @patch("ads.opctl.conda.cmds.run_command")
     @patch("ads.opctl.conda.cmds.get_docker_client")
     @patch("ads.opctl.conda.cmds.run_container")
+    @patch("ads.opctl.conda.cmds._safe_extract_tar")
     @patch("ads.opctl.conda.cmds.subprocess.Popen")
     @patch("ads.opctl.conda.cmds.click.prompt", return_value="q")
     def test_install_conda(
-        self, prompt, popen, mock_run_container, mock_docker, mock_run_cmd, monkeypatch
+        self,
+        prompt,
+        popen,
+        mock_safe_extract_tar,
+        mock_run_container,
+        mock_docker,
+        mock_run_cmd,
+        monkeypatch,
     ):
         process = MagicMock()
         process.returncode = 0
@@ -223,7 +233,10 @@ manifest:
                 oci_profile=None,
                 overwrite=True,
             )
-            assert popen.call_count == 2
+            assert popen.call_count == 1
+            mock_safe_extract_tar.assert_called_with(
+                os.path.join(td, "slug.tar.gz"), os.path.join(td, "slug")
+            )
             mock_run_container.assert_called_with(
                 image=ML_JOB_IMAGE,
                 bind_volumes={
@@ -245,6 +258,93 @@ manifest:
             mock_run_cmd.assert_called_with(
                 os.path.join(td, "slug", "bin", "conda-unpack")
             )
+
+    def test_safe_extract_tar_extracts_valid_archive(self):
+        with tempfile.TemporaryDirectory() as td:
+            pack_path = os.path.join(td, "pack.tar.gz")
+            target_dir = os.path.join(td, "target")
+            payload_path = os.path.join(td, "payload.txt")
+            with open(payload_path, "w") as f:
+                f.write("valid conda pack content")
+
+            with tarfile.open(pack_path, "w:gz") as tar:
+                tar.add(payload_path, arcname="bin/activate")
+
+            os.makedirs(target_dir)
+            _safe_extract_tar(pack_path, target_dir)
+
+            with open(os.path.join(target_dir, "bin", "activate")) as f:
+                assert f.read() == "valid conda pack content"
+
+    @pytest.mark.parametrize(
+        "member_name",
+        [
+            "../ESCAPED.txt",
+            "bin/../../ESCAPED.txt",
+        ],
+    )
+    def test_safe_extract_tar_rejects_unsafe_member_paths(self, member_name):
+        with tempfile.TemporaryDirectory() as td:
+            pack_path = os.path.join(td, "pack.tar.gz")
+            target_dir = os.path.join(td, "target")
+            escaped_path = os.path.join(td, "ESCAPED.txt")
+            payload_path = os.path.join(td, "payload.txt")
+            with open(payload_path, "w") as f:
+                f.write("unsafe conda pack content")
+
+            with tarfile.open(pack_path, "w:gz") as tar:
+                tar.add(payload_path, arcname=member_name)
+
+            os.makedirs(target_dir)
+            with pytest.raises(ValueError):
+                _safe_extract_tar(pack_path, target_dir)
+
+            assert not os.path.exists(escaped_path)
+
+    def test_safe_extract_tar_rejects_absolute_member_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            pack_path = os.path.join(td, "pack.tar.gz")
+            target_dir = os.path.join(td, "target")
+            payload = b"unsafe conda pack content"
+            member = tarfile.TarInfo("/tmp/ESCAPED.txt")
+            member.size = len(payload)
+
+            with tarfile.open(pack_path, "w:gz") as tar:
+                tar.addfile(member, BytesIO(payload))
+
+            os.makedirs(target_dir)
+            with pytest.raises(ValueError):
+                _safe_extract_tar(pack_path, target_dir)
+
+    def test_safe_extract_tar_rejects_symlink_escape(self):
+        with tempfile.TemporaryDirectory() as td:
+            pack_path = os.path.join(td, "pack.tar.gz")
+            target_dir = os.path.join(td, "target")
+            link = tarfile.TarInfo("bin/escape")
+            link.type = tarfile.SYMTYPE
+            link.linkname = "../../ESCAPED.txt"
+
+            with tarfile.open(pack_path, "w:gz") as tar:
+                tar.addfile(link)
+
+            os.makedirs(target_dir)
+            with pytest.raises(ValueError):
+                _safe_extract_tar(pack_path, target_dir)
+
+    def test_safe_extract_tar_rejects_hardlink_escape(self):
+        with tempfile.TemporaryDirectory() as td:
+            pack_path = os.path.join(td, "pack.tar.gz")
+            target_dir = os.path.join(td, "target")
+            link = tarfile.TarInfo("bin/escape")
+            link.type = tarfile.LNKTYPE
+            link.linkname = "../ESCAPED.txt"
+
+            with tarfile.open(pack_path, "w:gz") as tar:
+                tar.addfile(link)
+
+            os.makedirs(target_dir)
+            with pytest.raises(ValueError):
+                _safe_extract_tar(pack_path, target_dir)
 
 
 class TestMultiPartUploader:


### PR DESCRIPTION
## Summary

  This updates conda pack installation to extract archives through a validated Python tar handling path instead of invoking the system `tar` command directly.

  The extraction path now validates archive members before writing files and rejects unsupported or unsafe entries, including absolute paths, parent-directory traversal, special file types, and links that resolve outside the intended extraction directory.

  ## Why

  This makes conda pack extraction behavior consistent across runtime environments and prevents archive contents from being written outside the requested installation directory.

  ## Testing

  - `conda run -n venv python -m pytest tests/unitary/with_extras/opctl/test_opctl_conda.py::TestOpctlConda::test_install_conda tests/unitary/with_extras/opctl/test_opctl_conda.py::TestOpctlConda::test_safe_extract_tar_extracts_valid_archive tests/unitary/with_extras/
  opctl/test_opctl_conda.py::TestOpctlConda::test_safe_extract_tar_rejects_unsafe_member_paths tests/unitary/with_extras/opctl/test_opctl_conda.py::TestOpctlConda::test_safe_extract_tar_rejects_absolute_member_path tests/unitary/with_extras/opctl/
  test_opctl_conda.py::TestOpctlConda::test_safe_extract_tar_rejects_symlink_escape tests/unitary/with_extras/opctl/test_opctl_conda.py::TestOpctlConda::test_safe_extract_tar_rejects_hardlink_escape -q`
  - `conda run -n venv python -m py_compile ads/opctl/conda/cmds.py tests/unitary/with_extras/opctl/test_opctl_conda.py`
  - `git diff --check`