### PR TITLE
Onboard Macaron GitHub Actions security checks

### DIFF
--- a/.github/workflows/add-3plicense-warning.yml
+++ b/.github/workflows/add-3plicense-warning.yml
@@ -31,7 +31,7 @@ jobs:
           echo "BODY_MSG<<EOF" >> $GITHUB_ENV
           echo "$BODY_MSG" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # v6
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,6 +69,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/macaron.yml
+++ b/.github/workflows/macaron.yml
@@ -1,0 +1,39 @@
+name: "Macaron GitHub Actions Security"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  schedule:
+    - cron: "17 9 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-github-actions:
+    name: "check-github-actions"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: "Run Macaron"
+        uses: oracle/macaron@4ddb55e3c9ef2c77b548be55c557078c4476fd9c # v0.24.0
+        with:
+          repo_path: ./
+          policy_file: check-github-actions
+          policy_purl: "pkg:github.com/oracle/accelerated-data-science@.*"
+          output_dir: macaron-output
+          reports_retention_days: 90

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,15 +3,18 @@ name: "[DO NOT TRIGGER] Publish to PyPI"
 # To run this workflow manually from the Actions tab
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distribution 📦 to PyPI
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.x"
       - name: Build distribution 📦

--- a/.github/workflows/publish-to-readthedocs.yml
+++ b/.github/workflows/publish-to-readthedocs.yml
@@ -7,6 +7,8 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions: {}
+
 env:
   RTDS_ADS_PROJECT: https://readthedocs.org/api/v3/projects/accelerated-data-science
   RTDS_ADS_TOKEN: ${{ secrets.RTDS_ADS_TOKEN }}

--- a/.github/workflows/run-forecast-explainer-tests.yml
+++ b/.github/workflows/run-forecast-explainer-tests.yml
@@ -29,12 +29,12 @@ jobs:
         python-version: ["3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/run-forecast-unit-tests.yml
+++ b/.github/workflows/run-forecast-unit-tests.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: ["3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -38,7 +38,7 @@ jobs:
       - uses: ./.github/workflows/create-more-space
         name: "Create more disk space"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/run-operators-unit-tests.yml
+++ b/.github/workflows/run-operators-unit-tests.yml
@@ -30,9 +30,9 @@ jobs:
         python-version: ["3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/run-unittests-default_setup.yml
+++ b/.github/workflows/run-unittests-default_setup.yml
@@ -35,9 +35,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/run-unittests-py310-py311.yml
+++ b/.github/workflows/run-unittests-py310-py311.yml
@@ -50,12 +50,12 @@ jobs:
             test-path: "tests/unitary/with_extras/model"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - uses: ./.github/workflows/create-more-space
         name: "Create more disk space"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/run-unittests-py39-cov-report.yml
+++ b/.github/workflows/run-unittests-py39-cov-report.yml
@@ -47,12 +47,12 @@ jobs:
             test-path: "tests/unitary/with_extras/model"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - uses: ./.github/workflows/create-more-space
         name: "Create more disk space"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.9"
           cache: "pip"
@@ -101,7 +101,7 @@ jobs:
           ${{ matrix.test-path }} ${{ matrix.ignore-path }}
 
       - name: "Save coverage files"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cov-reports-${{ matrix.name }}
           path: |
@@ -121,11 +121,11 @@ jobs:
 
     steps:
       - name: "Checkout current branch"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: "Download coverage files"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       - name: "Calculate overall coverage"
         run: |
           set -x # print commands that are executed
@@ -184,7 +184,7 @@ jobs:
 
       - name: "Add comment with cov diff to PR"
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         if: github.event_name == 'pull_request'
         with:
           github-token: ${{ github.token }}
@@ -201,7 +201,7 @@ jobs:
           --compare-branch=origin/${{ env.COMPARE_BRANCH }} \
           --html-report=cov-diff.html
       - name: "Save coverage difference report"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cov-html-reports
           path: |


### PR DESCRIPTION
## Summary
- Add a Macaron GitHub Actions workflow for ADS
- Configure Macaron to run the `check-github-actions` policy
- Scope PR/push triggers to `.github/workflows/**` and `.github/actions/**`
- Add weekly and manual runs for ongoing workflow security validation
- Pin the new workflow actions to full commit SHAs
