### PR TITLE
Fix annotation lookup on Python 3.14

### DIFF
--- a/ads/model/base_properties.py
+++ b/ads/model/base_properties.py
@@ -39,21 +39,22 @@ class BaseProperties(Serializable):
 
     def __setattr__(self, name: str, value: Any):
         """Adds type validation when attribute assignment is attempted."""
+        annotations = getattr(type(self), "__annotations__", {})
         if value is None:
             self.__dict__[name] = value
-        elif name in self.__annotations__:
-            if hasattr(self.__annotations__[name], "__origin__"):
-                if self.__annotations__[name].__origin__ is Union and not isinstance(
-                    value, self.__annotations__[name].__args__
+        elif name in annotations:
+            if hasattr(annotations[name], "__origin__"):
+                if annotations[name].__origin__ is Union and not isinstance(
+                    value, annotations[name].__args__
                 ):
                     raise TypeError(
-                        f"Field `{name}` was expected to be of type `{self.__annotations__[name].__args__}` "
+                        f"Field `{name}` was expected to be of type `{annotations[name].__args__}` "
                         f"but type `{type(value)}` was provided."
                     )
 
-            elif self.__annotations__[name] != type(value):
+            elif annotations[name] != type(value):
                 raise TypeError(
-                    f"Field `{name}` was expected to be of type `{self.__annotations__[name]}` "
+                    f"Field `{name}` was expected to be of type `{annotations[name]}` "
                     f"but type `{type(value)}` was provided."
                 )
 
@@ -101,14 +102,15 @@ class BaseProperties(Serializable):
         if not isinstance(obj_dict, Dict):
             raise TypeError("The `obj_dict` should be a dictionary.")
 
+        annotations = getattr(type(self), "__annotations__", {})
         for key, value in obj_dict.items():
             # if expected type of input value is not a string, but
             # actual type of the value is string, then try to convert value to the
             # expected format by using JSON.loads()
             if (
                 not value is None
-                and key in self.__annotations__
-                and self.__annotations__[key] != str
+                and key in annotations
+                and annotations[key] != str
                 and isinstance(value, str)
             ):
                 try:

--- a/tests/unitary/default_setup/common/test_common_base_properties.py
+++ b/tests/unitary/default_setup/common/test_common_base_properties.py
@@ -22,6 +22,18 @@ class MockTestProperties(BaseProperties):
     union_type_value: Union[int, float] = None
 
 
+@dataclass(repr=False)
+class Python314LikeProperties(BaseProperties):
+    """Simulates Python 3.14, where instances do not expose annotations."""
+
+    age: int = None
+
+    def __getattribute__(self, name):
+        if name == "__annotations__":
+            raise AttributeError("instance annotations are unavailable")
+        return super().__getattribute__(name)
+
+
 class TestBaseProperties:
     def setup_method(self):
         self.mock_test_properties = MockTestProperties()
@@ -124,6 +136,14 @@ class TestBaseProperties:
             self.mock_test_properties.union_type_value
             == expected_result["union_type_value"]
         )
+
+    def test_with_dict_uses_class_annotations(self):
+        """Ensures annotation lookups do not depend on instance attributes."""
+        properties = Python314LikeProperties()
+
+        properties.with_dict({"age": "10"})
+
+        assert properties.age == 10
 
     @patch.object(BaseProperties, "with_dict")
     def test_from_dict(self, mock_with_dict):


### PR DESCRIPTION
Fix annotation lookup on Python 3.14
python 3.14 does not have _annotations_ method on class objects, so to fix it had to update this ads code.
The change is backward compatible.