### PR TITLE
Fix model parameter serialization for ETS and Theta

### DIFF
--- a/ads/opctl/operator/lowcode/forecast/model/ets.py
+++ b/ads/opctl/operator/lowcode/forecast/model/ets.py
@@ -98,6 +98,24 @@ class ETSOperatorModel(UnivariateForecasterOperatorModel):
 
         return params
 
+    @staticmethod
+    def _fit_statistics_as_dict(fit) -> Dict[str, Any]:
+        """Return JSON-safe scalar fit statistics for model parameter output."""
+        return {
+            name: float(getattr(fit, name))
+            for name in ["aic", "bic", "aicc", "llf", "sse"]
+            if hasattr(fit, name)
+        }
+
+    @staticmethod
+    def _fit_params_as_dict(fit) -> Dict[str, float]:
+        """Return named fitted ETS parameters as JSON-safe scalar values."""
+        values = getattr(fit, "params", [])
+        values = values.tolist() if isinstance(values, pd.Series) else list(values)
+        names = getattr(fit, "param_names", None)
+        names = names if names and len(names) == len(values) else range(len(values))
+        return {str(name): float(value) for name, value in zip(names, values)}
+
     def _train_model(self, i, series_id, df: pd.DataFrame, model_kwargs: Dict[str, Any]):
         try:
             self.forecast_output.init_series_output(series_id=series_id, data_at_series=df)
@@ -199,13 +217,16 @@ class ETSOperatorModel(UnivariateForecasterOperatorModel):
             self.models[series_id]["model"] = fit
             self.models[series_id]["le"] = self.le[series_id]
 
-            params = vars(model).copy()
-            for param in ["arima_res_", "endog_index_"]:
-                if param in params:
-                    params.pop(param)
             self.model_parameters[series_id] = {
                 "framework": SupportedModels.ETSForecaster,
-                **params,
+                "error": model.error,
+                "trend": model.trend,
+                "damped_trend": model.damped_trend,
+                "seasonal": model.seasonal,
+                "seasonal_periods": model.seasonal_periods,
+                "initialization_method": model.initialization_method,
+                "fit_params": self._fit_params_as_dict(fit),
+                "fit_statistics": self._fit_statistics_as_dict(fit),
             }
 
             logger.debug("===========Done===========")

--- a/ads/opctl/operator/lowcode/forecast/model/theta.py
+++ b/ads/opctl/operator/lowcode/forecast/model/theta.py
@@ -99,6 +99,15 @@ class ThetaOperatorModel(UnivariateForecasterOperatorModel):
         logger.debug(f"Found {valid_candidates} seasonality candidates")
         return sorted(list(valid_candidates))
 
+    @staticmethod
+    def _fit_params_as_dict(model) -> Dict[str, float]:
+        """Return scalar fitted Theta parameters as JSON-safe values."""
+        return {
+            str(name): float(value)
+            for name, value in model.get_fitted_params().items()
+            if isinstance(value, (int, float, np.integer, np.floating))
+        }
+
     def _train_model(self, i, series_id, df: pd.DataFrame, model_kwargs: Dict[str, Any]):
         try:
             self.forecast_output.init_series_output(series_id=series_id, data_at_series=df)
@@ -227,10 +236,15 @@ class ThetaOperatorModel(UnivariateForecasterOperatorModel):
             self.models[series_id]["model_params"] = model_kwargs
             self.models[series_id]["le"] = self.le[series_id]
 
-            params = vars(model).copy()
+            model_params = model.get_params()
             self.model_parameters[series_id] = {
                 "framework": SupportedModels.Theta,
-                **params,
+                "initial_level": model_params.get("initial_level"),
+                "deseasonalize": model_params.get("deseasonalize"),
+                "deseasonalize_model": model_kwargs.get("deseasonalize_model"),
+                "sp": model_params.get("sp"),
+                "uses_additive_deseasonalization": using_additive_deseasonalization,
+                "fit_params": self._fit_params_as_dict(model),
             }
 
             logger.debug("===========Done===========")

--- a/docs/source/user_guide/operators/forecast_operator/yaml_schema.rst
+++ b/docs/source/user_guide/operators/forecast_operator/yaml_schema.rst
@@ -267,7 +267,7 @@ Further Description
         * **format**: (Optional) Specify the format for output data (e.g., ``csv``, ``json``, ``excel``).
         * **options**: (Optional) Include any additional arguments, such as connection parameters for storage.
 
-    * **model**: (Optional) The name of the model framework to use. Defaults to ``auto-select``. Available options include ``arima``, ``prophet``, ``theta``, ``ets``, ``neuralprophet``, ``autots``, and ``auto-select``.
+    * **model**: (Optional) The name of the model framework to use. Defaults to ``prophet``. Available options include ``prophet``, ``arima``, ``neuralprophet``, ``theta``, ``ets``, ``lgbforecast``, ``xgbforecast``, ``automlx``, ``autots``, ``auto-select``, and ``auto-select-series``.
 
     * **model_kwargs**: (Optional) A dictionary of arguments to pass directly to the model framework, allowing for detailed control over modeling.
 

--- a/tests/operators/forecast/test_explainers.py
+++ b/tests/operators/forecast/test_explainers.py
@@ -46,6 +46,7 @@ TEMPLATE_YAML = {
         "target_category_columns": [],
         "horizon": None,
         "generate_explanations": True,
+        "generate_model_parameters" : True,
     },
 }
 


### PR DESCRIPTION
This PR fixes crashes during model parameter output generation for ETS and Theta forecast models.
Both models were storing raw model internals. Those internals can include non-JSON-safe native objects, causing the Python process to crash during Pandas JSON serialization.
Updated related test cases.