### PR TITLE
Release ADS v2.15.3

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,17 @@
 Release Notes
 =============
 
+2.15.3
+------
+Release date: July 27, 2026
+
+* Forecast Operator fixes:
+  * Fixed ARIMA failures for sparse series when confidence intervals are enabled.
+* AI Quick Actions fixes:
+  * Fixed Hugging Face model search compatibility with current Hugging Face client behavior.
+* Model artifact and runtime fixes:
+  * Fixed conda slug and full path resolution for model runtime environments and artifacts.
+
 2.15.2
 ------
 Release date: June 17, 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "flit_core.buildapi"
 
 # Required
 name = "oracle_ads" # the install (PyPI) name; name for local build in [tool.flit.module] section below
-version = "2.15.2"
+version = "2.15.3"
 
 # Optional
 description = "Oracle Accelerated Data Science SDK"


### PR DESCRIPTION
## Summary

Release ADS `2.15.3`.

## Changes

- Bumped `oracle_ads` version from `2.15.2` to `2.15.3`.
- Added `2.15.3` release notes.

## Release highlights

- Fixed ARIMA failures for sparse series when confidence intervals are enabled.
- Fixed Aqua Hugging Face model search compatibility.
- Fixed conda slug and full path resolution for model runtime environments and artifacts.