### PR TITLE
Fix ARIMA failure on sparse series with confidence intervals

### DIFF
--- a/ads/opctl/operator/lowcode/forecast/model/arima.py
+++ b/ads/opctl/operator/lowcode/forecast/model/arima.py
@@ -41,7 +41,7 @@ class ArimaOperatorModel(ForecastOperatorBaseModel):
                 "alpha", 0.05
             )
         model_kwargs = self.spec.model_kwargs
-        model_kwargs["alpha"] = 1 - self.spec.confidence_interval_width
+        self.prediction_alpha = 1 - self.spec.confidence_interval_width
         if "error_action" not in model_kwargs:
             model_kwargs["error_action"] = "ignore"
         return model_kwargs
@@ -101,7 +101,7 @@ class ArimaOperatorModel(ForecastOperatorBaseModel):
                 n_periods=self.spec.horizon,
                 X=X_pred,
                 return_conf_int=True,
-                alpha=model_kwargs["alpha"],
+                alpha=self.prediction_alpha,
             )
             yhat_clean = pd.DataFrame(yhat, index=yhat.index, columns=["yhat"])
 

--- a/ads/opctl/operator/lowcode/forecast/model/automlx.py
+++ b/ads/opctl/operator/lowcode/forecast/model/automlx.py
@@ -94,7 +94,6 @@ class AutoMLXOperatorModel(ForecastOperatorBaseModel):
 
         self.models = {}
         horizon = self.spec.horizon
-        self.spec.confidence_interval_width = self.spec.confidence_interval_width or 0.8
         self.forecast_output = ForecastOutput(
             confidence_interval_width=self.spec.confidence_interval_width,
             horizon=self.spec.horizon,

--- a/ads/opctl/operator/lowcode/forecast/operator_config.py
+++ b/ads/opctl/operator/lowcode/forecast/operator_config.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List
 
 from ads.common.serializer import DataClassSerializable
+from ads.opctl import logger
 from ads.opctl.operator.common.operator_config import (
     InputData,
     OperatorConfig,
@@ -139,7 +140,16 @@ class ForecastOperatorSpec(DataClassSerializable):
         self.generate_model_pickle = self.generate_model_pickle or self.what_if_analysis
         self.metric = (self.metric or "").lower() or SupportedMetrics.SMAPE.lower()
         self.model = self.model or SupportedModels.Prophet
-        self.confidence_interval_width = self.confidence_interval_width or 0.80
+        if self.confidence_interval_width is None:
+            self.confidence_interval_width = 0.80
+        elif not 0 < self.confidence_interval_width < 1:
+            logger.warning(
+                "Ignoring invalid confidence_interval_width=%s. "
+                "The value must be greater than 0 and less than 1. "
+                "Using the default value 0.80.",
+                self.confidence_interval_width,
+            )
+            self.confidence_interval_width = 0.80
         self.report_filename = self.report_filename or "report.html"
         self.preprocessing = (
             self.preprocessing

--- a/docs/source/user_guide/operators/forecast_operator/yaml_schema.rst
+++ b/docs/source/user_guide/operators/forecast_operator/yaml_schema.rst
@@ -223,7 +223,7 @@ Below is an example of a ``forecast.yaml`` file with every parameter specified:
      - float
      - No
      - 0.80
-     - Width of confidence intervals in forecast.
+     - Width of confidence intervals in forecast. Must be greater than 0 and less than 1.
 
    * - tuning.n_trials
      - integer
@@ -286,7 +286,7 @@ Further Description
 
     * **metric**: (Optional) The metric to select during model evaluation. Options include ``MAPE``, ``RMSE``, ``MSE``, and ``SMAPE``. The default is ``MAPE``.
 
-    * **confidence_interval_width**: (Optional) The width of the confidence interval to calculate in the forecast. The default is 0.80, indicating an 80% confidence interval.
+    * **confidence_interval_width**: (Optional) The width of the confidence interval to calculate in the forecast. Must be greater than 0 and less than 1. The default is 0.80, indicating an 80% confidence interval.
 
     * **report_filename**: (Optional) The name of the report file. It is saved in the output directory, with a default name of ``report.html``.
     


### PR DESCRIPTION
This PR fixes a small ARIMA bug where the Forecast Operator’s confidence_interval_width was also being passed into auto_arima as the training/model-selection alpha. In rare cases with extremely sparse data, this could cause ARIMA to select an unstable differenced model and fail while generating confidence intervals.

The fix keeps confidence interval alpha separate from ARIMA training kwargs, so the interval setting is only used during prediction.

This PR also includes related cleanup for confidence_interval_width handling:

- Add a warning when Forecast Operator receives an invalid confidence_interval_width.
- Preserve valid values where 0 < confidence_interval_width < 1.
- Keep the default 0.80 behavior when the value is omitted.
- Document the supported range in the Forecast Operator YAML schema docs.