### PR TITLE
Fix AQUA Hugging Face model search compatibility

### DIFF
--- a/ads/aqua/common/utils.py
+++ b/ads/aqua/common/utils.py
@@ -1170,7 +1170,7 @@ def format_hf_custom_error_message(error: HfHubHTTPError):
             "Please check the revision identifier and try again.",
             service_payload={"error": "RevisionNotFoundError"},
         )
-                
+
     raise AquaRuntimeError(
         reason=f"An error occurred while accessing `{url}` "
         "Please check your network connection and try again. "
@@ -1205,14 +1205,29 @@ def get_hf_model_info(repo_id: str) -> ModelInfo:
 def list_hf_models(query: str) -> List[str]:
     try:
         models = HfApi().list_models(
-            model_name=query,
+            search=query,
             sort="downloads",
-            direction=-1,
             limit=500,
         )
-        return [model.id for model in models if model.disabled is None]
+        return [
+            model.id
+            for model in sorted(
+                models,
+                key=lambda model: getattr(model, "downloads", 0) or 0,
+                reverse=True,
+            )
+            if getattr(model, "disabled", None) is not True
+        ]
     except HfHubHTTPError as err:
         raise format_hf_custom_error_message(err) from err
+    except TypeError as err:
+        raise AquaRuntimeError(
+            reason=(
+                "Unable to list Hugging Face models because the installed "
+                "`huggingface_hub` package is incompatible with ADS AQUA."
+            ),
+            service_payload={"error": "HuggingFaceHubClientCompatibilityError"},
+        ) from err
 
 
 def generate_tei_cmd_var(os_path: str) -> List[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ opctl = [
   "rich",
   "fire",
   "cachetools",
-  "huggingface_hub"
+  "huggingface_hub>=0.36.2,<0.37"
 ]
 optuna = ["optuna==2.9.0", "oracle_ads[viz]"]
 spark = ["pyspark>=3.0.0"]
@@ -230,7 +230,7 @@ aqua = [
   "notebook>=6.4,<=6.6",
   "fire",
   "cachetools",
-  "huggingface_hub",
+  "huggingface_hub>=0.36.2,<0.37",
   "python-dotenv",
   "rich",
   "openai==1.109.1"

--- a/tests/unitary/with_extras/aqua/test_model_handler.py
+++ b/tests/unitary/with_extras/aqua/test_model_handler.py
@@ -14,7 +14,7 @@ from notebook.base.handlers import HTTPError, IPythonHandler
 from parameterized import parameterized
 
 from ads.aqua.common.errors import AquaRuntimeError
-from ads.aqua.common.utils import get_hf_model_info
+from ads.aqua.common.utils import get_hf_model_info, list_hf_models
 from ads.aqua.constants import AQUA_TROUBLESHOOTING_LINK, STATUS_CODE_MESSAGES, AQUA_CHAT_TEMPLATE_METADATA_KEY
 from ads.aqua.extension.errors import ReplyDetails
 from ads.aqua.extension.model_handler import (
@@ -375,6 +375,46 @@ class TestAquaHuggingFaceHandler:
             self.mock_handler.finish = MagicMock()
             self.mock_handler.set_header = MagicMock()
             self.mock_handler.set_status = MagicMock()
+
+    def teardown_method(self):
+        get_hf_model_info.cache_clear()
+        list_hf_models.cache_clear()
+
+    @patch.object(HfApi, "list_models")
+    def test_get_positive(self, mock_list_models):
+        self.mock_handler.get_argument = MagicMock(return_value="bert")
+        mock_list_models.return_value = [
+            MagicMock(id="organization/model-low", disabled=False, downloads=10),
+            MagicMock(id="organization/model-disabled", disabled=True, downloads=100),
+            MagicMock(id="organization/model-high", disabled=None, downloads=20),
+        ]
+
+        self.mock_handler.get()
+
+        mock_list_models.assert_called_once_with(
+            search="bert",
+            sort="downloads",
+            limit=500,
+        )
+        self.mock_handler.finish.assert_called_with(
+            {"models": ["organization/model-high", "organization/model-low"]}
+        )
+
+    @patch.object(HfApi, "list_models")
+    def test_get_hf_client_signature_error(self, mock_list_models):
+        self.mock_handler.get_argument = MagicMock(return_value="bert")
+        mock_list_models.side_effect = TypeError(
+            "HfApi.list_models() got an unexpected keyword argument 'direction'"
+        )
+
+        self.mock_handler.get()
+
+        reply_details = self.mock_handler.finish.call_args.args[0]
+        assert reply_details.status == 400
+        assert reply_details.service_payload == {
+            "error": "HuggingFaceHubClientCompatibilityError"
+        }
+        assert "installed `huggingface_hub` package is incompatible" in reply_details.reason
 
     @pytest.mark.parametrize(
         "test_model_id, test_author, expected_aqua_model_name, expected_aqua_model_id",


### PR DESCRIPTION
## Summary
- constrain `huggingface_hub` for ADS `aqua` and `opctl` extras to the tested `0.36.x` line
- update AQUA Hugging Face model search to use the supported `search` argument instead of the deprecated/stale call shape
- add regression coverage for the AQUA Hugging Face search path and client signature failures

## Details
AQUA model registration could fail in the Hugging Face GUI flow with:

```text
TypeError: HfApi.list_models() got an unexpected keyword argument 'direction'
```

The failure was caused by ADS calling `HfApi.list_models()` with a call signature that is not stable across resolved `huggingface_hub` versions. Since service VMs can install ADS fresh and resolve transitive dependencies at install time, ADS now restricts `huggingface_hub` to `>=0.36.2,<0.37`.

## Testing
- `git diff --check`
- `python -m pytest tests/unitary/with_extras/aqua/test_model_handler.py::TestAquaHuggingFaceHandler::test_get_positive tests/unitary/with_extras/aqua/test_model_handler.py::TestAquaHuggingFaceHandler::test_get_hf_client_signature_error -q`

## Notes
A full local run of `test_model_handler.py` is currently blocked by an unrelated expired OCI security token in this environment.
