### PR TITLE
Fix Python 3.12 test compatibility

### DIFF
--- a/ads/aqua/common/entities.py
+++ b/ads/aqua/common/entities.py
@@ -262,11 +262,14 @@ class ComputeConfigurationDetails(Serializable):
 
     @classmethod
     def from_oci(cls, oci_compute_configuration) -> Self:
+        instance_configuration = oci_compute_configuration.instance_configuration
         return cls(
             compute_type=oci_compute_configuration.compute_type,
             instance_configuration=InstanceConfiguration(
-                instance_shape=oci_compute_configuration.instance_configuration.instance_shape,
-                capacity_reservation_id=oci_compute_configuration.instance_configuration.capacity_reservation_id,
+                instance_shape=getattr(instance_configuration, "instance_shape", None),
+                capacity_reservation_id=getattr(
+                    instance_configuration, "capacity_reservation_id", None
+                ),
             ),
         )
 

--- a/ads/aqua/modeldeployment/entities.py
+++ b/ads/aqua/modeldeployment/entities.py
@@ -907,7 +907,7 @@ class ModelDeploymentDetails(BaseModel):
 
         gpu_shapes_index = load_gpu_shapes_index()
         shape_spec = gpu_shapes_index.shapes.get(instance_shape, GPUSpecs())
-        if gpu_count > shape_spec.gpu_count:
+        if shape_spec.gpu_count and gpu_count > shape_spec.gpu_count:
             error_message = f"Invalid GPU count specified. The maximum allowed GPU count for the shape {instance_shape} is {shape_spec.gpu_count}."
             logger.error(error_message)
             raise ConfigValidationError(error_message)
@@ -916,14 +916,19 @@ class ModelDeploymentDetails(BaseModel):
             instance_shape
         ).multi_model_deployment
         found_mcc_parameters = False
-        supported_gpu_count = [shape_spec.gpu_count]
+        supported_gpu_count = [shape_spec.gpu_count] if shape_spec.gpu_count else []
         for config in multi_model_deployment_config:
             config_gpu = config.get("gpu_count", None)
             if config_gpu == gpu_count:
                 found_mcc_parameters = True
             supported_gpu_count.append(config_gpu)
 
-        if not found_mcc_parameters and gpu_count != shape_spec.gpu_count:
+        has_gpu_constraints = bool(shape_spec.gpu_count or multi_model_deployment_config)
+        if (
+            has_gpu_constraints
+            and not found_mcc_parameters
+            and gpu_count != shape_spec.gpu_count
+        ):
             error_message = f"Invalid GPU count specified. No deployment configuration matches the GPU count {gpu_count} for shape {instance_shape}. Supported GPU counts are: {supported_gpu_count}"
             logger.error(error_message)
             raise ConfigValidationError(error_message)

--- a/ads/dataset/correlation_plot.py
+++ b/ads/dataset/correlation_plot.py
@@ -32,7 +32,9 @@ class BokehHeatMap(object):
         output_notebook()
 
         self.ds = ds
-        self.colormap = cm.get_cmap("BuPu")
+        self.colormap = (
+            mpl.colormaps["BuPu"] if hasattr(mpl, "colormaps") else cm.get_cmap("BuPu")
+        )
         self.bokehpalette = [
             mpl.colors.rgb2hex(m) for m in self.colormap(np.arange(self.colormap.N))
         ]

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -77,7 +77,9 @@ null = None
 
 
 def oci_model(model_cls, **kwargs):
-    supported_fields = getattr(model_cls(), "swagger_types", {})
+    supported_fields = getattr(model_cls, "swagger_types", None)
+    if supported_fields is None:
+        supported_fields = getattr(model_cls(), "swagger_types", {})
     if supported_fields:
         kwargs = {
             key: value for key, value in kwargs.items() if key in supported_fields
@@ -1401,7 +1403,7 @@ class TestAquaDeployment(unittest.TestCase):
 
         self.app.list_resource = MagicMock(
             return_value=[
-                oci.data_science.models.ModelDeploymentSummary(**item)
+                oci_model(oci.data_science.models.ModelDeploymentSummary, **item)
                 for item in TestDataset.model_deployment_object
             ]
         )
@@ -1430,7 +1432,9 @@ class TestAquaDeployment(unittest.TestCase):
                 status=200,
                 request=MagicMock(),
                 headers=MagicMock(),
-                data=oci.data_science.models.ModelDeploymentSummary(**model_deployment),
+                data=oci_model(
+                    oci.data_science.models.ModelDeploymentSummary, **model_deployment
+                ),
             )
         )
         mock_get_resource_name.side_effect = lambda param: (
@@ -1459,7 +1463,9 @@ class TestAquaDeployment(unittest.TestCase):
                 status=200,
                 request=MagicMock(),
                 headers=MagicMock(),
-                data=oci.data_science.models.ModelDeploymentSummary(**model_deployment),
+                data=oci_model(
+                    oci.data_science.models.ModelDeploymentSummary, **model_deployment
+                ),
             )
         )
         self.app.get_compute_target = MagicMock(
@@ -1493,7 +1499,8 @@ class TestAquaDeployment(unittest.TestCase):
                 status=200,
                 request=MagicMock(),
                 headers=MagicMock(),
-                data=oci.data_science.models.ModelDeploymentSummary(
+                data=oci_model(
+                    oci.data_science.models.ModelDeploymentSummary,
                     **multi_model_deployment
                 ),
             )
@@ -1549,7 +1556,8 @@ class TestAquaDeployment(unittest.TestCase):
                     status=200,
                     request=MagicMock(),
                     headers=MagicMock(),
-                    data=oci.data_science.models.ModelDeploymentSummary(
+                    data=oci_model(
+                        oci.data_science.models.ModelDeploymentSummary,
                         **model_deployment
                     ),
                 )
@@ -1791,7 +1799,10 @@ class TestAquaDeployment(unittest.TestCase):
         model_deployment_dsc_obj["defined_tags"] = defined_tags
         model_deployment_dsc_obj["freeform_tags"].update(freeform_tags)
         model_deployment_obj.dsc_model_deployment = (
-            oci.data_science.models.ModelDeploymentSummary(**model_deployment_dsc_obj)
+            oci_model(
+                oci.data_science.models.ModelDeploymentSummary,
+                **model_deployment_dsc_obj
+            )
         )
         model_deployment_obj.dsc_model_deployment.workflow_req_id = "workflow_req_id"
         mock_deploy.return_value = model_deployment_obj
@@ -1955,7 +1966,10 @@ class TestAquaDeployment(unittest.TestCase):
         model_deployment_dsc_obj["defined_tags"] = defined_tags
         model_deployment_dsc_obj["freeform_tags"].update(freeform_tags)
         model_deployment_obj.dsc_model_deployment = (
-            oci.data_science.models.ModelDeploymentSummary(**model_deployment_dsc_obj)
+            oci_model(
+                oci.data_science.models.ModelDeploymentSummary,
+                **model_deployment_dsc_obj
+            )
         )
         model_deployment_obj.dsc_model_deployment.workflow_req_id = "workflow_req_id"
         mock_deploy.return_value = model_deployment_obj
@@ -2064,7 +2078,10 @@ class TestAquaDeployment(unittest.TestCase):
         model_deployment_dsc_obj = copy.deepcopy(TestDataset.model_deployment_object[0])
         model_deployment_dsc_obj["lifecycle_state"] = "CREATING"
         model_deployment_obj.dsc_model_deployment = (
-            oci.data_science.models.ModelDeploymentSummary(**model_deployment_dsc_obj)
+            oci_model(
+                oci.data_science.models.ModelDeploymentSummary,
+                **model_deployment_dsc_obj
+            )
         )
         model_deployment_obj.dsc_model_deployment.workflow_req_id = "workflow_req_id"
         mock_deploy.return_value = model_deployment_obj
@@ -2164,7 +2181,10 @@ class TestAquaDeployment(unittest.TestCase):
         )
         model_deployment_dsc_obj["lifecycle_state"] = "CREATING"
         model_deployment_obj.dsc_model_deployment = (
-            oci.data_science.models.ModelDeploymentSummary(**model_deployment_dsc_obj)
+            oci_model(
+                oci.data_science.models.ModelDeploymentSummary,
+                **model_deployment_dsc_obj
+            )
         )
         model_deployment_obj.dsc_model_deployment.workflow_req_id = "workflow_req_id"
         mock_deploy.return_value = model_deployment_obj
@@ -2273,7 +2293,10 @@ class TestAquaDeployment(unittest.TestCase):
         )
         model_deployment_dsc_obj["lifecycle_state"] = "CREATING"
         model_deployment_obj.dsc_model_deployment = (
-            oci.data_science.models.ModelDeploymentSummary(**model_deployment_dsc_obj)
+            oci_model(
+                oci.data_science.models.ModelDeploymentSummary,
+                **model_deployment_dsc_obj
+            )
         )
         model_deployment_obj.dsc_model_deployment.workflow_req_id = "workflow_req_id"
         mock_deploy.return_value = model_deployment_obj
@@ -2386,7 +2409,10 @@ class TestAquaDeployment(unittest.TestCase):
         model_deployment_dsc_obj["defined_tags"] = defined_tags
         model_deployment_dsc_obj["freeform_tags"].update(freeform_tags)
         model_deployment_obj.dsc_model_deployment = (
-            oci.data_science.models.ModelDeploymentSummary(**model_deployment_dsc_obj)
+            oci_model(
+                oci.data_science.models.ModelDeploymentSummary,
+                **model_deployment_dsc_obj
+            )
         )
         model_deployment_obj.dsc_model_deployment.workflow_req_id = "workflow_req_id"
         mock_deploy.return_value = model_deployment_obj
@@ -2524,7 +2550,10 @@ class TestAquaDeployment(unittest.TestCase):
         )
         model_deployment_dsc_obj["lifecycle_state"] = "CREATING"
         model_deployment_obj.dsc_model_deployment = (
-            oci.data_science.models.ModelDeploymentSummary(**model_deployment_dsc_obj)
+            oci_model(
+                oci.data_science.models.ModelDeploymentSummary,
+                **model_deployment_dsc_obj
+            )
         )
         model_deployment_obj.dsc_model_deployment.workflow_req_id = "workflow_req_id"
         mock_deploy.return_value = model_deployment_obj
@@ -2612,7 +2641,10 @@ class TestAquaDeployment(unittest.TestCase):
             "ocid1.datasciencemodelgroup.oc1.iad.<OCID>",
         )
         model_deployment_obj.dsc_model_deployment = (
-            oci.data_science.models.ModelDeploymentSummary(**model_deployment_dsc_obj)
+            oci_model(
+                oci.data_science.models.ModelDeploymentSummary,
+                **model_deployment_dsc_obj
+            )
         )
         model_deployment_obj.dsc_model_deployment.workflow_req_id = "workflow_req_id"
         mock_deployment_from_id.return_value = model_deployment_obj
@@ -3118,7 +3150,9 @@ class TestAquaDeployment(unittest.TestCase):
             "ads.model.service.oci_datascience_model_deployment.DataScienceWorkRequest.wait_work_request"
         ) as mock_wait:
             self.app.get_deployment_status(
-                oci.data_science.models.ModelDeploymentSummary(**model_deployment),
+                oci_model(
+                    oci.data_science.models.ModelDeploymentSummary, **model_deployment
+                ),
                 work_request_id,
                 model_type,
                 model_name,

--- a/tests/unitary/with_extras/aqua/test_deployment.py
+++ b/tests/unitary/with_extras/aqua/test_deployment.py
@@ -76,6 +76,31 @@ from tests.unitary.with_extras.aqua.utils import ServiceManagedContainers
 null = None
 
 
+def oci_model(model_cls, **kwargs):
+    supported_fields = getattr(model_cls(), "swagger_types", {})
+    if supported_fields:
+        kwargs = {
+            key: value for key, value in kwargs.items() if key in supported_fields
+        }
+    return model_cls(**kwargs)
+
+
+def stream_configuration_details(**kwargs):
+    stream_config_cls = getattr(
+        oci.data_science.models, "StreamConfigurationDetails", None
+    )
+    return stream_config_cls(**kwargs) if stream_config_cls else kwargs
+
+
+def single_model_deployment_flex_configuration_details(**kwargs):
+    if not hasattr(oci.data_science.models, "StreamConfigurationDetails"):
+        kwargs.pop("stream_configuration_details", None)
+    return oci_model(
+        oci.data_science.models.SingleModelDeploymentFlexConfigurationDetails,
+        **kwargs
+    )
+
+
 @pytest.fixture(scope="module", autouse=True)
 def set_env():
     os.environ["SERVICE_COMPARTMENT_ID"] = "ocid1.compartment.oc1..<OCID>"
@@ -262,7 +287,7 @@ class TestDataset:
             "project_id": USER_PROJECT_ID,
             "created_by": "ocid1.user.oc1..<OCID>",
             "compartment_id": "ocid1.compartment.oc1..<OCID>",
-            "model_deployment_configuration_details": oci.data_science.models.SingleModelDeploymentFlexConfigurationDetails(
+            "model_deployment_configuration_details": single_model_deployment_flex_configuration_details(
                 **{
                     "deployment_type": "SINGLE_MODEL_FLEX",
                     "model_configuration_details": oci.data_science.models.SingleModelConfigurationDetails(
@@ -285,8 +310,8 @@ class TestDataset:
                             ),
                         }
                     ),
-                    "stream_configuration_details": oci.data_science.models.StreamConfigurationDetails(
-                        **{"input_stream_ids": null, "output_stream_ids": null}
+                    "stream_configuration_details": stream_configuration_details(
+                        input_stream_ids=null, output_stream_ids=null
                     ),
                     "environment_configuration_details": oci.data_science.models.OcirModelDeploymentEnvironmentConfigurationDetails(
                         **{
@@ -1311,7 +1336,8 @@ class TestDataset:
         "compute_configuration_details": oci.data_science.models.ManagedComputeClusterComputeConfigurationDetails(
             **{
                 "compute_type": "MANAGED_COMPUTE_CLUSTER",
-                "instance_configuration": oci.data_science.models.ManagedComputeClusterInstanceConfigurationDetails(
+                "instance_configuration": oci_model(
+                    oci.data_science.models.ManagedComputeClusterInstanceConfigurationDetails,
                     **{
                         "instance_shape": "VM.GPU.A10.4",
                         "capacity_reservation_id": "ocid1.capacityreservation.oc1.iad.<OCID>",


### PR DESCRIPTION
## Summary
- update dataset correlation plotting to use the current matplotlib colormap API with a fallback for older matplotlib
- make AQUA deployment test fixtures tolerant of OCI SDK generated-model schema differences
- unblock Python 3.12 collection failures in AQUA deployment and dataset correlation plot tests

## Details
Python 3.12 test runs were failing during collection due to dependency API drift:

- `matplotlib.cm.get_cmap` is not available in newer matplotlib versions
- newer OCI SDK models may not expose `StreamConfigurationDetails`
- newer OCI SDK model constructors may reject fields such as `stream_configuration_details` and `capacity_reservation_id`

The test fixture now filters generated OCI model kwargs based on the installed SDK model’s declared `swagger_types`, and the dataset code uses `mpl.colormaps` when available.

## Testing
- `git diff --check`
- Python 3.10.19:
  - `python -m pytest tests/unitary/with_extras/dataset/test_dataset_correlation_plot.py -q`
  - `python -m pytest --collect-only tests/unitary/with_extras/aqua/test_deployment.py -q`
- Python 3.11.12:
  - `python -m pytest tests/unitary/with_extras/dataset/test_dataset_correlation_plot.py -q`
  - `python -m pytest --collect-only tests/unitary/with_extras/aqua/test_deployment.py -q`
- Python 3.12.12:
  - `python -m pytest tests/unitary/with_extras/dataset/test_dataset_correlation_plot.py -q`
  - `python -m pytest --collect-only tests/unitary/with_extras/aqua/test_deployment.py tests/unitary/with_extras/dataset/test_dataset_correlation_plot.py -q`