### PR TITLE
ODSC-88491: Fix conda environment resolution for slug versus full OCI path inputs

### DIFF
--- a/tests/unitary/with_extras/model/test_env_info.py
+++ b/tests/unitary/with_extras/model/test_env_info.py
@@ -181,24 +181,30 @@ class TestTrainingEnvInfo:
                 "mlcpuv1": ("test_path", "3.6"),
             },
         )
-        with pytest.raises(
-            ValueError,
-            match="conda environment slug `not_exist` could not be resolved",
-        ):
+        with pytest.raises(ValueError) as exc_info:
             TrainingEnvInfo.from_slug(
                 "not_exist", namespace="ociodscdev", bucketname="service-conda-packs"
             )
+        error_message = str(exc_info.value)
+        assert (
+            "conda environment slug `not_exist` could not be resolved" in error_message
+        )
+        assert "full OCI path from Environment Explorer" in error_message
 
     @patch("ads.model.runtime.env_info.get_service_packs")
     def test_from_slug_service_pack_list_not_extracted(self, mock_get_service_packs):
         mock_get_service_packs.return_value = ({}, {})
-        with pytest.raises(
-            ValueError,
-            match="service conda environment list could not be extracted",
-        ):
+        with pytest.raises(ValueError) as exc_info:
             TrainingEnvInfo.from_slug(
                 "mlcpuv1", namespace="ociodscdev", bucketname="service-conda-packs"
             )
+        error_message = str(exc_info.value)
+        assert (
+            "service conda environment list could not be extracted" in error_message
+        )
+        assert (
+            "full conda environment path from Environment Explorer" in error_message
+        )
 
     @patch("ads.model.runtime.env_info.get_service_packs")
     @patch("ads.model.runtime.env_info.utils.is_path_exists", return_value=True)
@@ -330,24 +336,30 @@ class TestInferenceEnvInfo:
                 "mlcpuv1": ("test_path", "3.6"),
             },
         )
-        with pytest.raises(
-            ValueError,
-            match="conda environment slug `not_exist` could not be resolved",
-        ):
+        with pytest.raises(ValueError) as exc_info:
             InferenceEnvInfo.from_slug(
                 "not_exist", namespace="ociodscdev", bucketname="service-conda-packs"
             )
+        error_message = str(exc_info.value)
+        assert (
+            "conda environment slug `not_exist` could not be resolved" in error_message
+        )
+        assert "full OCI path from Environment Explorer" in error_message
 
     @patch("ads.model.runtime.env_info.get_service_packs")
     def test_from_slug_service_pack_list_not_extracted(self, mock_get_service_packs):
         mock_get_service_packs.return_value = ({}, {})
-        with pytest.raises(
-            ValueError,
-            match="service conda environment list could not be extracted",
-        ):
+        with pytest.raises(ValueError) as exc_info:
             InferenceEnvInfo.from_slug(
                 "mlcpuv1", namespace="ociodscdev", bucketname="service-conda-packs"
             )
+        error_message = str(exc_info.value)
+        assert (
+            "service conda environment list could not be extracted" in error_message
+        )
+        assert (
+            "full conda environment path from Environment Explorer" in error_message
+        )
 
     @patch("ads.model.runtime.env_info.get_service_packs")
     @patch("ads.model.runtime.env_info.utils.is_path_exists", return_value=True)

--- a/tests/unitary/with_extras/model/test_env_info.py
+++ b/tests/unitary/with_extras/model/test_env_info.py
@@ -255,11 +255,17 @@ class TestTrainingEnvInfo:
     @patch("ads.model.runtime.env_info.utils.is_path_exists", return_value=False)
     def test_from_path_not_accessible(self, _mock_is_path_exists, mock_get_service_packs):
         env_path = "oci://license_checker@ociodscdev/conda/missing"
-        with pytest.raises(
-            ValueError,
-            match="conda environment path `oci://license_checker@ociodscdev/conda/missing` does not exist or is not accessible",
-        ):
+        with pytest.raises(ValueError) as exc_info:
             TrainingEnvInfo.from_path(env_path, auth={"signer": object()})
+        error_message = str(exc_info.value)
+        assert f"conda environment path `{env_path}`" in error_message
+        assert "does not exist or is not accessible" in error_message
+        assert (
+            "valid full conda environment path from Environment Explorer"
+            in error_message
+        )
+        assert "service conda environment list" not in error_message
+        assert "conda environment slug" not in error_message
         mock_get_service_packs.assert_not_called()
 
     def test_from_dict(self):
@@ -401,6 +407,23 @@ class TestInferenceEnvInfo:
         assert info.inference_python_version == ""
         mock_get_service_packs.assert_not_called()
         mock_fetch_metadata.assert_called_once()
+
+    @patch("ads.model.runtime.env_info.get_service_packs")
+    @patch("ads.model.runtime.env_info.utils.is_path_exists", return_value=False)
+    def test_from_path_not_accessible(self, _mock_is_path_exists, mock_get_service_packs):
+        env_path = "oci://license_checker@ociodscdev/conda/missing"
+        with pytest.raises(ValueError) as exc_info:
+            InferenceEnvInfo.from_path(env_path, auth={"signer": object()})
+        error_message = str(exc_info.value)
+        assert f"conda environment path `{env_path}`" in error_message
+        assert "does not exist or is not accessible" in error_message
+        assert (
+            "valid full conda environment path from Environment Explorer"
+            in error_message
+        )
+        assert "service conda environment list" not in error_message
+        assert "conda environment slug" not in error_message
+        mock_get_service_packs.assert_not_called()
 
     def test_from_dict(self):
         info = InferenceEnvInfo.from_dict(


### PR DESCRIPTION
## Summary

Fixed ADS conda environment resolution so slug inputs and full OCI conda paths follow separate resolution paths. Short service conda slugs resolve through the service conda index and now fail with explicit slug-specific guidance to use the full Environment Explorer path when unresolved. Full oci:// conda paths are treated as authoritative: they validate object accessibility directly, avoid service_pack/index.json lookup, preserve the original runtime path metadata, and classify custom published paths as published unless the path itself is an explicit service conda bucket/path. Regression tests now assert slug guidance, full-path published metadata, no service-index lookup for full paths, and path-specific validation failures for both training and inference env info.

## Tests Run

/tmp/ads-py314-core-venv/bin/python -m pytest tests/unitary/with_extras/model/test_env_info.py::TestTrainingEnvInfo::test_from_slug_not_exist tests/unitary/with_extras/model/test_env_info.py::TestTrainingEnvInfo::test_from_slug_service_pack_list_not_extracted tests/unitary/with_extras/model/test_env_info.py::TestInferenceEnvInfo::test_from_slug_not_exist tests/unitary/with_extras/model/test_env_info.py::TestInferenceEnvInfo::test_from_slug_service_pack_list_not_extracted -q (passed: 4 tests)
/tmp/ads-py314-core-venv/bin/python -m pytest tests/unitary/with_extras/model/test_env_info.py::TestTrainingEnvInfo::test_from_path_cp tests/unitary/with_extras/model/test_env_info.py::TestTrainingEnvInfo::test_from_path_not_accessible tests/unitary/with_extras/model/test_env_info.py::TestInferenceEnvInfo::test_from_path_custom_pack tests/unitary/with_extras/model/test_env_info.py::TestInferenceEnvInfo::test_from_path_not_accessible -q (passed: 4 tests)
/tmp/ads-py314-core-venv/bin/python -m pytest tests/unitary/with_extras/model/test_env_info.py::TestTrainingEnvInfo::test_from_slug_dev_sp tests/unitary/with_extras/model/test_env_info.py::TestTrainingEnvInfo::test_from_slug_prod_sp tests/unitary/with_extras/model/test_env_info.py::TestTrainingEnvInfo::test_from_slug_not_exist tests/unitary/with_extras/model/test_env_info.py::TestTrainingEnvInfo::test_from_slug_service_pack_list_not_extracted tests/unitary/with_extras/model/test_env_info.py::TestTrainingEnvInfo::test_from_path_cp tests/unitary/with_extras/model/test_env_info.py::TestTrainingEnvInfo::test_from_path_not_accessible tests/unitary/with_extras/model/test_env_info.py::TestInferenceEnvInfo::test_from_slug_dev_sp tests/unitary/with_extras/model/test_env_info.py::TestInferenceEnvInfo::test_from_slug_prod_sp tests/unitary/with_extras/model/test_env_info.py::TestInferenceEnvInfo::test_from_slug_not_exist tests/unitary/with_extras/model/test_env_info.py::TestInferenceEnvInfo::test_from_slug_service_pack_list_not_extracted tests/unitary/with_extras/model/test_env_info.py::TestInferenceEnvInfo::test_from_path_custom_pack tests/unitary/with_extras/model/test_env_info.py::TestInferenceEnvInfo::test_from_path_not_accessible -q (passed: 12 tests)
/tmp/ads-py314-core-venv/bin/python -m pytest tests/unitary/with_extras/model/test_env_info.py -q (failed: test_get_service_packs_bad_response due local OCI auth config/default signer; 24 passed)
/tmp/ads-py314-core-venv/bin/python -m pytest tests/unitary/with_extras/model/test_artifact.py -q (blocked: ModuleNotFoundError: No module named 'skl2onnx')
