### PR TITLE
Restore Aqua handler preparation in Jupyter mode

### DIFF
--- a/ads/aqua/extension/base_handler.py
+++ b/ads/aqua/extension/base_handler.py
@@ -35,8 +35,13 @@ class AquaAPIhandler(APIHandler):
             pass
 
     def prepare(self, *args, **kwargs):
-        """The base class prepare is not required for Aqua"""
-        pass
+        """Run Jupyter request checks unless Aqua is running standalone."""
+        if self.settings.get("aqua_standalone_server", False):
+            if self.settings.get("aqua_cors_enabled", False):
+                self.set_header("Access-Control-Allow-Origin", "*")
+            return
+
+        return super().prepare(*args, **kwargs)
 
     @staticmethod
     def serialize(obj: Any):

--- a/ads/aqua/server/app.py
+++ b/ads/aqua/server/app.py
@@ -20,18 +20,14 @@ AQUA_CORS_ENABLE = "AQUA_CORS_ENABLE"
 URL_PATTERN = r"/aqua/"
 
 
-def prepare(self):
-    self.set_header("Access-Control-Allow-Origin", "*")
-
-
 def make_app():
-    # Patch the prepare method to allow CORS request
-    if os.environ.get(AQUA_CORS_ENABLE, "0") == "1":
-        for _, handler in __handlers__:
-            handler.prepare = prepare
     handlers = [(URL_PATTERN + url, handler) for url, handler in __handlers__]
     # logger.debug(handlers)
-    return tornado.web.Application(handlers)
+    return tornado.web.Application(
+        handlers,
+        aqua_standalone_server=True,
+        aqua_cors_enabled=os.environ.get(AQUA_CORS_ENABLE, "0") == "1",
+    )
 
 
 def start_server():

--- a/tests/unitary/with_extras/aqua/test_handlers.py
+++ b/tests/unitary/with_extras/aqua/test_handlers.py
@@ -47,13 +47,20 @@ from ads.aqua.extension.errors import ReplyDetails
 class TestBaseHandlers(unittest.TestCase):
     """Contains test cases for base handler."""
 
+    @staticmethod
+    def _prepare_test_handler(**settings):
+        handler = object.__new__(AquaAPIhandler)
+        handler.application = Application(**settings)
+        handler.set_header = MagicMock()
+        return handler
+
     @patch.object(APIHandler, "__init__")
     def setUp(self, mock_init) -> None:
         mock_init.return_value = None
         application = Application()
         request = HTTPServerRequest(method="GET", uri="/test", connection=MagicMock())
         self.test_instance = AquaAPIhandler(application, request)
-        self.test_instance.telemetry.record_event_async = MagicMock()
+        self.test_instance.telemetry = MagicMock()
 
     @parameterized.expand(
         [
@@ -193,6 +200,56 @@ class TestBaseHandlers(unittest.TestCase):
         )
 
         mock_logger.error.assert_called_with(error_message)
+
+    @patch.object(APIHandler, "prepare")
+    def test_prepare_calls_base_handler_by_default(self, mock_prepare):
+        handler = self._prepare_test_handler()
+
+        handler.prepare()
+
+        mock_prepare.assert_called_once_with()
+        handler.set_header.assert_not_called()
+
+    @patch.object(APIHandler, "prepare")
+    def test_prepare_skips_base_handler_for_standalone_server(self, mock_prepare):
+        handler = self._prepare_test_handler(aqua_standalone_server=True)
+
+        handler.prepare()
+
+        mock_prepare.assert_not_called()
+        handler.set_header.assert_not_called()
+
+    @patch.object(APIHandler, "prepare")
+    def test_prepare_sets_cors_header_for_standalone_server_when_enabled(
+        self, mock_prepare
+    ):
+        handler = self._prepare_test_handler(
+            aqua_standalone_server=True,
+            aqua_cors_enabled=True,
+        )
+
+        handler.prepare()
+
+        mock_prepare.assert_not_called()
+        handler.set_header.assert_called_once_with("Access-Control-Allow-Origin", "*")
+
+    def test_standalone_app_sets_aqua_handler_mode(self):
+        from ads.aqua.server.app import AQUA_CORS_ENABLE, make_app
+
+        with patch.dict(os.environ, {AQUA_CORS_ENABLE: "0"}):
+            app = make_app()
+
+        assert app.settings["aqua_standalone_server"] is True
+        assert app.settings["aqua_cors_enabled"] is False
+
+    def test_standalone_app_sets_cors_mode_from_environment(self):
+        from ads.aqua.server.app import AQUA_CORS_ENABLE, make_app
+
+        with patch.dict(os.environ, {AQUA_CORS_ENABLE: "1"}):
+            app = make_app()
+
+        assert app.settings["aqua_standalone_server"] is True
+        assert app.settings["aqua_cors_enabled"] is True
 
 
 class TestHandlers(unittest.TestCase):


### PR DESCRIPTION
## Summary

  This updates `AquaAPIhandler.prepare()` so Aqua uses the inherited Jupyter handler preparation path when running as a Jupyter extension.

  For the standalone Aqua server, the app now sets explicit Tornado application settings so the handler can keep the standalone behavior without monkey-patching handler classes at startup.

  ## Why

  This keeps Aqua behavior aligned with the runtime context:

  - Jupyter extension mode uses the normal Jupyter request preparation flow.
  - Standalone server mode keeps its existing lightweight request preparation behavior.
  - Optional standalone CORS handling is preserved through app settings instead of replacing handler methods dynamically.

  ## Testing

  - `conda run -n venv python -m pytest tests/unitary/with_extras/aqua/test_handlers.py::TestBaseHandlers::test_prepare_calls_base_handler_by_default tests/unitary/with_extras/aqua/test_handlers.py::TestBaseHandlers::test_prepare_skips_base_handler_for_standalone_server
  tests/unitary/with_extras/aqua/test_handlers.py::TestBaseHandlers::test_prepare_sets_cors_header_for_standalone_server_when_enabled tests/unitary/with_extras/aqua/test_handlers.py::TestBaseHandlers::test_standalone_app_sets_aqua_handler_mode tests/unitary/with_extras/
  aqua/test_handlers.py::TestBaseHandlers::test_standalone_app_sets_cors_mode_from_environment -q`
  - `conda run -n venv python -m py_compile ads/aqua/extension/base_handler.py ads/aqua/server/app.py tests/unitary/with_extras/aqua/test_handlers.py`
  - `git diff --check`