### PR TITLE
Batch prediction support for Regression Operator

### DIFF
--- a/ads/opctl/operator/lowcode/regression/README.md
+++ b/ads/opctl/operator/lowcode/regression/README.md
@@ -2,7 +2,7 @@
 
 The Regression Operator trains supervised tabular regression models through a YAML-based interface. The supported model values are `linear_regression`, `random_forest`, `knn`, `xgboost`, and `auto`.
 
-When a run completes, the operator writes artifacts into `output_directory`. Depending on the configuration and available data, these can include `training_predictions.csv`, `test_predictions.csv`, `training_metrics.csv`, `test_metrics.csv`, `global_explanations.csv`, `report.html`, and `model.pkl`.
+When a run completes, the operator writes artifacts into `output_directory`. Depending on the configuration and available data, these can include `training_predictions.csv`, `test_predictions.csv`, `predictions.csv`, `training_metrics.csv`, `test_metrics.csv`, `global_explanations.csv`, `report.html`, and `model.pkl`.
 
 Below are the steps to configure and run the Regression Operator on different resources.
 
@@ -44,7 +44,7 @@ To run regression locally, create and activate a conda environment and install t
 - xgboost
 ```
 
-Then review `regression.yaml` and fill in the required operator inputs. At minimum, the schema requires `spec.training_data` and `spec.target_column`. `spec.test_data` is optional.
+Then review `regression.yaml` and fill in the required operator inputs. At minimum, the schema requires `spec.training_data` and `spec.target_column`. Labeled `spec.test_data` is optional and is reserved for holdout evaluation. Use `spec.prediction_data` for unlabeled batch scoring.
 
 Example:
 
@@ -185,3 +185,24 @@ The logs can be monitored using:
 ```bash
 ads opctl watch <OCID>
 ```
+
+## 7. Producing batch predictions without deployment
+
+Configure a separate unlabeled `prediction_data` source and a stable output contract. The prediction dataset must include all learned feature columns and every configured passthrough column. It does not need the target column or a unique key. When `passthrough_columns` is omitted, every column from `prediction_data` is included in the output; use an explicit empty list to output only `prediction`.
+
+```yaml
+spec:
+  training_data:
+    url: oci://bucket@namespace/regression/input_data/train.csv
+  prediction_data:
+    url: oci://bucket@namespace/regression/input_data/rows_to_score.csv
+  prediction_output:
+    passthrough_columns: [record_id, series_id, period]
+    filename: predictions.csv
+  output_directory:
+    url: oci://bucket@namespace/regression/result/
+  target_column: target
+  model: random_forest
+```
+
+The resulting `predictions.csv` contains the configured passthrough columns followed by `prediction`, in the same row order as `prediction_data`. Passthrough values may be duplicated or null. Batch scoring does not require Model Catalog registration or a Model Deployment.

--- a/ads/opctl/operator/lowcode/regression/cmd.py
+++ b/ads/opctl/operator/lowcode/regression/cmd.py
@@ -9,8 +9,7 @@ from ads.opctl.operator.common.operator_yaml_generator import YamlGenerator
 from ads.opctl.operator.common.utils import _load_yaml_from_uri
 
 
-
-def init(**kwargs: Dict) -> str:
+def init(**kwargs: Dict) -> dict:
     """Generates operator config by the schema."""
     return YamlGenerator(
         schema=_load_yaml_from_uri(__file__.replace("cmd.py", "schema.yaml"))

--- a/ads/opctl/operator/lowcode/regression/deployment/deployment_manager.py
+++ b/ads/opctl/operator/lowcode/regression/deployment/deployment_manager.py
@@ -48,19 +48,25 @@ class ModelDeploymentManager:
     ):
         self.spec = spec
         self.model_name = model_name
-        self.display_name = spec.save_and_deploy_to_md.model_catalog_display_name
+        lifecycle_config = spec.save_and_deploy_to_md
+        self.deployment_config = lifecycle_config.model_deployment
+        self.display_name = lifecycle_config.model_catalog_display_name
         self.project_id = (
-            spec.save_and_deploy_to_md.project_id
-            if spec.save_and_deploy_to_md.project_id
+            lifecycle_config.project_id
+            if lifecycle_config.project_id
             else os.environ.get("PROJECT_OCID")
         )
         self.compartment_id = (
-            spec.save_and_deploy_to_md.compartment_id
-            if spec.save_and_deploy_to_md.compartment_id
+            lifecycle_config.compartment_id
+            if lifecycle_config.compartment_id
             else os.environ.get("NB_SESSION_COMPARTMENT_OCID")
         )
         if self.project_id is None or self.compartment_id is None:
-            raise ValueError("Either project_id or compartment_id cannot be None.")
+            raise ValueError(
+                "`save_and_deploy_to_md.project_id` and "
+                "`save_and_deploy_to_md.compartment_id` are required, either "
+                "explicitly or through PROJECT_OCID and NB_SESSION_COMPARTMENT_OCID."
+            )
 
         tmp_dir_obj = tempfile.TemporaryDirectory()
         self._artifact_dir_obj = tmp_dir_obj
@@ -109,9 +115,13 @@ class ModelDeploymentManager:
             loaded_model = load_model()
             input_data = {"data": sanity_data.to_dict(orient="records")}
             prediction_test = predict(input_data, loaded_model)
-            logger.info(f"Regression deployment sanity test completed with result: {prediction_test}")
+            logger.info(
+                f"Regression deployment sanity test completed with result: {prediction_test}"
+            )
         except Exception as e:
-            logger.error(f"An error occurred during regression deployment sanity test: {e}")
+            logger.error(
+                f"An error occurred during regression deployment sanity test: {e}"
+            )
             raise
         finally:
             sys.path = org_sys_path
@@ -158,7 +168,9 @@ class ModelDeploymentManager:
         self._copy_score_file()
         self._sanity_test()
 
-        description = f"Regression operator deployment artifact for model `{self.model_name}`."
+        description = (
+            f"Regression operator scoring artifact for model `{self.model_name}`."
+        )
         if not self.test_mode:
             catalog_entry = artifact.save(
                 display_name=self.display_name,
@@ -182,12 +194,20 @@ class ModelDeploymentManager:
     def create_deployment(self):
         """Create an OCI model deployment for the saved regression model."""
         if not self.catalog_id and not self.test_mode:
-            raise ValueError("Model must be saved to catalog before creating deployment.")
+            raise ValueError(
+                "Model must be saved to catalog before creating deployment."
+            )
 
-        initial_shape = self.spec.save_and_deploy_to_md.model_deployment.initial_shape
-        name = self.spec.save_and_deploy_to_md.model_deployment.display_name
-        description = self.spec.save_and_deploy_to_md.model_deployment.description
-        auto_scaling_config = self.spec.save_and_deploy_to_md.model_deployment.auto_scaling
+        if self.deployment_config.id:
+            raise ValueError(
+                "Updating an existing Model Deployment is not supported. Remove "
+                "`model_deployment.id` to create a new deployment."
+            )
+
+        initial_shape = self.deployment_config.initial_shape
+        name = self.deployment_config.display_name
+        description = self.deployment_config.description
+        auto_scaling_config = self.deployment_config.auto_scaling
 
         if auto_scaling_config and auto_scaling_config.maximum_instance:
             scaling_policy = oci.data_science.models.AutoScalingPolicy(
@@ -238,8 +258,8 @@ class ModelDeploymentManager:
             model_configuration_details=model_configuration_details_object,
         )
 
-        log_group = self.spec.save_and_deploy_to_md.model_deployment.log_group
-        log_id = self.spec.save_and_deploy_to_md.model_deployment.log_id
+        log_group = self.deployment_config.log_group
+        log_id = self.deployment_config.log_id
         if not log_id and log_group and not self.test_mode:
             signer = oci.auth.signers.get_resource_principals_signer()
             auth = {"signer": signer, "config": {}}

--- a/ads/opctl/operator/lowcode/regression/model/auto.py
+++ b/ads/opctl/operator/lowcode/regression/model/auto.py
@@ -11,7 +11,10 @@ import pandas as pd
 from sklearn.model_selection import KFold
 
 from ads.opctl import logger
-from ads.opctl.operator.lowcode.regression.const import SupportedMetrics, SupportedModels
+from ads.opctl.operator.lowcode.regression.const import (
+    SupportedMetrics,
+    SupportedModels,
+)
 
 from .base_model import RegressionOperatorBaseModel
 from .knn import KNNRegressionOperatorModel
@@ -87,6 +90,7 @@ class AutoRegressionOperatorModel(RegressionOperatorBaseModel):
         self.feature_names_out = final_model.feature_names_out
         self.train_predictions = final_model.train_predictions
         self.test_predictions = final_model.test_predictions
+        self.prediction_values = final_model.prediction_values
         self.train_metrics = final_model.train_metrics
         self.test_metrics = final_model.test_metrics
         self.global_explanations_df = final_model.global_explanations_df
@@ -116,7 +120,9 @@ class AutoRegressionOperatorModel(RegressionOperatorBaseModel):
         for model_name, model_cls in self._CANDIDATES.items():
             fold_scores = []
             try:
-                for fold_index, (train_idx, valid_idx) in enumerate(splitter.split(x_train), start=1):
+                for fold_index, (train_idx, valid_idx) in enumerate(
+                    splitter.split(x_train), start=1
+                ):
                     fold_config = copy.deepcopy(self.config)
                     fold_config.spec.model = model_name
                     fold_config.spec.model_kwargs = {}

--- a/ads/opctl/operator/lowcode/regression/model/base_model.py
+++ b/ads/opctl/operator/lowcode/regression/model/base_model.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2026 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
+import json
 import logging
 import os
 import tempfile
@@ -15,7 +16,10 @@ import report_creator as rc
 from plotly import graph_objects as go
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 
-from ads.common.decorator.runtime_dependency import OptionalDependency, runtime_dependency
+from ads.common.decorator.runtime_dependency import (
+    OptionalDependency,
+    runtime_dependency,
+)
 from ads.common.object_storage_details import ObjectStorageDetails
 from ads.opctl import logger
 from ads.opctl.operator.lowcode.common.utils import (
@@ -24,14 +28,14 @@ from ads.opctl.operator.lowcode.common.utils import (
     write_data,
     write_file,
     write_pkl,
-    write_simple_json,
 )
 from ads.opctl.operator.lowcode.regression.const import SupportedMetrics
-from ads.opctl.operator.lowcode.regression.model.regression_dataset import RegressionDatasets
+from ads.opctl.operator.lowcode.regression.model.regression_dataset import (
+    RegressionDatasets,
+)
 from ads.opctl.operator.lowcode.regression.operator_config import (
     RegressionOperatorConfig,
     RegressionOperatorSpec,
-    RegressionDeploymentConfig,
 )
 from ads.opctl.operator.lowcode.regression.deployment import ModelDeploymentManager
 from ads.opctl.operator.lowcode.regression.model.inference_model import (
@@ -79,6 +83,7 @@ class RegressionOperatorBaseModel(ABC):
         self.feature_names_out = []
         self.train_predictions = None
         self.test_predictions = None
+        self.prediction_values = None
         self.train_metrics = None
         self.test_metrics = None
         self.global_explanations_df = None
@@ -140,7 +145,11 @@ class RegressionOperatorBaseModel(ABC):
         y_true = np.asarray(y_true)
         y_pred = np.asarray(y_pred)
         mask = y_true != 0
-        mape = np.mean(np.abs((y_true[mask] - y_pred[mask]) / y_true[mask])) * 100 if mask.any() else np.nan
+        mape = (
+            np.mean(np.abs((y_true[mask] - y_pred[mask]) / y_true[mask])) * 100
+            if mask.any()
+            else np.nan
+        )
 
         smape_denominator = np.abs(y_true) + np.abs(y_pred)
         smape = (
@@ -252,7 +261,9 @@ class RegressionOperatorBaseModel(ABC):
             ).sort_values("importance", ascending=False)
 
         if self.global_explanations_df is not None:
-            self.global_explanations_df = self.global_explanations_df.reset_index(drop=True)
+            self.global_explanations_df = self.global_explanations_df.reset_index(
+                drop=True
+            )
         return x_proc
 
     @runtime_dependency(
@@ -282,7 +293,9 @@ class RegressionOperatorBaseModel(ABC):
             if hasattr(model, "feature_importances_"):
                 explainer = shap.TreeExplainer(model)
                 shap_values = explainer.shap_values(x_sample)
-                values = shap_values[0] if isinstance(shap_values, list) else shap_values
+                values = (
+                    shap_values[0] if isinstance(shap_values, list) else shap_values
+                )
             else:
                 explainer = shap.Explainer(model.predict, x_sample)
                 shap_obj = explainer(x_sample)
@@ -412,7 +425,7 @@ class RegressionOperatorBaseModel(ABC):
 
     def _report_config_dict(self):
         config_dict = self.config.to_dict()
-        for dataset_key in ("training_data", "test_data"):
+        for dataset_key in ("training_data", "test_data", "prediction_data"):
             dataset_config = config_dict.get("spec", {}).get(dataset_key)
             if isinstance(dataset_config, dict):
                 dataset_config.pop("data", None)
@@ -453,7 +466,9 @@ class RegressionOperatorBaseModel(ABC):
             rows.append({"parameter": key, "value": value})
         return pd.DataFrame(rows)
 
-    def _build_predictions_output_df(self, predictions_df: pd.DataFrame) -> pd.DataFrame:
+    def _build_predictions_output_df(
+        self, predictions_df: pd.DataFrame
+    ) -> pd.DataFrame:
         if predictions_df is None or predictions_df.empty:
             return pd.DataFrame(columns=["input_value", "predicted_value", "residual"])
 
@@ -464,6 +479,18 @@ class RegressionOperatorBaseModel(ABC):
                 "residual": predictions_df["residual"],
             }
         )
+
+    def _build_batch_predictions_output_df(self) -> pd.DataFrame:
+        """Builds batch output while preserving prediction_data row order."""
+        if self.datasets.prediction_data is None or self.prediction_values is None:
+            return pd.DataFrame()
+
+        columns = self.datasets.prediction_passthrough_columns
+        result = (
+            self.datasets.prediction_data.loc[:, columns].reset_index(drop=True).copy()
+        )
+        result["prediction"] = np.asarray(self.prediction_values)
+        return result
 
     def _write_outputs(self, output_dir: str, storage_options):
         if not ObjectStorageDetails.is_oci_path(output_dir):
@@ -477,7 +504,10 @@ class RegressionOperatorBaseModel(ABC):
         )
         metrics_path = os.path.join(output_dir, self.spec.training_metrics_filename)
         test_metrics_path = os.path.join(output_dir, self.spec.test_metrics_filename)
-        global_expl_path = os.path.join(output_dir, self.spec.global_explanation_filename)
+        global_expl_path = os.path.join(
+            output_dir, self.spec.global_explanation_filename
+        )
+        prediction_path = os.path.join(output_dir, self.spec.prediction_output.filename)
 
         write_data(
             data=self._build_predictions_output_df(self.train_predictions),
@@ -491,6 +521,15 @@ class RegressionOperatorBaseModel(ABC):
             write_data(
                 data=self._build_predictions_output_df(self.test_predictions),
                 filename=test_predictions_path,
+                format="csv",
+                storage_options=storage_options,
+                index=False,
+            )
+
+        if self.prediction_values is not None:
+            write_data(
+                data=self._build_batch_predictions_output_df(),
+                filename=prediction_path,
                 format="csv",
                 storage_options=storage_options,
                 index=False,
@@ -513,7 +552,10 @@ class RegressionOperatorBaseModel(ABC):
                 index=False,
             )
 
-        if self.global_explanations_df is not None and not self.global_explanations_df.empty:
+        if (
+            self.global_explanations_df is not None
+            and not self.global_explanations_df.empty
+        ):
             write_data(
                 data=self.global_explanations_df,
                 filename=global_expl_path,
@@ -539,14 +581,14 @@ class RegressionOperatorBaseModel(ABC):
         self,
         x_train: pd.DataFrame,
         y_train: pd.Series,
-        deploy_config: RegressionDeploymentConfig = None,
     ):
         manager = ModelDeploymentManager(
             spec=self.spec,
             model_name=self.model_name,
         )
         manager.save_to_catalog()
-        manager.create_deployment()
+        if self.spec.save_and_deploy_to_md.model_deployment:
+            manager.create_deployment()
         manager.save_deployment_info()
         return manager.deployment_info
 
@@ -555,7 +597,9 @@ class RegressionOperatorBaseModel(ABC):
             return
 
         training_rows = len(self.datasets.training_data)
-        test_rows = len(self.datasets.test_data) if self.datasets.test_data is not None else 0
+        test_rows = (
+            len(self.datasets.test_data) if self.datasets.test_data is not None else 0
+        )
 
         sections = [
             rc.Block(
@@ -596,7 +640,10 @@ class RegressionOperatorBaseModel(ABC):
                 "Training Actual vs Predicted with Ideal Fit Reference",
             ),
             rc.Heading("Training Predictions (Top Rows)", level=3),
-            rc.DataTable(self._build_predictions_output_df(self.train_predictions).head(25), index=False),
+            rc.DataTable(
+                self._build_predictions_output_df(self.train_predictions).head(25),
+                index=False,
+            ),
         ]
 
         if self.spec.generate_explanations:
@@ -610,7 +657,10 @@ class RegressionOperatorBaseModel(ABC):
                 ]
             )
 
-            if self.global_explanations_df is not None and not self.global_explanations_df.empty:
+            if (
+                self.global_explanations_df is not None
+                and not self.global_explanations_df.empty
+            ):
                 sections.extend(
                     [
                         self._build_bar_plot(
@@ -650,7 +700,9 @@ class RegressionOperatorBaseModel(ABC):
                         ),
                         rc.Heading("Test Predictions (Top Rows)", level=3),
                         rc.DataTable(
-                            self._build_predictions_output_df(self.test_predictions).head(25),
+                            self._build_predictions_output_df(
+                                self.test_predictions
+                            ).head(25),
                             index=False,
                         ),
                     ]
@@ -708,7 +760,9 @@ class RegressionOperatorBaseModel(ABC):
                 logger.warning(f"Skipping explainability generation. Error: {e}")
 
         output_dir = self.spec.output_directory.url
-        storage_options = default_signer() if ObjectStorageDetails.is_oci_path(output_dir) else {}
+        storage_options = (
+            default_signer() if ObjectStorageDetails.is_oci_path(output_dir) else {}
+        )
 
         self._write_outputs(output_dir, storage_options)
         elapsed_time = time.time() - start_time
@@ -719,11 +773,6 @@ class RegressionOperatorBaseModel(ABC):
             model_registration_info = self._publish_to_oci(
                 x_train=x_train,
                 y_train=y_train,
-                deploy_config=self.spec.save_and_deploy_to_md,
-            )
-            write_simple_json(
-                model_registration_info,
-                os.path.join(output_dir, "model_registration_info.json"),
             )
 
         logger.info(f"Regression artifacts generated at: {output_dir}")

--- a/ads/opctl/operator/lowcode/regression/model/regression_dataset.py
+++ b/ads/opctl/operator/lowcode/regression/model/regression_dataset.py
@@ -9,7 +9,9 @@ import pandas as pd
 
 from ads.opctl.operator.lowcode.common.errors import InvalidParameterError
 from ads.opctl.operator.lowcode.common.utils import load_data
-from ads.opctl.operator.lowcode.regression.operator_config import RegressionOperatorConfig
+from ads.opctl.operator.lowcode.regression.operator_config import (
+    RegressionOperatorConfig,
+)
 
 
 class RegressionDatasets:
@@ -21,14 +23,26 @@ class RegressionDatasets:
 
         self.training_data = self._load(self.spec.training_data, "training_data")
         self.test_data = self._load_optional(self.spec.test_data, "test_data")
+        self.prediction_data = self._load_optional(
+            self.spec.prediction_data, "prediction_data"
+        )
 
         self._validate_target(self.training_data, "training_data")
 
         self.feature_columns = self._resolve_feature_columns(self.training_data)
+        self.prediction_passthrough_columns = []
 
         self._validate_columns(self.training_data, "training_data", require_target=True)
         if self.test_data is not None:
-            self._validate_columns(self.test_data, "test_data", require_target=False)
+            self._validate_columns(self.test_data, "test_data", require_target=True)
+        if self.prediction_data is not None:
+            self.prediction_passthrough_columns = (
+                self._resolve_prediction_passthrough_columns()
+            )
+            self._validate_columns(
+                self.prediction_data, "prediction_data", require_target=False
+            )
+            self._validate_prediction_output_contract()
 
     def _load(self, data_spec, name: str) -> pd.DataFrame:
         try:
@@ -39,15 +53,12 @@ class RegressionDatasets:
     def _load_optional(self, data_spec, name: str):
         if data_spec is None:
             return None
-        if not any(
-            [
-                getattr(data_spec, "url", None),
-                getattr(data_spec, "data", None),
-                getattr(data_spec, "sql", None),
-                getattr(data_spec, "table_name", None),
-                getattr(data_spec, "connect_args", None),
-            ]
-        ):
+        has_inline_data = getattr(data_spec, "data", None) is not None
+        has_external_source = any(
+            bool(getattr(data_spec, attribute, None))
+            for attribute in ("url", "sql", "table_name", "connect_args")
+        )
+        if not has_inline_data and not has_external_source:
             return None
         return self._load(data_spec, name)
 
@@ -58,19 +69,48 @@ class RegressionDatasets:
             )
 
     def _resolve_feature_columns(self, data: pd.DataFrame) -> List[str]:
-        return [
-            col
-            for col in data.columns
-            if col != self.spec.target_column
-        ]
+        return [col for col in data.columns if col != self.spec.target_column]
 
     def _validate_columns(self, data: pd.DataFrame, name: str, require_target: bool):
         missing = [c for c in self.feature_columns if c not in data.columns]
         if missing:
-            raise InvalidParameterError(
-                f"Columns {missing} are missing from `{name}`."
-            )
+            raise InvalidParameterError(f"Columns {missing} are missing from `{name}`.")
         if require_target and self.spec.target_column not in data.columns:
-            raise InvalidParameterError(
-                f"Column `{self.spec.target_column}` is missing from `{name}`."
+            hint = (
+                " Use `prediction_data` for an unlabeled dataset."
+                if name == "test_data"
+                else ""
             )
+            raise InvalidParameterError(
+                f"Column `{self.spec.target_column}` is missing from `{name}`.{hint}"
+            )
+
+    def _validate_prediction_output_contract(self):
+        """Validates passthrough columns for batch scoring."""
+        data = self.prediction_data
+
+        if data.empty:
+            raise InvalidParameterError(
+                "`prediction_data` must contain at least one row."
+            )
+
+        passthrough_columns = self.prediction_passthrough_columns
+        if len(passthrough_columns) != len(set(passthrough_columns)):
+            raise InvalidParameterError(
+                "`prediction_output.passthrough_columns` contains duplicate column names."
+            )
+        missing_passthrough = [
+            column for column in passthrough_columns if column not in data.columns
+        ]
+        if missing_passthrough:
+            raise InvalidParameterError(
+                f"Passthrough columns {missing_passthrough} are missing from "
+                "`prediction_data`."
+            )
+
+    def _resolve_prediction_passthrough_columns(self) -> List[str]:
+        """Returns configured passthroughs, defaulting to every input column."""
+        configured_columns = self.spec.prediction_output.passthrough_columns
+        if configured_columns is None:
+            return list(self.prediction_data.columns)
+        return list(configured_columns)

--- a/ads/opctl/operator/lowcode/regression/model/shared_model.py
+++ b/ads/opctl/operator/lowcode/regression/model/shared_model.py
@@ -7,6 +7,8 @@ from abc import abstractmethod
 
 import pandas as pd
 
+from ads.opctl.operator.lowcode.common.errors import InvalidParameterError
+
 from .base_model import RegressionOperatorBaseModel
 
 
@@ -57,5 +59,20 @@ class SharedRegressionOperatorModel(RegressionOperatorBaseModel):
             self.test_metrics = pd.DataFrame(
                 [{"metric": k, "value": v} for k, v in test_metric_dict.items()]
             )
+
+        if self.datasets.prediction_data is not None:
+            x_prediction = self.datasets.prediction_data[self.feature_columns]
+            try:
+                self.prediction_values = self.model_obj.predict(x_prediction)
+            except Exception as e:
+                raise InvalidParameterError(
+                    "`prediction_data` is incompatible with the fitted scoring "
+                    f"schema. Expected feature columns {self.feature_columns}. Error: {e}"
+                ) from e
+            if len(self.prediction_values) != len(self.datasets.prediction_data):
+                raise InvalidParameterError(
+                    "Batch scoring did not produce exactly one prediction for every "
+                    "`prediction_data` row."
+                )
 
         return self._compute_global_explanations(x_train, y_train)

--- a/ads/opctl/operator/lowcode/regression/operator_config.py
+++ b/ads/opctl/operator/lowcode/regression/operator_config.py
@@ -5,10 +5,14 @@
 
 import os
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, List, Optional
 
 from ads.common.serializer import DataClassSerializable
-from ads.opctl.operator.common.operator_config import InputData, OperatorConfig, OutputDirectory
+from ads.opctl.operator.common.operator_config import (
+    InputData,
+    OperatorConfig,
+    OutputDirectory,
+)
 from ads.opctl.operator.common.utils import _load_yaml_from_uri
 from ads.opctl.operator.lowcode.common.utils import find_output_dirname
 from .const import SupportedMetrics, SupportedModels
@@ -41,7 +45,7 @@ class ModelDeploymentServer(DataClassSerializable):
 
 @dataclass(repr=True)
 class RegressionDeploymentConfig(DataClassSerializable):
-    """Class representing regression model deployment settings."""
+    """Model Catalog and Model Deployment settings for regression."""
 
     model_catalog_display_name: str = None
     compartment_id: str = None
@@ -54,6 +58,22 @@ class RegressionDeploymentConfig(DataClassSerializable):
 @dataclass(repr=True)
 class TestData(InputData):
     """Class representing optional test data details."""
+
+
+@dataclass(repr=True)
+class PredictionData(InputData):
+    """Class representing optional unlabeled batch prediction data details."""
+
+
+@dataclass(repr=True)
+class PredictionOutput(DataClassSerializable):
+    """Class representing the stable batch prediction artifact contract."""
+
+    passthrough_columns: Optional[List[str]] = None
+    filename: str = "predictions.csv"
+
+    def __post_init__(self):
+        self.filename = self.filename or "predictions.csv"
 
 
 @dataclass(repr=True)
@@ -78,6 +98,8 @@ class RegressionOperatorSpec(DataClassSerializable):
 
     training_data: InputData = field(default_factory=InputData)
     test_data: TestData = field(default_factory=TestData)
+    prediction_data: PredictionData = field(default_factory=PredictionData)
+    prediction_output: PredictionOutput = field(default_factory=PredictionOutput)
     output_directory: OutputDirectory = field(default_factory=OutputDirectory)
 
     target_column: str = None
@@ -120,6 +142,19 @@ class RegressionOperatorSpec(DataClassSerializable):
             else DataPreprocessor(enabled=True)
         )
 
+        if self.prediction_data is None:
+            self.prediction_data = PredictionData()
+        elif not isinstance(self.prediction_data, PredictionData):
+            self.prediction_data = PredictionData.from_dict(self.prediction_data)
+
+        if self.prediction_output is None:
+            self.prediction_output = PredictionOutput()
+        elif not isinstance(self.prediction_output, PredictionOutput):
+            self.prediction_output = PredictionOutput.from_dict(self.prediction_output)
+        self.prediction_output.filename = (
+            self.prediction_output.filename or "predictions.csv"
+        )
+
         self.training_predictions_filename = (
             self.training_predictions_filename or "training_predictions.csv"
         )
@@ -137,15 +172,16 @@ class RegressionOperatorSpec(DataClassSerializable):
             self.global_explanation_filename or "global_explanations.csv"
         )
 
-        self.generate_report = self.generate_report if self.generate_report is not None else True
-        self.generate_explanations = (
-            self.generate_explanations if self.generate_explanations is not None else False
+        self.generate_report = (
+            self.generate_report if self.generate_report is not None else True
         )
-        if isinstance(self.save_and_deploy_to_md, bool):
-            self.save_and_deploy_to_md = (
-                RegressionDeploymentConfig() if self.save_and_deploy_to_md else None
-            )
-        elif self.save_and_deploy_to_md is not None and not isinstance(
+        self.generate_explanations = (
+            self.generate_explanations
+            if self.generate_explanations is not None
+            else False
+        )
+
+        if self.save_and_deploy_to_md is not None and not isinstance(
             self.save_and_deploy_to_md, RegressionDeploymentConfig
         ):
             self.save_and_deploy_to_md = RegressionDeploymentConfig.from_dict(

--- a/ads/opctl/operator/lowcode/regression/schema.yaml
+++ b/ads/opctl/operator/lowcode/regression/schema.yaml
@@ -25,6 +25,7 @@ type:
 
 spec:
   required: true
+  type: dict
   schema:
     training_data:
       required: true
@@ -114,6 +115,79 @@ spec:
         url:
           required: false
           type: string
+
+    prediction_data:
+      required: false
+      type: dict
+      meta:
+        description: "Optional unlabeled dataset to score after training. It must contain every learned feature column but does not require the target column."
+      schema:
+        connect_args:
+          nullable: true
+          required: false
+          type: dict
+        data:
+          nullable: true
+          required: false
+        format:
+          allowed:
+            - csv
+            - json
+            - clipboard
+            - excel
+            - feather
+            - sql_table
+            - sql_query
+            - hdf
+            - tsv
+            - parquet
+            - pandas
+          required: false
+          type: string
+        columns:
+          required: false
+          type: list
+          schema:
+            type: string
+        options:
+          nullable: true
+          required: false
+          type: dict
+        sql:
+          required: false
+          type: string
+        table_name:
+          required: false
+          type: string
+        url:
+          required: false
+          type: string
+        limit:
+          required: false
+          type: integer
+        vault_secret_id:
+          required: false
+          type: string
+
+    prediction_output:
+      required: false
+      type: dict
+      meta:
+        description: "Output contract for prediction_data. Passthrough columns are copied to the prediction artifact in input row order."
+      schema:
+        passthrough_columns:
+          required: false
+          type: list
+          schema:
+            type: string
+          meta:
+            description: "Input columns copied unchanged into the batch prediction artifact in configured order. When omitted, all prediction_data columns are copied. Set to [] to copy none."
+        filename:
+          required: false
+          type: string
+          default: predictions.csv
+          meta:
+            description: "Stable batch prediction artifact filename under output_directory."
 
     output_directory:
       required: false
@@ -317,14 +391,14 @@ spec:
         model_catalog_display_name:
           type: string
           required: false
-          meta: "The trained model is saved to OCI Model Catalog with this name"
+          meta: "The trained model is saved to OCI Model Catalog with this name."
         project_id:
           type: string
           required: false
-          meta: "If not provided, the project OCID from config.PROJECT_OCID is used."
+          meta: "If not provided, the project OCID from PROJECT_OCID is used."
         compartment_id:
           type: string
           required: false
-          meta: "If not provided, the compartment OCID from ADS config is used."
+          meta: "If not provided, the compartment OCID from NB_SESSION_COMPARTMENT_OCID is used."
       meta:
-        description: "When provided, the trained model is saved to OCI Model Catalog and deployed to Model Deployment."
+        description: "When provided, the trained model is saved to OCI Model Catalog and optionally deployed to Model Deployment."

--- a/docs/source/user_guide/operators/regression_operator/index.rst
+++ b/docs/source/user_guide/operators/regression_operator/index.rst
@@ -2,7 +2,7 @@
 Regression Operator
 ===================
 
-The Regression Operator is a low-code operator for supervised tabular regression. It trains a model from a training dataset, optionally evaluates on held-out test data, and writes a consistent set of artifacts such as predictions, metrics, an HTML report, and a serialized model bundle.
+The Regression Operator is a low-code operator for supervised tabular regression. It trains a model from a training dataset, optionally evaluates on labeled held-out test data, scores a separate unlabeled batch dataset, and writes a consistent set of artifacts such as predictions, metrics, an HTML report, and a serialized model bundle. Batch prediction does not require model registration or deployment.
 
 Overview
 --------
@@ -21,10 +21,11 @@ All columns in ``training_data`` except ``target_column`` are treated as feature
 The operator also supports:
 
 * ``test_data`` for held-out evaluation
+* ``prediction_data`` and ``prediction_output`` for unlabeled batch scoring; all prediction input columns pass through by default
 * ``output_directory`` for artifact location
 * ``column_types`` to override automatic type inference
 * ``model_kwargs`` to control explicit model runs
-* ``save_and_deploy_to_md`` to save the trained model to OCI Model Catalog and create a Model Deployment
+* ``save_and_deploy_to_md`` for Model Catalog registration and Model Deployment creation
 
 **Supported models**
 
@@ -54,12 +55,12 @@ Depending on the configuration and available data, the operator can write:
 
 * ``training_predictions.csv``
 * ``test_predictions.csv``
+* ``predictions.csv``
 * ``training_metrics.csv``
 * ``test_metrics.csv``
 * ``global_explanations.csv``
 * ``report.html``
 * ``model.pkl``
-* ``model_registration_info.json``
 * ``deployment_info.json``
 
 ``global_explanations.csv`` is written only when ``generate_explanations: true`` and explainability output is successfully produced.

--- a/docs/source/user_guide/operators/regression_operator/productionize.rst
+++ b/docs/source/user_guide/operators/regression_operator/productionize.rst
@@ -108,6 +108,10 @@ Example:
         url: oci://bucket@namespace/regression/input/train.csv
       test_data:
         url: oci://bucket@namespace/regression/input/test.csv
+      prediction_data:
+        url: oci://bucket@namespace/regression/input/rows_to_score.csv
+      prediction_output:
+        passthrough_columns: [record_id, series_id, period]
       output_directory:
         url: oci://bucket@namespace/regression/output/
       target_column: target
@@ -130,6 +134,8 @@ Example:
 
     save_and_deploy_to_md:
       model_catalog_display_name: regression-rf-model
+      project_id: ocid1.datascienceproject.oc1..example
+      compartment_id: ocid1.compartment.oc1..example
       model_deployment:
         display_name: regression-rf-md
         initial_shape: VM.Standard.E4.Flex
@@ -142,8 +148,7 @@ Notes from the current implementation
 * ``compartment_id`` defaults from ``NB_SESSION_COMPARTMENT_OCID`` if not provided.
 * ``model.pkl`` is always written first and then used for model packaging.
 * The deployment artifact bundles ``models.pickle`` plus ``score.py`` for inference.
-* When ``save_and_deploy_to_md`` is present, the run writes ``model_registration_info.json``.
-* The deployment manager also writes ``deployment_info.json``.
+* When ``save_and_deploy_to_md`` is present, the deployment manager writes ``deployment_info.json``.
 
 Autoscaling and Logging
 -----------------------

--- a/docs/source/user_guide/operators/regression_operator/quickstart.rst
+++ b/docs/source/user_guide/operators/regression_operator/quickstart.rst
@@ -30,7 +30,7 @@ If your ADS CLI defaults are configured for OCI Data Science Jobs, ``init`` also
 Prepare the YAML
 ----------------
 
-Open ``~/regression/regression.yaml`` and fill in the training data, optional test data, target column, and output directory.
+Open ``~/regression/regression.yaml`` and fill in the training data, optional labeled test data, optional unlabeled prediction data, target column, and output directory.
 
 Example:
 
@@ -44,6 +44,10 @@ Example:
         url: /path/to/train.csv
       test_data:
         url: /path/to/test.csv
+      prediction_data:
+        url: /path/to/rows_to_score.csv
+      prediction_output:
+        passthrough_columns: [record_id, series_id, period]
       output_directory:
         url: /path/to/results
       target_column: target
@@ -83,10 +87,13 @@ For a run with both training and test data, you should expect:
 
 * ``training_predictions.csv``
 * ``test_predictions.csv``
+* ``predictions.csv`` when ``prediction_data`` is configured
 * ``training_metrics.csv``
 * ``test_metrics.csv``
 * ``report.html`` when ``generate_report: true``
 * ``model.pkl``
+
+``predictions.csv`` contains the configured passthrough columns and ``prediction`` for every input row, preserving input order. If ``passthrough_columns`` is omitted, all ``prediction_data`` columns are included by default. A unique row key is not required. It is produced without registration or deployment unless ``save_and_deploy_to_md`` is configured.
 
 If you also set ``generate_explanations: true``, the run can additionally produce ``global_explanations.csv``. For example, the checked-in regression test asset produces prediction and metric outputs like:
 

--- a/docs/source/user_guide/operators/regression_operator/yaml_schema.rst
+++ b/docs/source/user_guide/operators/regression_operator/yaml_schema.rst
@@ -17,6 +17,11 @@ Complete Example
         url: train.csv
       test_data:
         url: test.csv
+      prediction_data:
+        url: rows_to_score.csv
+      prediction_output:
+        passthrough_columns: [record_id, series_id, period]
+        filename: predictions.csv
       output_directory:
         url: results
       target_column: target
@@ -104,8 +109,31 @@ Optional. Use this when you want held-out evaluation.
 
 Important:
 
-* The operator always validates that ``test_data`` contains the same feature columns as ``training_data``.
-* ``test_metrics.csv`` and ``test_predictions.csv`` are written only when ``test_data`` includes the target column.
+* The operator validates that ``test_data`` contains the same feature columns and target column as ``training_data``.
+* ``test_metrics.csv`` and ``test_predictions.csv`` preserve the existing holdout evaluation contract, including residuals.
+* Use ``prediction_data`` rather than ``test_data`` for unlabeled scoring rows.
+
+``prediction_data`` and ``prediction_output``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Optional. ``prediction_data`` is an unlabeled dataset scored by the fitted model during the same batch run. It supports the same local filesystem, Object Storage, inline pandas, and database input forms as ``training_data``.
+
+When ``prediction_output.passthrough_columns`` is omitted, all columns from ``prediction_data`` are copied to the output. Set it to an explicit empty list (``[]``) to output only ``prediction``. When a list is provided, every entry must exist in the prediction input. A unique row key is not required, and passthrough values may be duplicated or null. Missing learned features produce a validation error before fitting.
+
+Example:
+
+.. code-block:: yaml
+
+    prediction_data:
+      url: oci://bucket@namespace/regression/rows_to_score.csv
+    prediction_output:
+      passthrough_columns:
+        - record_id
+        - series_id
+        - period
+      filename: predictions.csv
+
+The output columns are the resolved passthrough columns followed by ``prediction``. By default, the passthrough columns are all columns from ``prediction_data`` in their original order. Input row order is preserved, so callers can align results without a unique identifier. The target column is not required and, when present, is not used for scoring.
 
 ``output_directory``
 ~~~~~~~~~~~~~~~~~~~~
@@ -195,13 +223,14 @@ Supported values:
 * ``mse``
 * ``r2``
 * ``mape``
+* ``smape``
 
 This metric controls:
 
 * explicit-model tuning
 * ``auto`` model selection
 
-The metrics output files still include all five metrics regardless of which one you choose as the primary optimization metric.
+The metrics output files still include all six metrics regardless of which one you choose as the primary optimization metric.
 
 ``model_kwargs``
 ~~~~~~~~~~~~~~~~
@@ -231,6 +260,7 @@ The output filenames can be customized with:
 
 * ``training_predictions_filename``
 * ``test_predictions_filename``
+* ``prediction_output.filename``
 * ``training_metrics_filename``
 * ``test_metrics_filename``
 * ``global_explanation_filename``
@@ -261,10 +291,8 @@ Current implementation details:
 * This SHAP fallback is most relevant to ``knn``.
 * If explainability is requested but cannot be produced, the run continues and the report explains that explainability was unavailable for that run.
 
-Deployment Configuration
-------------------------
-
-The operator also supports:
+Model Lifecycle Configuration
+-----------------------------
 
 .. code-block:: yaml
 

--- a/tests/operators/data/regression_operator_test_assets/prediction.csv
+++ b/tests/operators/data/regression_operator_test_assets/prediction.csv
@@ -1,0 +1,5 @@
+record_id,feature_num1,feature_num2,category,series_id
+prediction-1,1.5,9.5,A,north
+prediction-2,4.5,6.5,B,south
+prediction-3,7.5,3.5,C,north
+prediction-4,9.5,1.5,A,south

--- a/tests/operators/data/regression_operator_test_assets/regression_test.yaml
+++ b/tests/operators/data/regression_operator_test_assets/regression_test.yaml
@@ -9,12 +9,41 @@ spec:
   test_data:
     url: tests/operators/data/regression_operator_test_assets/test.csv
 
+  prediction_data:
+    url: tests/operators/data/regression_operator_test_assets/prediction.csv
+
+  prediction_output:
+    passthrough_columns:
+      - record_id
+      - series_id
+    filename: predictions.csv
+
   target_column: target
 
   model: linear_regression
+  model_kwargs:
+    tuning_n_trials: 0
 
   output_directory:
     url: tests/operators/data/regression_operator_test_assets/results
 
   generate_report: true
   generate_explanations: false
+
+  save_and_deploy_to_md:
+    project_id: ocid1.datascienceproject.oc1.p1xx
+    compartment_id: ocid1.compartment.oc1..c1xx
+    model_catalog_display_name: model_DD_MM_YYYY
+    model_deployment:
+      display_name: customerX
+      initial_shape: VM.Standard2.1
+      description: simple-description
+      log_group: test_log_group
+      log_id: test_log_id
+      auto_scaling:
+        minimum_instance: 1
+        maximum_instance: 2
+        cool_down_in_seconds: 600
+        scale_in_threshold: 20
+        scale_out_threshold: 80
+        scaling_metric: CPU_UTILIZATION

--- a/tests/unitary/with_extras/operator/regression/test_regression_operator.py
+++ b/tests/unitary/with_extras/operator/regression/test_regression_operator.py
@@ -8,12 +8,16 @@ from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
+import pytest
 from ads.opctl.operator.lowcode.regression.__main__ import operate
+from ads.opctl.operator.lowcode.common.errors import InvalidParameterError
 from ads.opctl.operator.lowcode.regression.const import SupportedMetrics
 from ads.opctl.operator.lowcode.regression.deployment.deployment_manager import (
     ModelDeploymentManager,
 )
-from ads.opctl.operator.lowcode.regression.deployment.score import predict as deployment_predict
+from ads.opctl.operator.lowcode.regression.deployment.score import (
+    predict as deployment_predict,
+)
 from ads.opctl.operator.lowcode.regression.model.auto import (
     AutoRegressionOperatorModel,
 )
@@ -35,7 +39,9 @@ from ads.opctl.operator.lowcode.regression.model.regression_dataset import (
 from ads.opctl.operator.lowcode.regression.model.factory import (
     RegressionOperatorModelFactory,
 )
-from ads.opctl.operator.lowcode.regression.operator_config import RegressionOperatorConfig
+from ads.opctl.operator.lowcode.regression.operator_config import (
+    RegressionOperatorConfig,
+)
 
 
 class _DummyRegressionModel:
@@ -86,10 +92,7 @@ def test_random_forest_uses_robust_defaults_for_mae_metric():
     rows = 1200
     rng = np.random.default_rng(11)
     df = pd.DataFrame(
-        {
-            f"x{i}": rng.normal(loc=i, scale=1.0, size=rows)
-            for i in range(8)
-        }
+        {f"x{i}": rng.normal(loc=i, scale=1.0, size=rows) for i in range(8)}
     )
     df["target"] = df.sum(axis=1) + rng.normal(0, 0.5, rows)
 
@@ -180,12 +183,7 @@ def test_random_forest_passes_native_model_kwargs_directly_to_estimator():
 def test_knn_uses_dataset_aware_defaults_and_direct_model_kwargs():
     rows = 600
     rng = np.random.default_rng(55)
-    df = pd.DataFrame(
-        {
-            f"x{i}": rng.normal(size=rows)
-            for i in range(6)
-        }
-    )
+    df = pd.DataFrame({f"x{i}": rng.normal(size=rows) for i in range(6)})
     df["target"] = df.sum(axis=1) + rng.normal(0, 0.2, rows)
 
     config = RegressionOperatorConfig.from_dict(
@@ -226,12 +224,7 @@ def test_knn_uses_dataset_aware_defaults_and_direct_model_kwargs():
 def test_xgboost_uses_metric_aware_defaults_and_direct_model_kwargs():
     rows = 1200
     rng = np.random.default_rng(66)
-    df = pd.DataFrame(
-        {
-            f"x{i}": rng.normal(size=rows)
-            for i in range(12)
-        }
-    )
+    df = pd.DataFrame({f"x{i}": rng.normal(size=rows) for i in range(12)})
     df["target"] = df.sum(axis=1) + rng.normal(0, 0.3, rows)
 
     config = RegressionOperatorConfig.from_dict(
@@ -290,10 +283,7 @@ def test_auto_regression_selects_best_model_via_cv_and_populates_predictions():
         }
     )
     train_df["target"] = (
-        10
-        + 4.0 * train_df["x1"]
-        - 1.5 * train_df["x2"]
-        + 2.2 * train_df["x3"]
+        10 + 4.0 * train_df["x1"] - 1.5 * train_df["x2"] + 2.2 * train_df["x3"]
     )
 
     test_df = pd.DataFrame(
@@ -304,10 +294,7 @@ def test_auto_regression_selects_best_model_via_cv_and_populates_predictions():
         }
     )
     test_df["target"] = (
-        10
-        + 4.0 * test_df["x1"]
-        - 1.5 * test_df["x2"]
-        + 2.2 * test_df["x3"]
+        10 + 4.0 * test_df["x1"] - 1.5 * test_df["x2"] + 2.2 * test_df["x3"]
     )
 
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -360,8 +347,8 @@ def test_linear_regression_tunes_hyperparameters_with_cv():
             "x3": rng.normal(-1, 0.8, rows),
         }
     )
-    df["target"] = 3.5 * df["x1"] - 1.2 * df["x2"] + 0.8 * df["x3"] + rng.normal(
-        0, 0.1, rows
+    df["target"] = (
+        3.5 * df["x1"] - 1.2 * df["x2"] + 0.8 * df["x3"] + rng.normal(0, 0.1, rows)
     )
 
     config = RegressionOperatorConfig.from_dict(
@@ -395,17 +382,9 @@ def test_linear_regression_tunes_hyperparameters_with_cv():
 def test_random_forest_tunes_hyperparameters_with_cv():
     rng = np.random.default_rng(89)
     rows = 120
-    df = pd.DataFrame(
-        {
-            f"x{i}": rng.normal(size=rows)
-            for i in range(6)
-        }
-    )
+    df = pd.DataFrame({f"x{i}": rng.normal(size=rows) for i in range(6)})
     df["target"] = (
-        df["x0"] * df["x1"]
-        + 0.5 * df["x2"]
-        - 0.8 * df["x3"]
-        + rng.normal(0, 0.2, rows)
+        df["x0"] * df["x1"] + 0.5 * df["x2"] - 0.8 * df["x3"] + rng.normal(0, 0.2, rows)
     )
 
     config = RegressionOperatorConfig.from_dict(
@@ -446,9 +425,7 @@ def test_knn_tunes_hyperparameters_with_cv():
             "x3": rng.normal(size=rows),
         }
     )
-    df["target"] = df["x1"] ** 2 + 0.5 * df["x2"] - df["x3"] + rng.normal(
-        0, 0.05, rows
-    )
+    df["target"] = df["x1"] ** 2 + 0.5 * df["x2"] - df["x3"] + rng.normal(0, 0.05, rows)
 
     config = RegressionOperatorConfig.from_dict(
         {
@@ -480,17 +457,9 @@ def test_knn_tunes_hyperparameters_with_cv():
 def test_xgboost_tunes_hyperparameters_with_cv():
     rng = np.random.default_rng(91)
     rows = 120
-    df = pd.DataFrame(
-        {
-            f"x{i}": rng.normal(size=rows)
-            for i in range(5)
-        }
-    )
+    df = pd.DataFrame({f"x{i}": rng.normal(size=rows) for i in range(5)})
     df["target"] = (
-        1.5 * df["x0"]
-        - 2.0 * df["x1"]
-        + df["x2"] * df["x3"]
-        + rng.normal(0, 0.1, rows)
+        1.5 * df["x0"] - 2.0 * df["x1"] + df["x2"] * df["x3"] + rng.normal(0, 0.1, rows)
     )
 
     config = RegressionOperatorConfig.from_dict(
@@ -561,6 +530,7 @@ def test_model_kwargs_can_override_tuning_trial_count():
     assert len(model.tuning_results_df) == 3
     assert "tuning_n_trials" not in model.best_tuned_params
 
+
 def test_regression_operator_smoke_random_forest_with_missing_values():
     rng = np.random.default_rng(123)
     rows = 90
@@ -569,7 +539,9 @@ def test_regression_operator_smoke_random_forest_with_missing_values():
             "x1": rng.normal(0, 1, rows),
             "x2": rng.normal(5, 2, rows),
             "city": rng.choice(["A", "B", "C", None], size=rows),
-            "event_date": pd.date_range("2025-01-01", periods=rows, freq="D").astype(str),
+            "event_date": pd.date_range("2025-01-01", periods=rows, freq="D").astype(
+                str
+            ),
         }
     )
     df.loc[df.index[::7], "x1"] = np.nan
@@ -616,7 +588,13 @@ def test_regression_operator_smoke_linear_regression():
     x1 = rng.normal(0, 1, rows)
     x2 = rng.normal(5, 2, rows)
     city = rng.choice(["A", "B", "C"], size=rows)
-    y = 5 + (2.5 * x1) + (0.7 * x2) + (city == "B").astype(int) * 1.1 + rng.normal(0, 0.2, rows)
+    y = (
+        5
+        + (2.5 * x1)
+        + (0.7 * x2)
+        + (city == "B").astype(int) * 1.1
+        + rng.normal(0, 0.2, rows)
+    )
 
     df = pd.DataFrame({"x1": x1, "x2": x2, "city": city, "target": y})
 
@@ -647,7 +625,7 @@ def test_regression_operator_smoke_linear_regression():
         assert not os.path.exists(os.path.join(out_path, "global_explanations.csv"))
         assert os.path.exists(os.path.join(out_path, "model.pkl"))
         # assert os.path.exists(os.path.join(out_path, "models.pickle"))
-        assert not os.path.exists(os.path.join(out_path, "model_registration_info.json"))
+        assert not os.path.exists(os.path.join(out_path, "deployment_info.json"))
         assert not os.path.exists(os.path.join(out_path, "feature_importance.csv"))
         assert not os.path.exists(os.path.join(out_path, "local_explanations.csv"))
         report_path = os.path.join(out_path, "report.html")
@@ -668,7 +646,10 @@ def test_regression_operator_smoke_linear_regression():
         assert "Data Summary Statistics" in report_html
         assert "Training Data Metrics" in report_html
         assert "Reference: YAML File" in report_html
-        assert "The following tables summarize the training dataset used for this regression analysis" in report_html
+        assert (
+            "The following tables summarize the training dataset used for this regression analysis"
+            in report_html
+        )
         assert "Training Actual vs Predicted" in report_html
         assert "Training Actual vs Predicted with Ideal Fit Reference" in report_html
         assert "Training Actual and Predicted Values by Row" not in report_html
@@ -817,7 +798,9 @@ def test_regression_date_features_are_generated_from_date_columns():
     rows = 12
     df = pd.DataFrame(
         {
-            "event_date": pd.date_range("2025-01-01", periods=rows, freq="D").astype(str),
+            "event_date": pd.date_range("2025-01-01", periods=rows, freq="D").astype(
+                str
+            ),
             "numeric_text": [str(v) for v in np.linspace(10, 20, rows)],
             "city": ["A", "B", "A", "B", "C", "A", "B", "C", "A", "B", "C", "A"],
         }
@@ -845,9 +828,7 @@ def test_regression_date_features_are_generated_from_date_columns():
 
         operate(RegressionOperatorConfig.from_dict(cfg))
 
-        explanations_df = pd.read_csv(
-            os.path.join(out_path, "global_explanations.csv")
-        )
+        explanations_df = pd.read_csv(os.path.join(out_path, "global_explanations.csv"))
 
         assert "event_date_year" in explanations_df["feature"].values
         assert "event_date_month" in explanations_df["feature"].values
@@ -878,6 +859,7 @@ def test_regression_deployment_sanity_test_uses_training_data_subset():
                 "generate_report": False,
                 "generate_explanations": False,
                 "save_and_deploy_to_md": {
+                    "model_catalog_display_name": "regression-model",
                     "project_id": "ocid1.project.oc1..exampleuniqueID",
                     "compartment_id": "ocid1.compartment.oc1..exampleuniqueID",
                     "model_deployment": {
@@ -960,9 +942,7 @@ def test_regression_invalid_dates_do_not_fail_operator():
 
         operate(RegressionOperatorConfig.from_dict(cfg))
 
-        explanations_df = pd.read_csv(
-            os.path.join(out_path, "global_explanations.csv")
-        )
+        explanations_df = pd.read_csv(os.path.join(out_path, "global_explanations.csv"))
         training_predictions_df = pd.read_csv(
             os.path.join(out_path, "training_predictions.csv")
         )
@@ -979,7 +959,9 @@ def test_regression_deployment_score_predict_uses_artifact_bundle():
             self.preprocessor = SimpleNamespace(feature_columns_=["x1", "x2"])
 
         def predict(self, x_df):
-            return x_df["x1"].fillna(0).astype(float) + x_df["x2"].fillna(0).astype(float)
+            return x_df["x1"].fillna(0).astype(float) + x_df["x2"].fillna(0).astype(
+                float
+            )
 
     bundle = {
         "spec": {"target_column": "target"},
@@ -1052,131 +1034,200 @@ def test_regression_deployment_score_predict_preprocesses_training_style_payload
     assert all(isinstance(prediction, float) for prediction in predictions)
 
 
-def test_regression_save_and_deploy_to_md_writes_registration_info():
-    rng = np.random.default_rng(12)
-    rows = 20
-    df = pd.DataFrame(
+def test_regression_batch_prediction_preserves_input_order():
+    rng = np.random.default_rng(89806)
+    training_rows = 30
+    prediction_rows = 7
+    training_df = pd.DataFrame(
         {
-            "x1": rng.normal(0, 1, rows),
-            "x2": rng.normal(2, 1, rows),
+            "x1": rng.normal(size=training_rows),
+            "x2": rng.normal(size=training_rows),
+            "series_id": rng.choice(["A", "B"], size=training_rows),
         }
     )
-    df["target"] = 2 + df["x1"] - 0.4 * df["x2"] + rng.normal(0, 0.1, rows)
+    training_df["target"] = 5 + training_df["x1"] - 0.25 * training_df["x2"]
+    prediction_df = pd.DataFrame(
+        {
+            "record_id": [
+                "duplicate",
+                "duplicate",
+                None,
+                "four",
+                "five",
+                "six",
+                "seven",
+            ],
+            "x1": rng.normal(size=prediction_rows),
+            "x2": rng.normal(size=prediction_rows),
+            "series_id": rng.choice(["A", "B"], size=prediction_rows),
+            "period": pd.date_range("2026-01-01", periods=prediction_rows).astype(str),
+        }
+    )
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-        train_path = os.path.join(tmp_dir, "train.csv")
-        out_path = os.path.join(tmp_dir, "out")
-        df.to_csv(train_path, index=False)
+        output_dir = os.path.join(tmp_dir, "results")
+        config = RegressionOperatorConfig.from_dict(
+            {
+                "kind": "operator",
+                "type": "regression",
+                "version": "v1",
+                "spec": {
+                    "training_data": {"data": training_df},
+                    "prediction_data": {"data": prediction_df},
+                    "output_directory": {"url": output_dir},
+                    "target_column": "target",
+                    "model": "linear_regression",
+                    "model_kwargs": {"tuning_n_trials": 0},
+                    "generate_report": False,
+                    "generate_explanations": False,
+                },
+            }
+        )
+        assert config.spec.prediction_output.filename == "predictions.csv"
+        assert config.spec.prediction_output.passthrough_columns is None
 
-        cfg = {
+        result = operate(config)
+
+        predictions = pd.read_csv(os.path.join(output_dir, "predictions.csv"))
+        assert list(predictions.columns) == [
+            "record_id",
+            "x1",
+            "x2",
+            "series_id",
+            "period",
+            "prediction",
+        ]
+        assert len(predictions) == prediction_rows
+        assert predictions["record_id"].iloc[:2].tolist() == ["duplicate", "duplicate"]
+        assert pd.isna(predictions["record_id"].iloc[2])
+        assert predictions["series_id"].tolist() == prediction_df["series_id"].tolist()
+        assert predictions["prediction"].notna().all()
+        assert result["model_registration"] is None
+
+
+@pytest.mark.parametrize(
+    "prediction_df,passthrough_columns,error_match",
+    [
+        (
+            pd.DataFrame({"other": [1.0, 2.0]}),
+            [],
+            "Columns .* are missing from `prediction_data`",
+        ),
+        (
+            pd.DataFrame({"x": [1.0, 2.0], "group": ["A", "B"]}),
+            ["group", "group"],
+            "contains duplicate column names",
+        ),
+        (
+            pd.DataFrame({"x": [1.0, 2.0]}),
+            ["group"],
+            "Passthrough columns .* are missing from `prediction_data`",
+        ),
+    ],
+)
+def test_regression_batch_prediction_validation_errors(
+    prediction_df, passthrough_columns, error_match
+):
+    training_df = pd.DataFrame({"x": [1.0, 2.0, 3.0], "target": [2.0, 4.0, 6.0]})
+    config = RegressionOperatorConfig.from_dict(
+        {
             "kind": "operator",
             "type": "regression",
             "version": "v1",
             "spec": {
-                "training_data": {"url": train_path},
-                "target_column": "target",
-                "model": "linear_regression",
-                "output_directory": {"url": out_path},
-                "generate_report": False,
-                "generate_explanations": False,
-                "save_and_deploy_to_md": {
-                    "model_catalog_display_name": "regression-linear-model",
-                    "model_deployment": {
-                        "display_name": "regression-linear-md",
-                        "initial_shape": "VM.Standard.E4.Flex",
-                        "description": "deployment description",
-                    },
+                "training_data": {"data": training_df},
+                "prediction_data": {"data": prediction_df},
+                "prediction_output": {
+                    "passthrough_columns": passthrough_columns,
                 },
+                "target_column": "target",
             },
         }
-
-        registration_info = {
-            "model_ocid": "ocid1.datasciencemodel.oc1..example",
-            "saved_to_model_catalog": True,
-            "deployed_to_model_deployment": False,
-            "model_name": "linear_regression",
-        }
-        with patch(
-            "ads.opctl.operator.lowcode.regression.model.base_model.RegressionOperatorBaseModel._publish_to_oci",
-            return_value=registration_info,
-        ) as mock_publish:
-            operate(RegressionOperatorConfig.from_dict(cfg))
-
-        mock_publish.assert_called_once()
-        _, kwargs = mock_publish.call_args
-        assert kwargs["deploy_config"].model_catalog_display_name == "regression-linear-model"
-
-        with open(os.path.join(out_path, "model_registration_info.json")) as f:
-            saved_info = json.load(f)
-        assert saved_info["model_ocid"] == registration_info["model_ocid"]
-        assert saved_info["saved_to_model_catalog"] is True
-        assert saved_info["deployed_to_model_deployment"] is False
-
-
-def test_regression_save_and_deploy_to_md_passes_deployment_config():
-    rng = np.random.default_rng(17)
-    rows = 20
-    df = pd.DataFrame(
-        {
-            "x1": rng.normal(0, 1, rows),
-            "x2": rng.normal(2, 1, rows),
-        }
     )
-    df["target"] = 2 + df["x1"] - 0.4 * df["x2"] + rng.normal(0, 0.1, rows)
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        train_path = os.path.join(tmp_dir, "train.csv")
-        out_path = os.path.join(tmp_dir, "out")
-        df.to_csv(train_path, index=False)
+    with pytest.raises(InvalidParameterError, match=error_match):
+        RegressionDatasets(config)
 
-        cfg = {
+
+def test_regression_unlabeled_test_data_points_to_prediction_data():
+    training_df = pd.DataFrame({"x": [1.0, 2.0, 3.0], "target": [2.0, 4.0, 6.0]})
+    config = RegressionOperatorConfig.from_dict(
+        {
             "kind": "operator",
             "type": "regression",
             "version": "v1",
             "spec": {
-                "training_data": {"url": train_path},
+                "training_data": {"data": training_df},
+                "test_data": {"data": training_df[["x"]]},
                 "target_column": "target",
-                "model": "linear_regression",
-                "output_directory": {"url": out_path},
-                "generate_report": False,
-                "generate_explanations": False,
-                "save_and_deploy_to_md": {
-                    "model_catalog_display_name": "regression-linear-model",
-                    "model_deployment": {
-                        "display_name": "regression-linear-md",
-                        "initial_shape": "VM.Standard.E4.Flex",
-                        "description": "deployment description",
-                    },
-                },
             },
         }
+    )
 
-        registration_info = {
-            "model_ocid": "ocid1.datasciencemodel.oc1..example",
-            "model_deployment_ocid": "ocid1.datasciencemodeldeployment.oc1..example",
-            "saved_to_model_catalog": True,
-            "deployed_to_model_deployment": True,
-            "model_name": "linear_regression",
+    with pytest.raises(InvalidParameterError, match="Use `prediction_data`"):
+        RegressionDatasets(config)
+
+
+@pytest.mark.parametrize("deploy", [False, True])
+def test_regression_save_and_deploy_lifecycle(deploy):
+    training_df = pd.DataFrame(
+        {"x": [1.0, 2.0, 3.0, 4.0], "target": [2.0, 4.0, 6.0, 8.0]}
+    )
+    lifecycle_config = {
+        "model_catalog_display_name": "regression-model",
+        "project_id": "ocid1.project.oc1..example",
+        "compartment_id": "ocid1.compartment.oc1..example",
+    }
+    if deploy:
+        lifecycle_config["model_deployment"] = {
+            "display_name": "regression-deployment",
+            "initial_shape": "VM.Standard.E4.Flex",
         }
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_dir = os.path.join(tmp_dir, "results")
+        config = RegressionOperatorConfig.from_dict(
+            {
+                "kind": "operator",
+                "type": "regression",
+                "version": "v1",
+                "spec": {
+                    "training_data": {"data": training_df},
+                    "output_directory": {"url": output_dir},
+                    "target_column": "target",
+                    "model": "linear_regression",
+                    "model_kwargs": {"tuning_n_trials": 0},
+                    "generate_report": False,
+                    "generate_explanations": False,
+                    "save_and_deploy_to_md": lifecycle_config,
+                },
+            }
+        )
+        registration_info = {
+            "model_name": "linear_regression",
+            "model_ocid": "ocid1.datasciencemodel.oc1..example",
+            "saved_to_model_catalog": True,
+            "deployed_to_model_deployment": deploy,
+        }
+        if deploy:
+            registration_info.update(
+                {
+                    "model_deployment_ocid": "ocid1.datasciencemodeldeployment.oc1..example",
+                    "model_deployment_endpoint": "https://example/predict",
+                }
+            )
+
         with patch(
-            "ads.opctl.operator.lowcode.regression.model.base_model.RegressionOperatorBaseModel._publish_to_oci",
-            return_value=registration_info,
-        ) as mock_publish:
-            operate(RegressionOperatorConfig.from_dict(cfg))
+            "ads.opctl.operator.lowcode.regression.model.base_model.ModelDeploymentManager"
+        ) as manager_class:
+            manager = manager_class.return_value
+            manager.deployment_info = registration_info
+            result = operate(config)
 
-        mock_publish.assert_called_once()
-        _, kwargs = mock_publish.call_args
-        assert kwargs["deploy_config"].model_catalog_display_name == "regression-linear-model"
-        assert (
-            kwargs["deploy_config"].model_deployment.display_name
-            == "regression-linear-md"
-        )
-
-        with open(os.path.join(out_path, "model_registration_info.json")) as f:
-            saved_info = json.load(f)
-        assert saved_info["model_ocid"] == registration_info["model_ocid"]
-        assert (
-            saved_info["model_deployment_ocid"]
-            == registration_info["model_deployment_ocid"]
-        )
-        assert saved_info["deployed_to_model_deployment"] is True
+        manager.save_to_catalog.assert_called_once()
+        manager.save_deployment_info.assert_called_once()
+        if deploy:
+            manager.create_deployment.assert_called_once()
+        else:
+            manager.create_deployment.assert_not_called()
+        assert result["model_registration"] == registration_info


### PR DESCRIPTION
Supports scoring a separate unlabeled dataset with the Regression Operator while making the Model Catalog and Model Deployment flow optional.

#### Changes
- Add optional `prediction_data` for batch scoring.
- Add optional `prediction_output` configuration.
- Write batch results to `predictions.csv`.
- Preserve `prediction_data` row order.
- Include all `prediction_data` columns by default.
- Support selecting specific output columns with `passthrough_columns`.
- Keep `test_data` for labeled model evaluation.
- Use `deployment_info.json` as the lifecycle metadata artifact.
- Support for optional Model Catalog and Model Deployment flows.
- Update the Regression Operator schema and documentation.