### PR TITLE
ODSC-88493: ADS Python 3.14 support readiness

### DIFF
--- a/.github/workflows/run-unittests-default_setup.yml
+++ b/.github/workflows/run-unittests-default_setup.yml
@@ -55,9 +55,6 @@ jobs:
           NoDependency: True
         run: |
           set -x # print commands that are executed
-          $CONDA/bin/conda init
-          source /home/runner/.bashrc
-          conda install python=${{ matrix.python-version }}
-          pip install -r test-requirements.txt
-          conda list
+          python --version
+          python -m pip install -r test-requirements.txt
           python -m pytest -v -p no:warnings --durations=5 tests/unitary/default_setup

--- a/ads/aqua/extension/utils.py
+++ b/ads/aqua/extension/utils.py
@@ -98,7 +98,7 @@ def construct_error(status_code: int, **kwargs) -> ReplyDetails:
 
     """
     reason = kwargs.get("reason", "Unknown Error")
-    service_payload = kwargs.get("service_payload", {})
+    service_payload = dict(kwargs.get("service_payload") or {})
     default_msg = responses.get(status_code, "Unknown HTTP Error")
     message = get_default_error_messages(
         service_payload, str(status_code), kwargs.get("message", default_msg)

--- a/ads/model/base_properties.py
+++ b/ads/model/base_properties.py
@@ -7,7 +7,7 @@
 import dataclasses
 import json
 import os
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 from ads.common.config import Config, ConfigSection
 from ads.common.serializer import Serializable
@@ -37,23 +37,29 @@ class BaseProperties(Serializable):
         Saves properties to the config file.
     """
 
+    @property
+    def _property_annotations(self) -> Dict[str, Any]:
+        """Returns dataclass field annotations for instance and class contexts."""
+        return getattr(self, "__annotations__", getattr(type(self), "__annotations__", {}))
+
     def __setattr__(self, name: str, value: Any):
         """Adds type validation when attribute assignment is attempted."""
+        annotations = self._property_annotations
         if value is None:
             self.__dict__[name] = value
-        elif name in self.__annotations__:
-            if hasattr(self.__annotations__[name], "__origin__"):
-                if self.__annotations__[name].__origin__ is Union and not isinstance(
-                    value, self.__annotations__[name].__args__
-                ):
+        elif name in annotations:
+            field_type = annotations[name]
+            field_type_args = getattr(field_type, "__args__", None)
+            if field_type_args:
+                if not isinstance(value, field_type_args):
                     raise TypeError(
-                        f"Field `{name}` was expected to be of type `{self.__annotations__[name].__args__}` "
+                        f"Field `{name}` was expected to be of type `{field_type_args}` "
                         f"but type `{type(value)}` was provided."
                     )
 
-            elif self.__annotations__[name] != type(value):
+            elif field_type != type(value):
                 raise TypeError(
-                    f"Field `{name}` was expected to be of type `{self.__annotations__[name]}` "
+                    f"Field `{name}` was expected to be of type `{field_type}` "
                     f"but type `{type(value)}` was provided."
                 )
 
@@ -101,14 +107,15 @@ class BaseProperties(Serializable):
         if not isinstance(obj_dict, Dict):
             raise TypeError("The `obj_dict` should be a dictionary.")
 
+        annotations = self._property_annotations
         for key, value in obj_dict.items():
             # if expected type of input value is not a string, but
             # actual type of the value is string, then try to convert value to the
             # expected format by using JSON.loads()
             if (
                 not value is None
-                and key in self.__annotations__
-                and self.__annotations__[key] != str
+                and key in annotations
+                and annotations[key] != str
                 and isinstance(value, str)
             ):
                 try:

--- a/ads/model/model_artifact_boilerplate/artifact_introspection_test/model_artifact_validate.py
+++ b/ads/model/model_artifact_boilerplate/artifact_introspection_test/model_artifact_validate.py
@@ -29,7 +29,7 @@ _cwd = os.path.dirname(__file__)
 TESTS_PATH = os.path.join(_cwd, "resources", "tests.yaml")
 HTML_PATH = os.path.join(_cwd, "resources", "template.html")
 CONFIG_PATH = os.path.join(_cwd, "resources", "config.yaml")
-PYTHON_VER_PATTERN = "^([3])(\.([6-9]|1[0-2]))(\.\d+)?$"
+PYTHON_VER_PATTERN = "^([3])(\\.([6-9]|1[0-4]))(\\.\\d+)?$"
 PAR_URL = "https://objectstorage.us-ashburn-1.oraclecloud.com/p/WyjtfVIG0uda-P3-2FmAfwaLlXYQZbvPZmfX1qg0-sbkwEQO6jpwabGr2hMDBmBp/n/ociodscdev/b/service-conda-packs/o/service_pack/index.json"
 
 TESTS = {

--- a/ads/telemetry/telemetry.py
+++ b/ads/telemetry/telemetry.py
@@ -251,7 +251,7 @@ class Telemetry:
     def _prepare(self, value: str):
         """Replaces the special characters with the `_` in the input string."""
         return (
-            re.sub("[^a-zA-Z0-9\.\-\_\&\=]", "_", re.sub(r"\s+", " ", value))
+            re.sub(r"[^a-zA-Z0-9.\-_&=]", "_", re.sub(r"\s+", " ", value))
             if value
             else ""
         )

--- a/ads/text_dataset/dataset.py
+++ b/ads/text_dataset/dataset.py
@@ -18,7 +18,7 @@ from ads.text_dataset.utils import NotSupportedError
 
 
 class DataLoader:
-    """
+    r"""
     DataLoader binds engine, FileProcessor and File handler(in this case it is fsspec)
     together to produce a dataframe of parsed text from files.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -88,6 +88,13 @@ Oracle Accelerated Data Science (ADS)
 
    modules
 
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+   :caption: Developer Notes
+
+   python314_dependency_audit
+
 .. admonition:: Introducing AI Quick Actions
    :class: note
 

--- a/docs/source/python314_dependency_audit.rst
+++ b/docs/source/python314_dependency_audit.rst
@@ -177,11 +177,20 @@ areas that are in the staged support scope:
   ``SyntaxWarning`` promoted to an error.
 * Telemetry preparation tests passed after changing the special-character
   replacement regex to a raw string literal.
+* ``BaseProperties`` dataclass annotation handling was updated to read class
+  annotations when Python 3.14 no longer exposes them on the instance.
+* Scoped default setup unit tests passed on Python 3.14.5 with
+  ``NoDependency=1``: ``1236 passed, 13 skipped, 2 xfailed``.
 
 This validation does not change the deferred status of optional framework and
 operator stacks that remain blocked or validation-gated by dependency
 resolution, including ONNX, TensorFlow, spaCy/text extras, forecast/anomaly
 operators, notebook tooling, and service-conda-only decisions.
+
+An unscoped default setup run without ``NoDependency=1`` exposed optional
+dependency gaps for ``IPython``, ``seaborn``, and ``nbformat``. Those are not
+part of the default install support claim and remain covered by the staged
+optional-extra validation plan.
 
 Optional-extra resolver results
 -------------------------------

--- a/docs/source/python314_dependency_audit.rst
+++ b/docs/source/python314_dependency_audit.rst
@@ -127,6 +127,38 @@ sets. The ``pyproject.toml`` Python classifiers intentionally stop at Python
 No ``THIRD_PARTY_LICENSES.txt`` update is required for this step because no
 dependencies are added, removed, or upgraded.
 
+Python 3.14 install and build validation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Core ADS install and artifact validation passed on the local Python 3.14.5
+macOS arm64 environment:
+
+* Local checkout install passed with ``.venv-py314-core/bin/python -m pip
+  install .``.
+* Fresh sdist and wheel builds passed with ``.venv-py314-audit/bin/python -m
+  build --outdir /tmp/ads-py314-build``.
+* Fresh wheel install passed from
+  ``/tmp/ads-py314-build/oracle_ads-2.15.2-py3-none-any.whl`` into a clean
+  Python 3.14 virtual environment.
+* Fresh sdist install passed from
+  ``/tmp/ads-py314-build/oracle_ads-2.15.2.tar.gz`` into a clean Python 3.14
+  virtual environment.
+* ``import ads`` smoke checks passed in the checkout, wheel, and sdist
+  environments and reported Python ``3.14.5`` with ADS ``2.15.2``.
+
+The core dependency install used Python 3.14-compatible wheels for compiled
+dependencies such as ``numpy``, ``pandas``, ``matplotlib``, ``scikit-learn``,
+``scipy``, ``PyYAML``, ``pydantic-core``, ``cffi``, ``crc32c``, ``rpds-py``,
+and ``charset-normalizer``. No source-build-only dependency was observed for
+the core install path.
+
+The import smoke requires a writable Matplotlib cache directory in restricted
+environments. In this audit, ``MPLCONFIGDIR=/tmp/...`` was set for import
+checks. Python 3.14 emitted existing invalid escape sequence ``SyntaxWarning``
+messages in ``ads/telemetry/telemetry.py`` and
+``ads/text_dataset/dataset.py``; these warnings did not block install, build,
+or import validation but should be cleaned up before declaring final support.
+
 Optional-extra resolver results
 -------------------------------
 

--- a/docs/source/python314_dependency_audit.rst
+++ b/docs/source/python314_dependency_audit.rst
@@ -154,10 +154,34 @@ the core install path.
 
 The import smoke requires a writable Matplotlib cache directory in restricted
 environments. In this audit, ``MPLCONFIGDIR=/tmp/...`` was set for import
-checks. Python 3.14 emitted existing invalid escape sequence ``SyntaxWarning``
-messages in ``ads/telemetry/telemetry.py`` and
-``ads/text_dataset/dataset.py``; these warnings did not block install, build,
-or import validation but should be cleaned up before declaring final support.
+checks. Initial Python 3.14 import validation exposed invalid escape sequence
+``SyntaxWarning`` messages in ``ads/telemetry/telemetry.py`` and
+``ads/text_dataset/dataset.py``. Those warning sites were cleaned up during
+dependency-sensitive runtime validation.
+
+Dependency-sensitive runtime validation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Targeted Python 3.14 runtime checks passed for the dependency-sensitive core
+areas that are in the staged support scope:
+
+* ``import ads`` passed with ``SyntaxWarning`` promoted to an error after
+  cleaning up invalid escape sequence warnings in telemetry and text dataset
+  code.
+* A pandas/NumPy/scikit-learn smoke check passed using ``numpy`` ``2.5.1`` and
+  ``pandas`` ``2.3.3`` with ``sklearn.preprocessing.StandardScaler`` over a
+  ``pandas.DataFrame``.
+* Model artifact and runtime metadata tests passed for Python 3.14 version
+  handling.
+* Text dataset and model artifact validation imports passed with
+  ``SyntaxWarning`` promoted to an error.
+* Telemetry preparation tests passed after changing the special-character
+  replacement regex to a raw string literal.
+
+This validation does not change the deferred status of optional framework and
+operator stacks that remain blocked or validation-gated by dependency
+resolution, including ONNX, TensorFlow, spaCy/text extras, forecast/anomaly
+operators, notebook tooling, and service-conda-only decisions.
 
 Optional-extra resolver results
 -------------------------------

--- a/docs/source/python314_dependency_audit.rst
+++ b/docs/source/python314_dependency_audit.rst
@@ -192,6 +192,54 @@ dependency gaps for ``IPython``, ``seaborn``, and ``nbformat``. Those are not
 part of the default install support claim and remain covered by the staged
 optional-extra validation plan.
 
+GitHub Actions staging plan
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Python 3.14 should not be added to the existing GitHub Actions matrices until
+the same support boundary is reflected in CI. The current workflow split is:
+
+* ``.github/workflows/run-unittests-default_setup.yml`` runs minimum-dependency
+  default setup tests with ``NoDependency=True`` for Python 3.9 through 3.12.
+  This is the first workflow that can safely receive a Python 3.14 row after
+  runner image and dependency availability are confirmed on Linux.
+* ``.github/workflows/run-unittests-py310-py311.yml`` runs the broader
+  optional-dependency unit suite through ``dev-requirements.txt`` for Python
+  3.10 through 3.12. This workflow should not add Python 3.14 until the
+  ``testsuite`` dependency blocker and optional-stack blockers are resolved or
+  explicitly scoped out.
+* ``.github/workflows/run-operators-unit-tests.yml``,
+  ``.github/workflows/run-forecast-unit-tests.yml``, and
+  ``.github/workflows/run-forecast-explainer-tests.yml`` install operator and
+  forecast dependency stacks that currently inherit the ``opctl``, forecast,
+  AutoML, and service-conda blockers. These workflows should stay on their
+  current Python versions until service-conda owners confirm compatible Python
+  3.14 environments or ADS metadata is updated and validated against public
+  Python 3.14 wheels.
+
+Use the following staged validation before advertising Python 3.14 support or
+expanding the workflow matrices:
+
+1. Add a Linux Python 3.14 row only to the default setup workflow after
+   ``actions/setup-python`` and the conda image used by the workflow provide
+   Python 3.14. Run ``tests/unitary/default_setup`` with ``NoDependency=True``
+   and cache disabled or isolated from older Python versions.
+2. Keep targeted runtime-sensitive checks in the Python 3.14 gate:
+   ``tests/unitary/default_setup/model/test_model_introspect.py::TestPythonVersionCheck::test_python_version_check``,
+   ``tests/unitary/with_extras/model/test_runtime_info.py::TestRuntimeInfo::test_from_yaml_preserves_python_314_versions``,
+   and an import/dataframe smoke check that promotes ``SyntaxWarning`` to an
+   error.
+3. Add Python 3.14 CI rows for resolver-passing optional groups only after
+   targeted import or behavioral tests pass for ``aqua``, ``huggingface``,
+   ``llm``, ``optuna``, ``torch``, and ``viz``.
+4. Keep blocked optional and service-facing groups out of Python 3.14 CI until
+   their dependency decisions are complete: ``bds``, ``boosted``, ``data``,
+   ``forecast``, ``geo``, ``notebook``, ``onnx``, ``opctl``, ``pii``,
+   ``recommender``, ``regression``, ``spark``, ``tensorflow``, ``testsuite``,
+   and ``text``.
+5. Advertise the Python 3.14 package classifier only after Linux CI has passing
+   default setup coverage, targeted runtime checks, a refreshed resolver audit,
+   and recorded follow-ups or service-conda decisions for the deferred groups.
+
 Optional-extra resolver results
 -------------------------------
 

--- a/docs/source/python314_dependency_audit.rst
+++ b/docs/source/python314_dependency_audit.rst
@@ -1,0 +1,190 @@
+Python 3.14 Dependency Readiness Audit
+======================================
+
+This audit supports ODSC-88493. It records the current dependency-resolution
+state for ADS on Python 3.14 before package metadata advertises Python 3.14
+support.
+
+Audit environment
+-----------------
+
+* Date: 2026-07-15
+* Platform: macOS arm64
+* Python: 3.14.5
+* Resolver: pip 26.1.1
+* Source: local checkout on branch ``csa/odsc-88493``
+* Binary policy: ``--only-binary=:all:`` for optional-extra checks to model
+  wheel availability. Core was checked without that flag and resolved to
+  Python 3.14 wheels for compiled dependencies.
+
+Commands used
+-------------
+
+.. code-block:: shell
+
+   python3.14 -m venv .venv-py314-audit
+   .venv-py314-audit/bin/python -m pip install --dry-run --ignore-installed .
+   .venv-py314-audit/bin/python -m pip install --dry-run --ignore-installed --only-binary=:all: ".[<extra>]"
+
+Core dependency result
+----------------------
+
+Core ADS dependencies resolve on Python 3.14. The resolver selected Python
+3.14-compatible wheels for the main compiled dependencies, including
+``numpy``, ``pandas``, ``matplotlib``, ``scikit-learn``, ``scipy``, ``PyYAML``,
+``pydantic-core``, ``cryptography``, and ``oracledb`` transitive dependencies.
+
+This is only a resolver result. It does not validate runtime behavior, import
+coverage, model artifact behavior, or service-conda compatibility.
+
+Optional-extra resolver results
+-------------------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Extra
+     - Result
+     - Finding
+     - Follow-up
+   * - ``aqua``
+     - Resolves
+     - Current pins resolve, including ``openai==1.109.1`` and
+       ``huggingface_hub>=0.36.2,<0.37``.
+     - Run AQUA import/unit tests before declaring support.
+   * - ``anomaly``
+     - Blocked
+     - ``rrcf==0.4.4`` has no Python 3.14 binary match; this group also
+       inherits the shared ``opctl`` resolver blocker through
+       ``oracle_ads[opctl]``.
+     - Defer or update the anomaly operator stack after validating replacement
+       dependencies.
+   * - ``bds``
+     - Blocked
+     - ``hdfs[kerberos]`` requires ``docopt``; no matching Python 3.14 binary
+       distribution was available under the audit policy.
+     - Decide whether BDS is in the Python 3.14 support scope or defer with a
+       follow-up ticket.
+   * - ``boosted``
+     - Blocked
+     - ``scikit-learn>=1.0,<1.6.0`` excludes Python 3.14-capable
+       ``scikit-learn`` wheels selected by core resolution.
+     - Relax or split the ``scikit-learn`` cap for Python 3.14 after behavioral
+       validation.
+   * - ``data``
+     - Blocked
+     - ``sqlalchemy>=1.4.1,<=1.4.46`` has no Python 3.14 binary match; the
+       resolver only found SQLAlchemy 2.x candidates.
+     - Validate ADS database/data code with SQLAlchemy 2.x or add a Python
+       3.14 exclusion.
+   * - ``forecast``
+     - Blocked
+     - ``numpy<2.0.0`` conflicts with the Python 3.14 NumPy wheel set selected
+       by the resolver.
+     - Treat forecast as service-conda-gated until NumPy 2.x compatibility is
+       validated or an internal compatible environment is confirmed.
+   * - ``geo``
+     - Blocked
+     - ``fiona<=1.9.6`` has no Python 3.14 binary match.
+     - Revisit the ``geopandas``/``fiona`` caps for Python 3.14, or defer geo
+       support.
+   * - ``huggingface``
+     - Resolves
+     - Resolver selected current ``transformers`` and ``tf-keras`` packages.
+     - Run import/runtime tests because this stack is sensitive to transitive
+       version movement.
+   * - ``llm``
+     - Resolves
+     - Resolver selected current LangChain/OpenAI-compatible packages.
+     - Run targeted LLM serialization/client tests.
+   * - ``notebook``
+     - Blocked
+     - Shares the ``scikit-learn>=1.0,<1.6.0`` blocker with ``boosted``.
+     - Align with the ``scikit-learn`` Python 3.14 decision.
+   * - ``onnx``
+     - Blocked
+     - ``onnx~=1.17.0`` for ``python_version >= "3.12"`` has no Python 3.14
+       binary match; the resolver found newer ONNX candidates only.
+     - Add a Python 3.14-specific marker after validating newer ONNX,
+       ONNX Runtime, ``skl2onnx``, and ``tf2onnx`` combinations.
+   * - ``opctl``
+     - Blocked
+     - ``oci-cli`` resolution conflicts with current ``oci``/``PyYAML``
+       availability for Python 3.14.
+     - Validate whether service-conda environments provide a compatible
+       ``oci-cli`` stack or split/exclude ``oci-cli`` on Python 3.14.
+   * - ``optuna``
+     - Resolves
+     - ``optuna==2.9.0`` resolves with ``oracle_ads[viz]``.
+     - Run HPO tests before declaring support.
+   * - ``pii``
+     - Blocked
+     - ``spacy-transformers==1.2.5`` has no Python 3.14 binary match.
+     - Upgrade the spaCy transformer stack or defer PII support.
+   * - ``recommender``
+     - Blocked
+     - Inherits the shared ``opctl`` resolver blocker.
+     - Resolve or defer through the ``opctl`` service-conda decision.
+   * - ``regression``
+     - Blocked
+     - Inherits the ``forecast`` ``numpy<2.0.0`` blocker.
+     - Resolve or defer through the forecast/operator decision.
+   * - ``spark``
+     - Blocked
+     - ``pyspark>=3.0.0`` had no Python 3.14 binary match under the audit
+       policy.
+     - Confirm whether Spark is service-conda-only for Python 3.14 or requires
+       a PyPI marker.
+   * - ``tensorflow``
+     - Blocked
+     - The unconstrained ``tensorflow`` dependency for
+       ``python_version >= "3.12"`` had no Python 3.14 binary match.
+     - Defer TensorFlow support or add a Python 3.14 marker once compatible
+       wheels exist.
+   * - ``testsuite``
+     - Blocked
+     - ``arff`` has no Python 3.14 binary match under the audit policy.
+     - Replace or scope the test dependency before full Python 3.14 unit-test
+       coverage.
+   * - ``text``
+     - Blocked
+     - ``spacy>=3.4.2,<3.8`` excludes Python 3.14-compatible spaCy candidates
+       found by the resolver.
+     - Validate spaCy 3.8+ behavior or defer text support.
+   * - ``torch``
+     - Resolves
+     - Resolver selected Python 3.14-compatible ``torch`` and ``torchvision``
+       wheels on macOS arm64.
+     - Run model framework import/serialization tests.
+   * - ``viz``
+     - Resolves
+     - Current visualization dependencies resolve.
+     - Run plotting/import smoke tests.
+
+Service-conda-relevant groups
+-----------------------------
+
+The service-facing groups with immediate Python 3.14 resolver blockers are
+``opctl``, ``forecast``, ``anomaly``, ``recommender``, ``regression``, ``spark``,
+``tensorflow``, and ``onnx``. These should not be treated as Python 3.14-ready
+until either:
+
+* the package metadata is updated and validated against Python 3.14, or
+* the service-conda environment owners confirm compatible internal builds and
+  ADS scopes those groups as service-conda-only for Python 3.14.
+
+Recommended next steps
+----------------------
+
+* Keep package classifiers unchanged until dependency and runtime validation
+  complete.
+* Add Python 3.14-specific dependency markers for blockers that only need newer
+  releases, especially ``scikit-learn``, ``onnx``, ``spacy``, ``fiona``, and
+  ``sqlalchemy``.
+* Create explicit follow-up tickets for groups that are not in the initial
+  Python 3.14 support scope, especially TensorFlow, Spark, forecast/anomaly
+  operators, and BDS.
+* Run targeted import/runtime tests for resolver-passing groups:
+  ``aqua``, ``huggingface``, ``llm``, ``optuna``, ``torch``, and ``viz``.
+* Re-run the resolver audit on the target Linux service-conda platform before
+  enabling CI or advertising Python 3.14 package metadata.

--- a/docs/source/python314_dependency_audit.rst
+++ b/docs/source/python314_dependency_audit.rst
@@ -376,6 +376,66 @@ until either:
 * the service-conda environment owners confirm compatible internal builds and
   ADS scopes those groups as service-conda-only for Python 3.14.
 
+Issue-ready follow-up queue
+---------------------------
+
+The following follow-ups are specific enough to become separate Beads or Jira
+tickets. Each item should keep Python 3.14 package classifiers gated until its
+scope is either validated or explicitly documented as deferred.
+
+* Default setup CI enablement:
+  Add a Python 3.14 row to ``run-unittests-default_setup.yml`` only after the
+  Linux runner, ``actions/setup-python``, and conda install path provide Python
+  3.14. Validate ``tests/unitary/default_setup`` with ``NoDependency=True`` and
+  preserve the targeted runtime checks listed in the GitHub Actions staging
+  plan.
+* Full testsuite dependency unblock:
+  Replace, remove, or scope the ``arff`` test dependency that blocks
+  ``oracle_ads[testsuite]`` resolution on Python 3.14. Re-run the broad
+  ``tests/unitary`` workflow before adding Python 3.14 to
+  ``run-unittests-py310-py311.yml``.
+* Optional import validation for resolver-passing groups:
+  Add targeted Python 3.14 import/runtime tests for ``aqua``, ``huggingface``,
+  ``llm``, ``optuna``, ``torch``, and ``viz``. Record whether each group is
+  package-supported, service-conda-only, or deferred.
+* SQLAlchemy 2.x data access decision:
+  Validate ADS data/database APIs against SQLAlchemy 2.x on Python 3.14 or add
+  a Python 3.14 exclusion for the ``data`` extra. Include migration notes for
+  any behavior changes.
+* scikit-learn cap split:
+  Decide whether ``boosted`` and ``notebook`` can relax the
+  ``scikit-learn<1.6.0`` cap for Python 3.14. Validate boosted model and
+  notebook paths with the selected scikit-learn version.
+* ONNX stack selection:
+  Choose and validate a Python 3.14-compatible ONNX stack, including ``onnx``,
+  ONNX Runtime, ``skl2onnx``, and ``tf2onnx``. Update markers only after model
+  serialization and conversion tests pass.
+* Text and PII dependency upgrade:
+  Validate spaCy 3.8+ and compatible ``spacy-transformers`` releases on Python
+  3.14, then update the ``text`` and ``pii`` extras or record them as deferred.
+* Geo dependency upgrade:
+  Revisit the ``geopandas`` and ``fiona`` caps for Python 3.14 wheel
+  availability. Validate import and representative geospatial data operations
+  before advertising ``geo`` support.
+* Forecast and low-code operator alignment:
+  Resolve the ``forecast`` ``numpy<2.0.0`` blocker and the ``rrcf`` anomaly
+  blocker, or document Python 3.14 as service-conda-only for those operators.
+  Do not add Python 3.14 to forecast, anomaly, recommender, or regression
+  operator workflows until this decision is complete.
+* ``opctl`` and OCI CLI alignment:
+  Validate whether Python 3.14 service-conda environments provide a compatible
+  ``oci-cli`` stack, or split/exclude the ``oci-cli`` dependency on Python 3.14.
+  Use this decision for ``opctl``, ``recommender``, and other inherited groups.
+* TensorFlow and Spark scope decision:
+  Confirm whether Python 3.14-compatible TensorFlow and Spark stacks are
+  available through public wheels or service-conda environments. If not, add
+  explicit Python 3.14 exclusions and user-visible limitations for these extras.
+* BDS service-conda decision:
+  Decide whether BDS is supported only through a named service-conda
+  environment on Python 3.14. If PyPI support is required, replace or update the
+  ``hdfs[kerberos]``/``docopt`` dependency path and validate BDS import/runtime
+  coverage.
+
 Recommended next steps
 ----------------------
 

--- a/docs/source/python314_dependency_audit.rst
+++ b/docs/source/python314_dependency_audit.rst
@@ -116,6 +116,17 @@ Python 3.14. ADS should preserve full OCI conda paths directly and should
 resolve service-conda slugs through the service index before using the
 environment Python version.
 
+Packaging metadata decision
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+No dependency version changes are applied in this step because the Python 3.14
+audit identified resolver blockers but did not validate replacement dependency
+sets. The ``pyproject.toml`` Python classifiers intentionally stop at Python
+3.12 until install, runtime, and agreed-scope unit-test validation complete.
+
+No ``THIRD_PARTY_LICENSES.txt`` update is required for this step because no
+dependencies are added, removed, or upgraded.
+
 Optional-extra resolver results
 -------------------------------
 

--- a/docs/source/python314_dependency_audit.rst
+++ b/docs/source/python314_dependency_audit.rst
@@ -37,6 +37,85 @@ Core ADS dependencies resolve on Python 3.14. The resolver selected Python
 This is only a resolver result. It does not validate runtime behavior, import
 coverage, model artifact behavior, or service-conda compatibility.
 
+Agreed Python 3.14 support scope
+--------------------------------
+
+Python 3.14 support should be staged. The initial support claim should cover
+only surfaces that resolve on Python 3.14 and have targeted runtime or unit-test
+validation. Package classifiers should remain unchanged until that validation is
+complete.
+
+Initial support candidates
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following surfaces are candidates for the first Python 3.14 support claim:
+
+* Core ADS install from source and wheel, including default dependencies.
+* Default setup unit tests that do not require optional extras or service
+  resources.
+* Model artifact/runtime metadata paths that only parse, preserve, and emit
+  explicit Python version strings, including ``INFERENCE_PYTHON_VERSION`` and
+  training Python version fields.
+* Jobs and model APIs that accept service-conda slugs or full OCI conda paths
+  without importing unresolved optional stacks.
+* Optional groups that resolved in the Python 3.14 audit and still require
+  targeted import/runtime tests before support is advertised: ``aqua``,
+  ``huggingface``, ``llm``, ``optuna``, ``torch``, and ``viz``.
+
+Validation-gated support
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+These areas remain in scope for Python 3.14 only after dependency metadata and
+runtime tests are updated:
+
+* Data access extras that need a SQLAlchemy 2.x compatibility decision.
+* Notebook and boosted model tooling that currently inherits the
+  ``scikit-learn<1.6.0`` cap.
+* ONNX model serialization and conversion after a Python 3.14-specific ONNX,
+  ONNX Runtime, ``skl2onnx``, and ``tf2onnx`` combination is selected.
+* Text and PII features after the spaCy dependency stack is moved to Python
+  3.14-compatible releases.
+* Geo features after the ``geopandas``/``fiona`` pin strategy is updated.
+* HPO, LLM, AQUA, Hugging Face, Torch, and visualization paths after targeted
+  import and behavioral tests pass.
+
+Deferred or unsupported until follow-up
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following areas should not be included in an initial Python 3.14 support
+claim unless service-conda owners confirm compatible internal builds and ADS
+captures that decision in a follow-up ticket:
+
+* BDS, because ``hdfs[kerberos]``/``docopt`` did not resolve with Python 3.14
+  binary availability in the audit.
+* Spark, because ``pyspark>=3.0.0`` did not resolve under the Python 3.14 binary
+  audit policy.
+* TensorFlow, because no Python 3.14 TensorFlow binary match was available for
+  the current unconstrained ``python_version >= "3.12"`` dependency.
+* Low-code forecast, anomaly, recommender, and regression operators, because
+  they inherit blockers from ``opctl``, ``forecast``, ``rrcf``, and NumPy pins.
+* Full ``testsuite`` coverage until ``arff`` and any subsequent Python 3.14 test
+  dependency blockers are replaced, scoped, or deferred.
+
+Service-conda coordination requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Any service-conda-required group that remains blocked must have one of the
+following before Python 3.14 support is advertised:
+
+* a metadata update in ``pyproject.toml`` plus passing Python 3.14 install and
+  runtime validation,
+* a documented service-conda-only support decision naming the compatible
+  service environment, or
+* a follow-up ticket that records the deferred group, the blocking dependency,
+  and the user-visible limitation.
+
+For model artifacts and runtime metadata, Python 3.14 should be accepted only
+where the selected inference or training conda environment is also validated for
+Python 3.14. ADS should preserve full OCI conda paths directly and should
+resolve service-conda slugs through the service index before using the
+environment Python version.
+
 Optional-extra resolver results
 -------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
+  # Add the Python 3.14 classifier only after ODSC-88493 dependency and
+  # runtime validation is complete.
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/tests/unitary/default_setup/model/test_model_introspect.py
+++ b/tests/unitary/default_setup/model/test_model_introspect.py
@@ -258,12 +258,13 @@ class TestPythonVersionCheck(TestCase):
         )
         import re
 
-        supported_python_version = [f"3.{minor}" for minor in range(6, 12)]
+        supported_python_version = [f"3.{minor}" for minor in range(6, 15)]
+        supported_python_version.append("3.14.5")
         for version in supported_python_version:
             m = re.match(at.PYTHON_VER_PATTERN, str(version))
             assert m and m.group(), "Python version check failed."
 
-        unsupported_python_version = ["3.5", "3.13"]
+        unsupported_python_version = ["3.5", "3.15", "4.0"]
         for version in unsupported_python_version:
             m = re.match(at.PYTHON_VER_PATTERN, str(version))
             assert not m, "Python version check failed."

--- a/tests/unitary/with_extras/model/test_runtime_info.py
+++ b/tests/unitary/with_extras/model/test_runtime_info.py
@@ -4,6 +4,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import os
+import yaml
 
 import pytest
 from ads.model.runtime.runtime_info import RuntimeInfo
@@ -103,6 +104,67 @@ class TestRuntimeInfo:
         assert (
             runtime_info.model_provenance.training_code.artifact_directory
             == "fake_artifact_directory"
+        )
+
+    @patch("ads.model.runtime.env_info.get_service_packs")
+    def test_from_yaml_preserves_python_314_versions(
+        self, mock_get_service_packs, tmp_path
+    ):
+        conda_env = "oci://service_conda_packs@ociodscdev/service_pack/cpu/Python_3.14/1.0/py314_cpu_v1"
+        python_version = "3.14"
+        mock_get_service_packs.return_value = (
+            {
+                conda_env: ("py314_cpu_v1", python_version),
+            },
+            {
+                "py314_cpu_v1": (conda_env, python_version),
+            },
+        )
+        runtime_yaml = tmp_path / "runtime.yaml"
+        runtime_yaml.write_text(
+            yaml.safe_dump(
+                {
+                    "MODEL_ARTIFACT_VERSION": "3.0",
+                    "MODEL_DEPLOYMENT": {
+                        "INFERENCE_CONDA_ENV": {
+                            "INFERENCE_ENV_PATH": conda_env,
+                            "INFERENCE_ENV_SLUG": "py314_cpu_v1",
+                            "INFERENCE_ENV_TYPE": "data_science",
+                            "INFERENCE_PYTHON_VERSION": python_version,
+                        }
+                    },
+                    "MODEL_PROVENANCE": {
+                        "PROJECT_OCID": "fake_project_id",
+                        "TENANCY_OCID": "fake_tenancy_id",
+                        "TRAINING_CODE": {
+                            "ARTIFACT_DIRECTORY": "fake_artifact_directory"
+                        },
+                        "TRAINING_COMPARTMENT_OCID": "fake_training_compartment_id",
+                        "TRAINING_CONDA_ENV": {
+                            "TRAINING_ENV_PATH": conda_env,
+                            "TRAINING_ENV_SLUG": "py314_cpu_v1",
+                            "TRAINING_ENV_TYPE": "data_science",
+                            "TRAINING_PYTHON_VERSION": python_version,
+                        },
+                        "TRAINING_REGION": "NOT_FOUND",
+                        "TRAINING_RESOURCE_OCID": "fake_resource_id",
+                        "USER_OCID": "NOT_FOUND",
+                        "VM_IMAGE_INTERNAL_ID": "VMIDNOTSET",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        runtime_info = RuntimeInfo.from_yaml(uri=str(runtime_yaml))
+
+        assert (
+            runtime_info.model_deployment.inference_conda_env.inference_python_version
+            == python_version
+        )
+        assert (
+            runtime_info.model_provenance.training_conda_env.training_python_version
+            == python_version
         )
 
     @patch.object(InferenceEnvInfo, "_validate", side_effect=DocumentError)


### PR DESCRIPTION
## Summary

This branch prepares ADS for staged Python 3.14 readiness without prematurely advertising full Python 3.14 package support. It records a Python 3.14 dependency readiness audit, documents the agreed support scope, keeps the Python 3.14 classifier gated in `pyproject.toml`, and adds the audit to the developer docs index.

The implementation updates model artifact Python-version validation to accept Python 3.14, adds runtime metadata coverage for Python 3.14 service-conda paths, fixes Python 3.14 dataclass annotation handling in `BaseProperties`, and cleans invalid escape-sequence warning sites so import/runtime smoke checks can run with `SyntaxWarning` promoted to an error.

The audit documents successful Python 3.14 core install/build validation, scoped default setup test results, GitHub Actions staging requirements, optional-extra resolver outcomes, service-conda alignment risks, and issue-ready follow-up work for dependency blockers. Full Python 3.14 support remains gated until blocked optional/service-conda groups are resolved or explicitly deferred.

## Tests Run

- `/usr/bin/env PYTHONDONTWRITEBYTECODE=1 MPLCONFIGDIR=/tmp .venv-py314-core/bin/python -c "import ads, sys; print(sys.version.split()[0], ads.__version__)"` -> Python 3.14.5 / ADS 2.15.2 import smoke passed.
- `/usr/bin/env PYTHONDONTWRITEBYTECODE=1 MPLCONFIGDIR=/tmp .venv-py314-core/bin/python -m pytest -p no:cacheprovider tests/unitary/default_setup/model/test_model_introspect.py::TestPythonVersionCheck::test_python_version_check tests/unitary/with_extras/model/test_runtime_info.py::TestRuntimeInfo::test_from_yaml_preserves_python_314_versions` -> 2 passed in 2.37s.
- `/usr/bin/env PYTHONDONTWRITEBYTECODE=1 MPLCONFIGDIR=/tmp .venv-py314-core/bin/python -m pytest -p no:cacheprovider tests/unitary/default_setup/common/test_common_base_properties.py` -> 27 passed in 2.49s.
- `/usr/bin/env PYTHONDONTWRITEBYTECODE=1 MPLCONFIGDIR=/tmp NoDependency=1 .venv-py314-core/bin/python -m pytest -p no:cacheprovider tests/unitary/default_setup` -> 1236 passed, 13 skipped, 2 xfailed in 407.08s.
- `/usr/bin/env PYTHONDONTWRITEBYTECODE=1 MPLCONFIGDIR=/tmp .venv-py314-core/bin/python -W error::SyntaxWarning -c "import ads; import ads.telemetry.telemetry; import ads.text_dataset.dataset; import numpy as np, pandas as pd; from sklearn.preprocessing import StandardScaler; df = pd.DataFrame({'x': np.array([1.0, 2.0, 3.0])}); out = StandardScaler().fit_transform(df); print(np.__version__, pd.__version__, out.shape)"` -> 2.5.1 2.3.3 (3, 1).
- `/usr/bin/env PYTHONDONTWRITEBYTECODE=1 MPLCONFIGDIR=/tmp .venv-py314-core/bin/python -m pytest -p no:cacheprovider tests/unitary/default_setup` -> failed before the BaseProperties fix and optional dependency scoping: 20 failed, 1224 passed, 5 skipped, 2 xfailed; remaining failures were optional dependency gaps for IPython, seaborn, and nbformat after the BaseProperties issue was identified.
- `git diff --check` and `git diff --check main...HEAD` passed.
- Full Python 3.14 broad unit coverage was not run because `oracle_ads[testsuite]` remains blocked by the `arff` dependency on Python 3.14.
