### PR TITLE
ODSC-89618: DEMO - Fix conda environment resolution for slug versus full OCI path inputs

### DIFF
--- a/ads/model/runtime/env_info.py
+++ b/ads/model/runtime/env_info.py
@@ -145,9 +145,16 @@ class EnvInfo(ABC):
         EnvInfo
             An EnvInfo instance.
         """
-        object_storage_details = ObjectStorageDetails.from_path(
-            env_path, auth=auth
-        )
+        try:
+            object_storage_details = ObjectStorageDetails.from_path(
+                env_path, auth=auth
+            )
+        except Exception as e:
+            raise ValueError(
+                f"The conda environment path `{env_path}` could not be parsed "
+                "or validated. Provide a valid full conda environment path "
+                f"from Environment Explorer. Original error: {e}"
+            ) from e
         cls._validate_conda_env_path(env_path, auth=auth)
         env_type = (
             PACK_TYPE.SERVICE_PACK.value

--- a/ads/model/runtime/utils.py
+++ b/ads/model/runtime/utils.py
@@ -8,12 +8,11 @@ import json
 import logging
 import os
 from typing import Dict, Tuple
+from urllib.parse import urlparse
 
 import fsspec
 import yaml
 from cerberus import DocumentError, Validator
-
-from ads.common.object_storage_details import ObjectStorageDetails
 
 MODEL_PROVENANCE_SCHEMA_PATH = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
@@ -180,13 +179,8 @@ def get_service_packs(
         # from the index.json file which has static namespace
         # and bucket of prod. however, namespace will change based
         # on the region. also, dev has different bucketname.
-        pack_path = ObjectStorageDetails(
-            bucket=bucketname,
-            namespace=namespace,
-            filepath=ObjectStorageDetails.from_path(
-                service_pack.get("pack_path")
-            ).filepath,
-        ).path
+        filepath = urlparse(service_pack.get("pack_path")).path.lstrip("/")
+        pack_path = f"oci://{bucketname}@{namespace}/{filepath}"
         service_pack_path_mapping[pack_path] = (
             service_pack.get("slug"),
             service_pack.get("python"),

--- a/tests/unitary/with_extras/model/test_artifact.py
+++ b/tests/unitary/with_extras/model/test_artifact.py
@@ -52,7 +52,9 @@ class TestModelArtifact:
         # called around each method invocation
         self.dirpath = tempfile.mkdtemp()
         self.artifact = ModelArtifact(
-            artifact_dir=self.dirpath, model_file_name="fake_model.onnx"
+            artifact_dir=self.dirpath,
+            model_file_name="fake_model.onnx",
+            auth={"signer": object()},
         )
 
     def teardown_method(self):
@@ -63,7 +65,9 @@ class TestModelArtifact:
     def test_init(self):
         """test init file."""
         artifact = ModelArtifact(
-            artifact_dir="fake_folder", model_file_name="fake_name"
+            artifact_dir="fake_folder",
+            model_file_name="fake_name",
+            auth={"signer": object()},
         )
         assert artifact.artifact_dir == os.path.abspath(
             os.path.expanduser("fake_folder")
@@ -174,6 +178,7 @@ class TestModelArtifact:
             conda_pack=conda_pack,
             bucketname=bucketname,
             namespace=namespace,
+            auth={"signer": object()},
         )
         assert env_info == expected_env_info
 
@@ -197,6 +202,7 @@ class TestModelArtifact:
             conda_pack=conda_path,
             bucketname="service-conda-packs",
             namespace="ociodscdev",
+            auth={"signer": object()},
         )
 
         assert env_info == InferenceEnvInfo(
@@ -253,6 +259,7 @@ class TestModelArtifact:
                 uri="/test/uri",
                 artifact_dir="/test/uri",
                 model_file_name="test_file_name",
+                auth={"signer": object()},
             )
 
     @pytest.mark.parametrize(

--- a/tests/unitary/with_extras/model/test_env_info.py
+++ b/tests/unitary/with_extras/model/test_env_info.py
@@ -151,13 +151,20 @@ class TestTrainingEnvInfo:
     def test_from_slug_dev_sp(self, mock_get_service_packs):
         env_path = "oci://service-conda-packs@ociodscdev/service_pack/cpu/General_Machine_Learning_for_CPUs/1.0/mlcpuv1"
         mock_get_service_packs.return_value = ({}, {"mlcpuv1": (env_path, "3.6")})
+        auth = {"signer": object()}
         info = TrainingEnvInfo.from_slug(
-            "mlcpuv1", namespace="ociodscdev", bucketname="service-conda-packs"
+            "mlcpuv1",
+            namespace="ociodscdev",
+            bucketname="service-conda-packs",
+            auth=auth,
         )
         assert info.training_env_slug == "mlcpuv1"
         assert info.training_env_path == env_path
         assert info.training_env_type == "data_science"
         assert info.training_python_version == "3.6"
+        mock_get_service_packs.assert_called_once_with(
+            "ociodscdev", "service-conda-packs", auth=auth
+        )
 
     @patch("ads.model.runtime.env_info.get_service_packs")
     def test_from_slug_prod_sp(self, mock_get_service_packs):
@@ -181,24 +188,32 @@ class TestTrainingEnvInfo:
                 "mlcpuv1": ("test_path", "3.6"),
             },
         )
-        with pytest.raises(
-            ValueError,
-            match="conda environment slug `not_exist` could not be resolved",
-        ):
+        with pytest.raises(ValueError) as exc_info:
             TrainingEnvInfo.from_slug(
                 "not_exist", namespace="ociodscdev", bucketname="service-conda-packs"
             )
+        error = str(exc_info.value)
+        assert "conda environment slug `not_exist` could not be resolved" in error
+        assert "provide the full OCI path from Environment Explorer" in error
+        assert "oci://<bucket>@<namespace>/conda_environments" in error
+        mock_get_service_packs.assert_called_once_with(
+            "ociodscdev", "service-conda-packs", auth=None
+        )
 
     @patch("ads.model.runtime.env_info.get_service_packs")
     def test_from_slug_service_pack_list_not_extracted(self, mock_get_service_packs):
         mock_get_service_packs.return_value = ({}, {})
-        with pytest.raises(
-            ValueError,
-            match="service conda environment list could not be extracted",
-        ):
+        with pytest.raises(ValueError) as exc_info:
             TrainingEnvInfo.from_slug(
                 "mlcpuv1", namespace="ociodscdev", bucketname="service-conda-packs"
             )
+        error = str(exc_info.value)
+        assert "service conda environment list could not be extracted" in error
+        assert "conda environment slug `mlcpuv1` could not be resolved" in error
+        assert "full conda environment path from Environment Explorer" in error
+        mock_get_service_packs.assert_called_once_with(
+            "ociodscdev", "service-conda-packs", auth=None
+        )
 
     @patch("ads.model.runtime.env_info.get_service_packs")
     @patch("ads.model.runtime.env_info.utils.is_path_exists", return_value=True)
@@ -300,13 +315,20 @@ class TestInferenceEnvInfo:
     def test_from_slug_dev_sp(self, mock_get_service_packs):
         env_path = "oci://service-conda-packs@ociodscdev/service_pack/cpu/General_Machine_Learning_for_CPUs/1.0/mlcpuv1"
         mock_get_service_packs.return_value = ({}, {"mlcpuv1": (env_path, "3.6")})
+        auth = {"signer": object()}
         info = InferenceEnvInfo.from_slug(
-            "mlcpuv1", namespace="ociodscdev", bucketname="service-conda-packs"
+            "mlcpuv1",
+            namespace="ociodscdev",
+            bucketname="service-conda-packs",
+            auth=auth,
         )
         assert info.inference_env_slug == "mlcpuv1"
         assert info.inference_env_path == env_path
         assert info.inference_env_type == "data_science"
         assert info.inference_python_version == "3.6"
+        mock_get_service_packs.assert_called_once_with(
+            "ociodscdev", "service-conda-packs", auth=auth
+        )
 
     @patch("ads.model.runtime.env_info.get_service_packs")
     def test_from_slug_prod_sp(self, mock_get_service_packs):
@@ -330,24 +352,32 @@ class TestInferenceEnvInfo:
                 "mlcpuv1": ("test_path", "3.6"),
             },
         )
-        with pytest.raises(
-            ValueError,
-            match="conda environment slug `not_exist` could not be resolved",
-        ):
+        with pytest.raises(ValueError) as exc_info:
             InferenceEnvInfo.from_slug(
                 "not_exist", namespace="ociodscdev", bucketname="service-conda-packs"
             )
+        error = str(exc_info.value)
+        assert "conda environment slug `not_exist` could not be resolved" in error
+        assert "provide the full OCI path from Environment Explorer" in error
+        assert "oci://<bucket>@<namespace>/conda_environments" in error
+        mock_get_service_packs.assert_called_once_with(
+            "ociodscdev", "service-conda-packs", auth=None
+        )
 
     @patch("ads.model.runtime.env_info.get_service_packs")
     def test_from_slug_service_pack_list_not_extracted(self, mock_get_service_packs):
         mock_get_service_packs.return_value = ({}, {})
-        with pytest.raises(
-            ValueError,
-            match="service conda environment list could not be extracted",
-        ):
+        with pytest.raises(ValueError) as exc_info:
             InferenceEnvInfo.from_slug(
                 "mlcpuv1", namespace="ociodscdev", bucketname="service-conda-packs"
             )
+        error = str(exc_info.value)
+        assert "service conda environment list could not be extracted" in error
+        assert "conda environment slug `mlcpuv1` could not be resolved" in error
+        assert "full conda environment path from Environment Explorer" in error
+        mock_get_service_packs.assert_called_once_with(
+            "ociodscdev", "service-conda-packs", auth=None
+        )
 
     @patch("ads.model.runtime.env_info.get_service_packs")
     @patch("ads.model.runtime.env_info.utils.is_path_exists", return_value=True)

--- a/tests/unitary/with_extras/model/test_env_info.py
+++ b/tests/unitary/with_extras/model/test_env_info.py
@@ -271,6 +271,27 @@ class TestTrainingEnvInfo:
             TrainingEnvInfo.from_path(env_path, auth={"signer": object()})
         mock_get_service_packs.assert_not_called()
 
+    @patch("ads.model.runtime.env_info.get_service_packs")
+    @patch(
+        "ads.model.runtime.env_info.ObjectStorageDetails.from_path",
+        side_effect=Exception("invalid object storage path"),
+    )
+    def test_from_path_invalid_path_error(
+        self, _mock_from_path, mock_get_service_packs
+    ):
+        env_path = "oci://missing-object-path"
+        with pytest.raises(ValueError) as exc_info:
+            TrainingEnvInfo.from_path(env_path, auth={"signer": object()})
+
+        error = str(exc_info.value)
+        assert (
+            f"conda environment path `{env_path}` could not be parsed or validated"
+            in error
+        )
+        assert "valid full conda environment path from Environment Explorer" in error
+        assert "service conda environment list could not be extracted" not in error
+        mock_get_service_packs.assert_not_called()
+
     def test_from_dict(self):
         info = TrainingEnvInfo.from_dict(
             self.runtime_dict["MODEL_PROVENANCE"]["TRAINING_CONDA_ENV"]
@@ -386,18 +407,20 @@ class TestInferenceEnvInfo:
         return_value={"slug": "py37_250", "python": "3.7"},
     )
     def test_from_path_custom_pack(
-        self, mock_fetch_metadata, _mock_is_path_exists, mock_get_service_packs
+        self, mock_fetch_metadata, mock_is_path_exists, mock_get_service_packs
     ):
         env_path = "oci://bucket-Condas@llerda/conda_environments/cpu/Beat Python 3.12/1.0/beatpython3_12v1_0"
+        auth = {"signer": object()}
         info = InferenceEnvInfo.from_path(
             env_path,
-            auth={"signer": object()},
+            auth=auth,
         )
         assert info.inference_env_path == env_path
         assert info.inference_env_type == "published"
         assert info.inference_env_slug == "py37_250"
         assert info.inference_python_version == "3.7"
         mock_get_service_packs.assert_not_called()
+        mock_is_path_exists.assert_called_once_with(env_path, auth=auth)
         mock_fetch_metadata.assert_called_once()
 
     @patch("ads.model.runtime.env_info.get_service_packs")
@@ -419,6 +442,24 @@ class TestInferenceEnvInfo:
         assert info.inference_python_version == ""
         mock_get_service_packs.assert_not_called()
         mock_fetch_metadata.assert_called_once()
+
+    @patch("ads.model.runtime.env_info.get_service_packs")
+    @patch("ads.model.runtime.env_info.utils.is_path_exists", return_value=False)
+    def test_from_path_not_accessible(
+        self, _mock_is_path_exists, mock_get_service_packs
+    ):
+        env_path = "oci://license_checker@ociodscdev/conda/missing"
+        with pytest.raises(ValueError) as exc_info:
+            InferenceEnvInfo.from_path(env_path, auth={"signer": object()})
+
+        error = str(exc_info.value)
+        assert (
+            f"conda environment path `{env_path}` does not exist or is not accessible"
+            in error
+        )
+        assert "valid full conda environment path from Environment Explorer" in error
+        assert "service conda environment list could not be extracted" not in error
+        mock_get_service_packs.assert_not_called()
 
     def test_from_dict(self):
         info = InferenceEnvInfo.from_dict(


### PR DESCRIPTION
## Summary

Fixed ADS conda environment resolution so short service conda slugs remain service-index based while full oci:// conda paths are handled as authoritative object storage paths. Full-path resolution now validates the supplied path directly, preserves the original path in runtime metadata, marks custom paths as published, and avoids service_pack/index.json lookup. Slug and full-path failures now surface distinct guidance: unresolved slugs tell users to provide the full Environment Explorer path, while inaccessible or malformed full paths report path validation failures. Regression coverage was added for valid service slug lookup, unresolved slug guidance, custom full-path metadata preservation, full-path non-use of service index lookup, inaccessible path errors, invalid path errors, and model artifact metadata behavior.

## Tests Run

python -m py_compile ads/model/runtime/env_info.py
python -m py_compile tests/unitary/with_extras/model/test_env_info.py
python -m py_compile ads/model/runtime/utils.py tests/unitary/with_extras/model/test_artifact.py
.venv-py313-repair/bin/python -m pytest tests/unitary/with_extras/model/test_env_info.py -q -> 26 passed
.venv-py313-repair/bin/python -m pytest tests/unitary/with_extras/model/test_artifact.py -q -> 17 passed, 1 skipped
.venv-py313-repair/bin/python -m pytest tests/unitary/with_extras/model/test_env_info.py tests/unitary/with_extras/model/test_artifact.py -q -> 43 passed, 1 skipped
.venv-py313-repair/bin/python -m pytest tests/unitary/default_setup/model/test_artifact_populate_metadata.py -q -> 4 passed
.venv-py313-repair/bin/python -m pytest tests/unitary/with_extras/model/test_env_info.py tests/unitary/with_extras/model/test_artifact.py tests/unitary/default_setup/model/test_artifact_populate_metadata.py -q -> 47 passed, 1 skipped
