### PR TITLE
Support what-if analysis for auto-select-series workflow

### DIFF
--- a/ads/opctl/operator/lowcode/forecast/__main__.py
+++ b/ads/opctl/operator/lowcode/forecast/__main__.py
@@ -94,6 +94,19 @@ def _merge_auto_select_series_backtesting_results(
     return results
 
 
+def _log_auto_select_series_profile(selection_df: pd.DataFrame):
+    """Log selected-model counts for an auto-select-series run."""
+    profile = ", ".join(
+        f"{model_name}: {count}"
+        for model_name, count in selection_df["selected_model"]
+        .astype(str)
+        .value_counts()
+        .sort_index()
+        .items()
+    )
+    logger.info("[MODEL_SELECTION] Auto-select-series selected model profile: %s", profile)
+
+
 def _save_combined_model_pickle(
         operator_config: ForecastOperatorConfig,
         sub_models: Dict,
@@ -139,6 +152,7 @@ def operate(operator_config: ForecastOperatorConfig) -> ForecastResults:
         results = ForecastResults()
         sub_results_list = []
         sub_models = {}
+        _log_auto_select_series_profile(meta_features)
 
         # Group the data by selected model
         for model_name in meta_features["selected_model"].unique():
@@ -199,6 +213,7 @@ def operate(operator_config: ForecastOperatorConfig) -> ForecastResults:
         series_model_selection = operator_config.spec.series_model_selection
         sub_results_list = []
         sub_models = {}
+        _log_auto_select_series_profile(series_model_selection)
 
         for model_name in series_model_selection["selected_model"].unique():
             series_groups = series_model_selection[

--- a/ads/opctl/operator/lowcode/forecast/__main__.py
+++ b/ads/opctl/operator/lowcode/forecast/__main__.py
@@ -12,11 +12,13 @@ from typing import Dict, List
 import pandas as pd
 import yaml
 
+from ads.common.object_storage_details import ObjectStorageDetails
 from ads.opctl import logger
 from ads.opctl.operator.common.const import ENV_OPERATOR_ARGS
 from ads.opctl.operator.common.utils import _parse_input_args
 from ads.opctl.operator.lowcode.anomaly.const import SupportedModels
 from ads.opctl.operator.lowcode.common.const import DataColumns
+from ads.opctl.operator.lowcode.common.utils import default_signer, write_pkl
 
 from .const import (
     AUTO_SELECT_SERIES,
@@ -92,6 +94,29 @@ def _merge_auto_select_series_backtesting_results(
     return results
 
 
+def _save_combined_model_pickle(
+        operator_config: ForecastOperatorConfig,
+        sub_models: Dict,
+) -> bool:
+    spec = operator_config.spec
+    if not spec.generate_model_pickle:
+        return False
+
+    output_dir = spec.output_directory.url
+    if not ObjectStorageDetails.is_oci_path(output_dir):
+        os.makedirs(output_dir, exist_ok=True)
+    storage_options = (
+        default_signer() if ObjectStorageDetails.is_oci_path(output_dir) else {}
+    )
+    write_pkl(
+        obj=sub_models,
+        filename="model.pkl",
+        output_dir=output_dir,
+        storage_options=storage_options,
+    )
+    return True
+
+
 def operate(operator_config: ForecastOperatorConfig) -> ForecastResults:
     """Runs the forecasting operator."""
     from .model.factory import ForecastOperatorModelFactory
@@ -113,6 +138,7 @@ def operate(operator_config: ForecastOperatorConfig) -> ForecastResults:
         meta_features = operator_config.spec.meta_features
         results = ForecastResults()
         sub_results_list = []
+        sub_models = {}
 
         # Group the data by selected model
         for model_name in meta_features["selected_model"].unique():
@@ -140,6 +166,15 @@ def operate(operator_config: ForecastOperatorConfig) -> ForecastResults:
                 save_sub_reports=True,
             )
             sub_results_list.append(sub_results)
+            sub_models[str(model_name)] = {
+                "series": [
+                    str(series_id)
+                    for series_id in series_groups[DataColumns.Series]
+                    .values.flatten()
+                    .tolist()
+                ],
+                "model_artifact": sub_results.get_models(),
+            }
 
         # Merge all sub_results into a single ForecastResults object
         if sub_results_list:
@@ -148,6 +183,10 @@ def operate(operator_config: ForecastOperatorConfig) -> ForecastResults:
                 results.merge(sub_result)
         else:
             results = None
+        _save_combined_model_pickle(
+            operator_config=operator_config,
+            sub_models=sub_models,
+        )
 
     elif (
         operator_config.spec.model == AUTO_SELECT_SERIES
@@ -159,6 +198,7 @@ def operate(operator_config: ForecastOperatorConfig) -> ForecastResults:
         # For backtesting-based AUTO_SELECT_SERIES, handle each series with its winner.
         series_model_selection = operator_config.spec.series_model_selection
         sub_results_list = []
+        sub_models = {}
 
         for model_name in series_model_selection["selected_model"].unique():
             series_groups = series_model_selection[
@@ -183,11 +223,24 @@ def operate(operator_config: ForecastOperatorConfig) -> ForecastResults:
                 save_sub_reports=True,
             )
             sub_results_list.append(sub_results)
+            sub_models[str(model_name)] = {
+                "series": [
+                    str(series_id)
+                    for series_id in series_groups[DataColumns.Series]
+                    .values.flatten()
+                    .tolist()
+                ],
+                "model_artifact": sub_results.get_models(),
+            }
 
         results = (
             _merge_auto_select_series_backtesting_results(sub_results_list)
             if sub_results_list
             else None
+        )
+        _save_combined_model_pickle(
+            operator_config=operator_config,
+            sub_models=sub_models,
         )
 
     else:

--- a/ads/opctl/operator/lowcode/forecast/model/forecast_datasets.py
+++ b/ads/opctl/operator/lowcode/forecast/model/forecast_datasets.py
@@ -467,7 +467,6 @@ class ForecastResults:
         "local_explanations",
         "global_explanations",
         "model_parameters",
-        "models",
         "errors_dict",
     ]
 

--- a/ads/opctl/operator/lowcode/forecast/whatifserve/deployment_manager.py
+++ b/ads/opctl/operator/lowcode/forecast/whatifserve/deployment_manager.py
@@ -36,6 +36,9 @@ from ads.opctl.operator.lowcode.common.utils import (
 
 from ..model.forecast_datasets import AdditionalData
 from ..operator_config import ForecastOperatorSpec
+from ..const import AUTO_SELECT_SERIES
+
+_AUTO_SELECT_SERIES_WHAT_IF_UNSUPPORTED_MODELS = {"ets", "theta"}
 
 
 class ModelDeploymentManager:
@@ -72,6 +75,19 @@ class ModelDeploymentManager:
         self.test_mode = os.environ.get("TEST_MODE", False)
         self.deployment_info = {}
 
+    def _get_model_series(self):
+        """Return the series ids represented by the loaded model artifact."""
+        if self.model_name == AUTO_SELECT_SERIES and isinstance(self.model_obj, dict):
+            return [
+                series
+                for model_name, model_info in self.model_obj.items()
+                if str(model_name).lower()
+                not in _AUTO_SELECT_SERIES_WHAT_IF_UNSUPPORTED_MODELS
+                if isinstance(model_info, dict)
+                for series in model_info.get("series", [])
+            ]
+        return list(self.additional_data.keys())
+
     def _sanity_test(self):
         """
         Function perform sanity test for saved artifact
@@ -85,7 +101,13 @@ class ModelDeploymentManager:
 
             # Write additional data to tmp file and perform sanity check
             with tempfile.NamedTemporaryFile(suffix=".csv") as temp_file:
-                one_series = next(iter(self.additional_data))
+                available_series = self._get_model_series()
+                if not available_series:
+                    raise ValueError(
+                        "No what-if-supported models were selected during "
+                        "automatic model selection."
+                    )
+                one_series = available_series[0]
                 sample_prediction_data = self.additional_data[one_series].tail(
                     self.horizon
                 )
@@ -150,10 +172,7 @@ class ModelDeploymentManager:
         self._copy_score_file()
         self._sanity_test()
 
-        if isinstance(self.model_obj, dict):
-            series = self.model_obj.keys()
-        else:
-            series = self.additional_data.keys()
+        series = self._get_model_series()
         description = f"The object contains {len(series)} {self.model_name} models"
 
         if not self.test_mode:

--- a/ads/opctl/operator/lowcode/forecast/whatifserve/score.py
+++ b/ads/opctl/operator/lowcode/forecast/whatifserve/score.py
@@ -13,7 +13,11 @@ import logging
 import ads
 from ads.opctl.operator.lowcode.common.utils import load_data
 from ads.opctl.operator.common.operator_config import InputData
-from ads.opctl.operator.lowcode.forecast.const import SupportedModels, ForecastOutputColumns
+from ads.opctl.operator.lowcode.forecast.const import (
+    AUTO_SELECT_SERIES,
+    SupportedModels,
+    ForecastOutputColumns,
+)
 
 ads.set_auth("resource_principal")
 
@@ -128,6 +132,35 @@ def post_inference(yhat):
     if isinstance(yhat, np.ndarray):
         yhat = yhat.tolist()
     return yhat
+
+
+def resolve_model_for_series(models, default_model_name, series_id):
+    """
+    Resolve the model framework and artifact to use for one series.
+
+    Normal forecast artifacts use one model framework for all series, so this
+    returns ``default_model_name`` and the original artifact unchanged. Combined
+    auto-select-series artifacts are keyed by model name. Each entry stores the
+    series assigned to that model and the model artifact for them.
+    """
+    if default_model_name != AUTO_SELECT_SERIES:
+        return default_model_name, models
+
+    if not isinstance(models, dict):
+        raise Exception("auto-select-series model artifact must be a dictionary.")
+
+    for model_name, model_info in models.items():
+        if not isinstance(model_info, dict):
+            continue
+        model_series = [str(series) for series in model_info.get("series", [])]
+        if str(series_id) in model_series:
+            return model_name, model_info.get("model_artifact")
+
+    logger_pred.warning(
+        "Skipping series %s because no what-if model artifact is available.",
+        series_id,
+    )
+    return None, None
 
 
 def get_forecast(future_df, model_name, series_id, model_object, date_col, target_column, target_cat_col, horizon):
@@ -283,8 +316,23 @@ def predict(data, model=load_model()) -> dict:
             s_id = str(key)
             filtered = additional_data[additional_data[target_category_column] == key]
             future = filtered.tail(horizon)
-            forecast = get_forecast(future, model_name, s_id, models, date_col,
-                                    target_column, target_category_column, horizon)
+            selected_model_name, selected_model_object = resolve_model_for_series(
+                models,
+                model_name,
+                s_id,
+            )
+            if selected_model_name is None:
+                continue
+            forecast = get_forecast(
+                future,
+                selected_model_name,
+                s_id,
+                selected_model_object,
+                date_col,
+                target_column,
+                target_category_column,
+                horizon,
+            )
             forecasts[s_id] = json.dumps(forecast)
         except Exception as e:
             raise RuntimeError(

--- a/docs/source/user_guide/operators/forecast_operator/index.rst
+++ b/docs/source/user_guide/operators/forecast_operator/index.rst
@@ -110,15 +110,13 @@ The model name can be any of the following:
     - **NeuralProphet** - Recommended for large or wide datasets
     - **AutoTS** - M6 Benchmark winner. Recommended if the other frameworks aren't providing enough accuracy
     - **Auto-Select** - Backtests multiple frameworks and picks the single best performer across the series.
-    - **Auto-Select-Series** - Chooses a model per series using either the default meta-learning strategy or an optional backtesting strategy. By default it will run with meta-learning strategy which is faster as well.
-      In meta-learning strategy, the operator extracts meta-features from each series (including frequency, variability, and exogenous behaviour) and then uses the trained meta model to recommend one of the best supported model.
-      In backtesting strategy, the operator tries several forecasting models on past data for each series, chooses the model that performed best for that specific series, then uses it to generate the final forecast.
+    - **Auto-Select-Series** - Chooses a model per series using either the default ``meta_learning`` strategy or an optional ``backtesting`` strategy. ``meta_learning`` is designed for fast, low-latency model selection, while ``backtesting`` is designed for more evidence-based, potentially more accurate selection by validating candidates against each series' history.
 
 
 Auto-Select the Best Model
 ---------------------------
 
-``Auto-Select`` backtests multiple models and selects the overall best performer across the series. 
+``Auto-Select`` backtests multiple models and selects the overall best performer across the series.
 ``Auto-Select-Series`` supports two per-series selection strategies. By default it derives meta-features per series, infers from a trained meta model, and recommends the forecasting framework that performed best during meta-model training for that series' pattern.
 Users can select which models to include using the ``model_list`` parameter.
 Users can tune the number of backtests per model using the ``num_backtests`` parameter, which is 5 by default.
@@ -143,7 +141,7 @@ Automatically Choosing the Right Model Per Series
   model_kwargs:
     selection_strategy: meta_learning
 
-Use this option when you want the operator to apply a meta-learning model for every series. The operator extracts meta-features from each series (including frequency, variability, and exogenous behaviour) and then uses the trained meta model to recommend one of the supported frameworks (``arima``, ``ets``, ``lgbforecast``, ``prophet``, ``theta``, ``xgbforecast``) per series.
+Use this option when model-selection latency should stay very low, including millisecond-level selection. The operator extracts meta-features from each series (including frequency, variability, and exogenous behaviour) and then uses a trained meta-learning selector to recommend one of the supported frameworks (``arima``, ``ets``, ``lgbforecast``, ``prophet``, ``theta``, ``xgbforecast``) per series without running historical backtests for every candidate.
 
 
 Backtesting Candidate Models Per Series
@@ -157,8 +155,30 @@ Backtesting Candidate Models Per Series
     model_list: ["prophet", "arima"]
     num_backtests: 5
 
-Use this option when you want ``auto-select-series`` to evaluate a fixed model list with historical backtests for each series instead of using the default meta-learning selector. The operator compares the candidate models independently per series using the configured metric, picks the winner for that series, and then retrains that winning model on the full series history before producing the final forecast.
+Use this option when you want ``auto-select-series`` to evaluate a fixed model list with historical backtests for each series instead of using the default meta-learning selector. This is especially useful for noisy series and can improve accuracy when recent historical performance is the best signal for model choice. The operator compares the candidate models independently per series using the configured metric, picks the winner for that series, and then retrains that winning model on the full series history before producing the final forecast. Because every candidate is backtested per series, this strategy trades additional runtime for more evidence-based model selection.
 If ``model_list`` is omitted, the operator evaluates all supported concrete forecasting models by default.
+
+
+Global and Per-Series Models
+----------------------------
+
+Some forecasting frameworks train one model across all series, while others fit one model per series.
+
+.. list-table::
+   :widths: 25 35 40
+   :header-rows: 1
+
+   * - Behavior
+     - Models
+     - Notes
+   * - Global
+     - ``lgbforecast``, ``xgbforecast``
+     - Learns shared patterns across related series. This can help with short, sparse, or noisy series because the model can use signal from the broader dataset.
+   * - Per-series
+     - ``prophet``, ``arima``, ``neuralprophet``, ``theta``, ``ets``
+     - Fits each series independently.
+
+When ``auto-select-series`` chooses the model for each series, it groups series by the selected framework and runs each group with that framework. If a global model is selected for a group, the series in that group are trained together.
 
 
 Additional Modeling Options
@@ -276,6 +296,8 @@ Multiple Related Forecasts
 
 Often times in forecasting there are multiple related forecasts we want to perform simultaneously. For example, a store owner may want to forecast the sales of all 1000 of their SKUs. This store owner can run the Operator once on all of the SKUs, generate thousands of models, and compare the results in 1 simple report.
 The key to running multiple related forecasts is the ``target_category_columns`` parameter. Our store owner can set the ``target_category_columns = SKU_ID``
+
+For best results, the ``target_column`` should represent one consistent business measure in a forecasting run.
 
 
 ===========   =========   ========= 

--- a/docs/source/user_guide/operators/forecast_operator/use_cases.rst
+++ b/docs/source/user_guide/operators/forecast_operator/use_cases.rst
@@ -20,13 +20,34 @@ Which Model is Right for You?
 - **AutoTS**: A global model that works well with wide datasets but can take a long time to train, especially on long datasets. For faster initial runs, consider passing ``model_list: superfast`` in the model kwargs. To fully utilize AutoTS, set ``model_list: all`` in the ``model_kwargs``; however, this may significantly increase runtime or cause the model to hang.
 - **Prophet and NeuralProphet**: These models are more consistent in their completion times and perform well on most datasets.
 - **AutoMLX**: Not recommended for datasets with intervals shorter than 1 hour.
+- **Auto-Select-Series**: Use ``model_kwargs.selection_strategy: meta_learning`` for fast, low-latency model selection. Use ``model_kwargs.selection_strategy: backtesting`` when noisy series need accuracy-oriented, evidence-based historical validation.
 - **Explainability**: Generating explanations can take several minutes to hours. Explanations are disabled by default (``generate_explanations: False``). Enabling them (``generate_explanations: True``) and scaling up your compute shape can speed up this highly parallelized computation.
+
+Global and Per-Series Models
+----------------------------
+
+The operator supports both global and per-series forecasting frameworks.
+
+.. list-table::
+   :widths: 25 35 40
+   :header-rows: 1
+
+   * - Behavior
+     - Models
+     - Best fit
+   * - Global
+     - ``lgbforecast``, ``xgbforecast``, ``autots``
+     - Many related series that can benefit from shared seasonality, trend, and cross-series signal.
+   * - Per-series
+     - ``prophet``, ``arima``, ``neuralprophet``, ``automlx``, ``theta``, ``ets``
+     - Series that should be modeled independently.
 
 Target Column
 -------------
 
 - The target column must be present in the dataset specified in the ``historical_data`` field.
 - The ``historical_data`` dataset must include: 1) a target column, 2) a datetime column, and optionally, 3) a target_category_column or series.
+- The ``target_column`` should represent one consistent business measure in a forecasting run. For example, keep sales, revenue, and unit price forecasts in separate runs so the forecast output, validation rules, and downstream interpretation have one clear meaning.
 - The ``historical_data`` dataset should not contain any other columns.
 - If you include ``additional_data``, it must have the same datetime column, the target_category_column (if present in the historical data), and any other required additional features.
 - The ``additional_data`` dataset should not contain the target column.

--- a/docs/source/user_guide/operators/forecast_operator/yaml_schema.rst
+++ b/docs/source/user_guide/operators/forecast_operator/yaml_schema.rst
@@ -107,7 +107,7 @@ Below is an example of a ``forecast.yaml`` file with every parameter specified:
      - string
      - Yes
      - target
-     - Column to forecast.
+     - Column to forecast. Use one consistent business measure per forecasting run, such as sales, revenue, or unit price.
 
    * - datetime_column.name
      - string
@@ -138,14 +138,14 @@ Below is an example of a ``forecast.yaml`` file with every parameter specified:
      - No
      - prophet
      - Model to use. Options: prophet, arima, neuralprophet, theta, ets, lgbforecast, xgbforecast, automlx, autots, auto-select, auto-select-series.
-       ``auto-select-series`` defaults to the ``meta_learning`` selection strategy and assigns ``arima``, ``ets``, ``lgbforecast``, ``prophet``, ``theta``, or ``xgbforecast`` per series using meta-features and a trained selector.
-       Set ``model_kwargs.selection_strategy`` to ``backtesting`` to backtest a fixed candidate list for each series independently and then retrain the winning model for that series on the full history. If ``model_kwargs.model_list`` is omitted, it evaluates all supported concrete forecasting models by default.
+       ``auto-select-series`` defaults to the fast ``meta_learning`` selection strategy and assigns ``arima``, ``ets``, ``lgbforecast``, ``prophet``, ``theta``, or ``xgbforecast`` per series using meta-features and a trained selector.
+       Set ``model_kwargs.selection_strategy`` to ``backtesting`` to backtest a fixed candidate list for each series independently and then retrain the winning model for that series on the full history. This can improve accuracy for noisy series by validating candidates against recent history and trading additional runtime for more evidence-based model selection. If ``model_kwargs.model_list`` is omitted, it evaluates all supported concrete forecasting models by default.
 
    * - model_kwargs
      - dict
      - No
      -
-     - Parameters specific to the chosen model. For ``auto-select-series``, use ``selection_strategy: meta_learning`` for the default meta-learning selector or ``selection_strategy: backtesting`` for per-series historical backtesting.
+     - Parameters specific to the chosen model. For ``auto-select-series``, use ``selection_strategy: meta_learning`` for fast, low-latency selection or ``selection_strategy: backtesting`` for per-series historical backtesting.
 
    * - preprocessing.enabled
      - boolean
@@ -247,7 +247,7 @@ Further Description
         * **options**: (Optional) Include any additional arguments for loading the data, such as ``filters``, ``columns``, and ``sql`` query parameters.
         * **vault_secret_id**: (Optional) The Vault secret ID for secure access if needed.
 
-    * **target_column**: This string specifies the name of the target data column within the historical data. The default is ``target``.
+    * **target_column**: This string specifies the name of the target data column within the historical data. The default is ``target``. The target column should represent one consistent business measure in a run. For example, keep sales, revenue, and unit price forecasts in separate runs so the forecast output and downstream interpretation have one clear meaning.
     
     * **datetime_column**: This dictionary outlines details about the datetime column.
         * **name**: The name of the datetime column. It must match between the historical and additional data. The default is ``Date``.
@@ -270,7 +270,7 @@ Further Description
 
     * **model**: (Optional) The name of the model framework to use. Defaults to ``prophet``. Available options include ``prophet``, ``arima``, ``neuralprophet``, ``theta``, ``ets``, ``lgbforecast``, ``xgbforecast``, ``automlx``, ``autots``, ``auto-select``, and ``auto-select-series``.
 
-    * **model_kwargs**: (Optional) A dictionary of arguments to pass directly to the model framework, allowing for detailed control over modeling. For ``auto-select-series``, set ``selection_strategy`` to ``meta_learning`` (default) or ``backtesting``.
+    * **model_kwargs**: (Optional) A dictionary of arguments to pass directly to the model framework, allowing for detailed control over modeling. For ``auto-select-series``, set ``selection_strategy`` to ``meta_learning`` (default) or ``backtesting``. ``meta_learning`` is designed for fast, low-latency model selection. ``backtesting`` is designed for more evidence-based, potentially more accurate selection by validating candidate models against each series' history.
 
     * **test_data**: (Optional) This dictionary specifies how to load test data, which must be formatted identically to the historical data and include values for every period in the forecast horizon.
         * **url**: Provide the URI for the dataset, using a pattern like ``oci://<bucket>@<namespace>/path/to/data.csv``.

--- a/tests/operators/forecast/test_errors.py
+++ b/tests/operators/forecast/test_errors.py
@@ -178,15 +178,22 @@ def operator_setup():
         yield tmpdirname
 
 
-def run_yaml(tmpdirname, yaml_i, output_data_path, test_metrics_check=True):
+def run_yaml(
+    tmpdirname,
+    yaml_i,
+    output_data_path,
+    test_metrics_check=True,
+    train_metrics_check=True,
+):
     run(yaml_i, backend="operator.local", debug=True)
     subprocess.run(f"ls -a {output_data_path}", shell=True)
 
     if test_metrics_check:
         test_metrics = pd.read_csv(f"{output_data_path}/test_metrics.csv")
         print(test_metrics)
-    train_metrics = pd.read_csv(f"{output_data_path}/metrics.csv")
-    print(train_metrics)
+    if train_metrics_check:
+        train_metrics = pd.read_csv(f"{output_data_path}/metrics.csv")
+        print(train_metrics)
 
 
 def populate_yaml(
@@ -816,29 +823,21 @@ def test_date_format(operator_setup, model):
     )
 
 
-@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("model", MODELS + ["auto-select-series"])
 def test_what_if_analysis(operator_setup, model):
     os.environ["TEST_MODE"] = "True"
     if model in ["auto-select", "theta", "ets"]:
         pytest.skip(f"Skipping what-if scenario for {model}")
     tmpdirname = operator_setup
-    historical_data_path, additional_data_path = setup_small_rossman()
-    additional_test_path = f"{tmpdirname}/additional_data.csv"
-    historical_test_path = f"{tmpdirname}/historical_data.csv"
-    historical_data = pd.read_csv(historical_data_path, parse_dates=["Date"])
-    historical_filtered = historical_data[historical_data["Date"] > "2013-03-01"]
-    additional_data = pd.read_csv(additional_data_path, parse_dates=["Date"])
-    add_filtered = additional_data[additional_data["Date"] > "2013-03-01"]
-    add_filtered.to_csv(f"{additional_test_path}", index=False)
-    historical_filtered.to_csv(f"{historical_test_path}", index=False)
+    historical_data_path, additional_data_path, _ = setup_rossman()
 
     yaml_i, output_data_path = populate_yaml(
         tmpdirname=tmpdirname,
-        historical_data_path=historical_test_path,
-        additional_data_path=additional_test_path,
+        historical_data_path=historical_data_path,
+        additional_data_path=additional_data_path,
         output_data_path=f"{tmpdirname}/{model}/results",
     )
-    yaml_i["spec"]["horizon"] = 10
+    yaml_i["spec"]["horizon"] = 5
     yaml_i["spec"]["model"] = model
     yaml_i["spec"]["what_if_analysis"] = {
         "model_name": f"model_{model}",
@@ -852,10 +851,11 @@ def test_what_if_analysis(operator_setup, model):
         yaml_i=yaml_i,
         output_data_path=output_data_path,
         test_metrics_check=False,
+        train_metrics_check=model != "auto-select-series",
     )
-    report_path = f"{output_data_path}/report.html"
     deployment_metadata = f"{output_data_path}/deployment_info.json"
-    assert os.path.exists(report_path), f"Report file not found at {report_path}"
+    report_files = list(Path(output_data_path).glob("report*.html"))
+    assert report_files, f"No report files found under {output_data_path}"
     assert os.path.exists(
         deployment_metadata
     ), f"Deployment info file not found at {deployment_metadata}"

--- a/tests/operators/forecast/test_errors.py
+++ b/tests/operators/forecast/test_errors.py
@@ -254,12 +254,32 @@ def run_operator(
     run_yaml(tmpdirname=tmpdirname, yaml_i=yaml_i, output_data_path=output_data_path)
 
 
-def setup_rossman():
+def setup_rossman(tmpdirname=None, series_id=None):
     curr_dir = pathlib.Path(__file__).parent.resolve()
     data_folder = f"{curr_dir}/../data/"
     historical_data_path = f"{data_folder}/rs_10_prim.csv"
     additional_data_path = f"{data_folder}/rs_10_add.csv"
     test_data_path = f"{data_folder}/rs_10_test.csv"
+
+    if series_id is None:
+        return historical_data_path, additional_data_path, test_data_path
+
+    assert tmpdirname is not None, "tmpdirname is required when selecting a Rossman series"
+
+    selected_paths = []
+    for source_path, filename in [
+        (historical_data_path, "rs_10_prim_selected.csv"),
+        (additional_data_path, "rs_10_add_selected.csv"),
+        (test_data_path, "rs_10_test_selected.csv"),
+    ]:
+        df = pd.read_csv(source_path)
+        selected = df[df["Store"].astype(str) == str(series_id)]
+        assert not selected.empty, f"Store {series_id} not found in {source_path}"
+        selected_path = f"{tmpdirname}/{filename}"
+        selected.to_csv(selected_path, index=False)
+        selected_paths.append(selected_path)
+
+    historical_data_path, additional_data_path, test_data_path = selected_paths
     return historical_data_path, additional_data_path, test_data_path
 
 
@@ -829,7 +849,10 @@ def test_what_if_analysis(operator_setup, model):
     if model in ["auto-select", "theta", "ets"]:
         pytest.skip(f"Skipping what-if scenario for {model}")
     tmpdirname = operator_setup
-    historical_data_path, additional_data_path, _ = setup_rossman()
+    historical_data_path, additional_data_path, _ = setup_rossman(
+        tmpdirname=tmpdirname,
+        series_id=1,
+    )
 
     yaml_i, output_data_path = populate_yaml(
         tmpdirname=tmpdirname,


### PR DESCRIPTION
## Summary
- Add what-if support for `auto-select-series` workflow.
- Use one `model.pkl` artifact for auto-select-series what-if analysis, instead of separate files for the different models used across series.
- Exclude Theta and ETS from what-if analysis because they do not use exogenous features.
- Update forecast operator docs for selection strategy guidance and model behavior.

[ODSC-87420](https://jira.oci.oraclecorp.com/browse/ODSC-87420)
[ODSC-87436](https://jira.oci.oraclecorp.com/browse/ODSC-87436)