### PR TITLE
Exclude AutoMLX and AutoTS from Forecast Operator auto-select defaults

### DIFF
--- a/ads/opctl/operator/lowcode/forecast/const.py
+++ b/ads/opctl/operator/lowcode/forecast/const.py
@@ -104,5 +104,12 @@ AUTO_SELECT_SERIES = "auto-select-series"
 AUTO_SELECT_SERIES_SELECTION_STRATEGY_KEY = "selection_strategy"
 BACKTEST_REPORT_NAME = "back_test.csv"
 SERIES_BACKTEST_REPORT_NAME = "series_back_test.csv"
-DEFAULT_AUTO_SELECT_SERIES_BACKTESTING_MODELS = [SupportedModels.Theta, SupportedModels.ETSForecaster, SupportedModels.Arima, SupportedModels.Prophet, SupportedModels.LGBForecast, SupportedModels.XGBForecast]
+DEFAULT_AUTO_SELECT_MODELS = [
+    SupportedModels.Theta,
+    SupportedModels.ETSForecaster,
+    SupportedModels.Arima,
+    SupportedModels.Prophet,
+    SupportedModels.LGBForecast,
+    SupportedModels.XGBForecast,
+]
 TROUBLESHOOTING_GUIDE = "https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-operators/troubleshooting.md"

--- a/ads/opctl/operator/lowcode/forecast/model/factory.py
+++ b/ads/opctl/operator/lowcode/forecast/model/factory.py
@@ -10,7 +10,7 @@ from ..const import (
     AUTO_SELECT_SERIES,
     AUTO_SELECT_SERIES_SELECTION_STRATEGY_KEY,
     AutoSelectSeriesSelectionStrategy,
-    DEFAULT_AUTO_SELECT_SERIES_BACKTESTING_MODELS,
+    DEFAULT_AUTO_SELECT_MODELS,
     ForecastOutputColumns,
     TROUBLESHOOTING_GUIDE,
     SpeedAccuracyMode,
@@ -124,13 +124,15 @@ class ForecastOperatorModelFactory:
             cls, datasets: ForecastDatasets, operator_config: ForecastOperatorConfig
     ) -> str:
         """
-        Selects AutoMLX or Arima model based on column count.
+        Select the best model for AUTO_SELECT using backtesting.
 
-        If the number of columns is less than or equal to the maximum allowed for AutoMLX,
-        returns 'AutoMLX'. Otherwise, returns 'Arima'.
+        If no ``model_list`` is provided, the evaluator uses the curated default
+        candidate list instead of every registered forecasting model.
 
         Parameters
         ------------
+        operator_config : ForecastOperatorConfig
+            Operator configuration containing model selection options.
         datasets:  ForecastDatasets
                 Datasets for predictions
 
@@ -140,7 +142,7 @@ class ForecastOperatorModelFactory:
             The type of the model.
         """
         all_models = operator_config.spec.model_kwargs.get(
-            "model_list", cls._MAP.keys()
+            "model_list", DEFAULT_AUTO_SELECT_MODELS
         )
         num_backtests = operator_config.spec.model_kwargs.get("num_backtests", 5)
         sample_ratio = operator_config.spec.model_kwargs.get("sample_ratio", 0.20)
@@ -204,7 +206,7 @@ class ForecastOperatorModelFactory:
             The most frequently selected model across all series.
         """
         all_models = operator_config.spec.model_kwargs.get(
-            "model_list", DEFAULT_AUTO_SELECT_SERIES_BACKTESTING_MODELS
+            "model_list", DEFAULT_AUTO_SELECT_MODELS
         )
         if AUTO_SELECT_SERIES in all_models:
             all_models = [

--- a/tests/unitary/with_extras/operator/forecast/test_model_factory.py
+++ b/tests/unitary/with_extras/operator/forecast/test_model_factory.py
@@ -12,7 +12,7 @@ import pandas as pd
 from ads.opctl.operator.lowcode.forecast.const import (
     AUTO_SELECT_SERIES,
     AutoSelectSeriesSelectionStrategy,
-    DEFAULT_AUTO_SELECT_SERIES_BACKTESTING_MODELS,
+    DEFAULT_AUTO_SELECT_MODELS,
 )
 from ads.opctl.operator.lowcode.forecast.model.factory import (
     ForecastOperatorModelFactory,
@@ -48,7 +48,7 @@ class TestForecastOperatorModelFactory:
             )
 
         evaluator_cls.assert_called_once_with(
-            DEFAULT_AUTO_SELECT_SERIES_BACKTESTING_MODELS,
+            DEFAULT_AUTO_SELECT_MODELS,
             5,
         )
         assert selected_model == "prophet"


### PR DESCRIPTION
`automlx` and `autots` remain supported when users explicitly select them, but they are no longer included by default in auto-select workflows 
[ODSC-88122](https://jira.oci.oraclecorp.com/browse/ODSC-88122)
